### PR TITLE
Build Next Message v0.2.1 iOS 16 diagnostics

### DIFF
--- a/.github/workflows/build-next-message.yml
+++ b/.github/workflows/build-next-message.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Install signing and packaging tools
+        uses: dhinakg/procursus-action@main
+        with:
+          packages: ldid dpkg
+
       - name: Install Theos toolchain
         run: |
           set -euxo pipefail

--- a/.github/workflows/build-next-message.yml
+++ b/.github/workflows/build-next-message.yml
@@ -44,9 +44,19 @@ jobs:
       - name: Build Next Message
         working-directory: NextMessage
         run: |
-          set -euxo pipefail
+          set -o pipefail
           make clean
-          make package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME="${{ matrix.scheme }}" messages=yes
+          make package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME="${{ matrix.scheme }}" messages=yes \
+            2>&1 | tee "$GITHUB_WORKSPACE/build-${{ matrix.scheme }}.log"
+
+      - name: Upload compiler log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: NextMessage-${{ matrix.scheme }}-build-log
+          path: build-${{ matrix.scheme }}.log
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Collect package
         run: |

--- a/.github/workflows/build-next-message.yml
+++ b/.github/workflows/build-next-message.yml
@@ -31,12 +31,20 @@ jobs:
 
       - name: Install Theos toolchain
         run: |
-          git clone --recursive --depth 1 https://github.com/roothide/theos.git "$THEOS"
-          git clone --depth 1 https://github.com/theos/sdks.git "$THEOS/sdks"
+          set -euxo pipefail
+          git clone --depth 1 https://github.com/roothide/theos.git "$THEOS"
+          git -C "$THEOS" submodule update --init --recursive --depth 1
+          mkdir -p "$THEOS/sdks"
+          curl -L --fail --retry 3 \
+            https://github.com/theos/sdks/releases/latest/download/iPhoneOS16.5.sdk.tar.xz \
+            -o /tmp/iPhoneOS16.5.sdk.tar.xz
+          tar -xJf /tmp/iPhoneOS16.5.sdk.tar.xz -C "$THEOS/sdks"
+          ls -la "$THEOS/sdks"
 
       - name: Build Next Message
         working-directory: NextMessage
         run: |
+          set -euxo pipefail
           make clean
           make package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME="${{ matrix.scheme }}" messages=yes
 

--- a/.github/workflows/build-next-message.yml
+++ b/.github/workflows/build-next-message.yml
@@ -50,6 +50,7 @@ jobs:
         working-directory: NextMessage
         run: |
           set -o pipefail
+          chmod 0755 layout/DEBIAN/postinst layout/DEBIAN/postrm
           make clean
           make package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME="${{ matrix.scheme }}" messages=yes \
             2>&1 | tee "$GITHUB_WORKSPACE/build-${{ matrix.scheme }}.log"

--- a/.github/workflows/build-next-message.yml
+++ b/.github/workflows/build-next-message.yml
@@ -1,0 +1,55 @@
+name: Build Next Message
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'NextMessage/**'
+      - '.github/workflows/build-next-message.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.scheme }} package
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        scheme:
+          - rootless
+          - roothide
+
+    env:
+      THEOS: ${{ github.workspace }}/theos
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install Theos toolchain
+        run: |
+          git clone --recursive --depth 1 https://github.com/roothide/theos.git "$THEOS"
+          git clone --depth 1 https://github.com/theos/sdks.git "$THEOS/sdks"
+
+      - name: Build Next Message
+        working-directory: NextMessage
+        run: |
+          make clean
+          make package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME="${{ matrix.scheme }}" messages=yes
+
+      - name: Collect package
+        run: |
+          mkdir -p "artifacts/${{ matrix.scheme }}"
+          find NextMessage/packages -maxdepth 1 -type f -name '*.deb' -exec cp {} "artifacts/${{ matrix.scheme }}/" \;
+          ls -la "artifacts/${{ matrix.scheme }}"
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: NextMessage-${{ matrix.scheme }}
+          path: artifacts/${{ matrix.scheme }}/*.deb
+          if-no-files-found: error
+          retention-days: 14

--- a/NextMessage/Makefile
+++ b/NextMessage/Makefile
@@ -15,5 +15,9 @@ include $(THEOS_MAKE_PATH)/tweak.mk
 SUBPROJECTS += NextMessagePrefs
 include $(THEOS_MAKE_PATH)/aggregate.mk
 
+before-package::
+	@chmod 0755 layout/DEBIAN/postinst 2>/dev/null || true
+	@chmod 0755 layout/DEBIAN/postrm 2>/dev/null || true
+
 after-install::
-	install.exec "killall -9 MobileSMS Preferences 2>/dev/null || true"
+	install.exec "uicache -a 2>/dev/null || true; killall -9 MobileSMS Preferences 2>/dev/null || true"

--- a/NextMessage/Makefile
+++ b/NextMessage/Makefile
@@ -1,0 +1,19 @@
+ARCHS = arm64 arm64e
+TARGET = iphone:clang:latest:15.0
+INSTALL_TARGET_PROCESSES = MobileSMS Preferences
+
+include $(THEOS)/makefiles/common.mk
+
+TWEAK_NAME = NextMessage
+NextMessage_FILES = Tweak.xm
+NextMessage_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
+NextMessage_FRAMEWORKS = UIKit Foundation QuartzCore
+NextMessage_LIBRARIES = sqlite3
+
+include $(THEOS_MAKE_PATH)/tweak.mk
+
+SUBPROJECTS += NextMessagePrefs
+include $(THEOS_MAKE_PATH)/aggregate.mk
+
+after-install::
+	install.exec "killall -9 MobileSMS Preferences 2>/dev/null || true"

--- a/NextMessage/Makefile
+++ b/NextMessage/Makefile
@@ -1,5 +1,5 @@
 ARCHS = arm64 arm64e
-TARGET = iphone:clang:latest:15.0
+TARGET = iphone:clang:16.5:15.0
 INSTALL_TARGET_PROCESSES = MobileSMS Preferences
 
 include $(THEOS)/makefiles/common.mk

--- a/NextMessage/Makefile
+++ b/NextMessage/Makefile
@@ -5,7 +5,7 @@ INSTALL_TARGET_PROCESSES = MobileSMS Preferences
 include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = NextMessage
-NextMessage_FILES = Tweak.xm
+NextMessage_FILES = Tweak.xm NMDiagnostics.m
 NextMessage_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
 NextMessage_FRAMEWORKS = UIKit Foundation QuartzCore
 NextMessage_LIBRARIES = sqlite3

--- a/NextMessage/NMDiagnostics.m
+++ b/NextMessage/NMDiagnostics.m
@@ -1,0 +1,331 @@
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <sys/utsname.h>
+
+static NSString * const NMDiagnosticPath = @"/var/mobile/Library/Preferences/com.nextsolution.nextmessage.diagnostic.txt";
+static CFStringRef const NMCaptureNotification = CFSTR("com.nextsolution.nextmessage.capturediagnostic");
+static CFStringRef const NMClearNotification = CFSTR("com.nextsolution.nextmessage.cleardiagnostic");
+static dispatch_queue_t NMDiagnosticQueue;
+static NSMutableSet<NSString *> *NMCapturedControllerClasses;
+static BOOL NMRuntimeInventoryWritten = NO;
+
+static NSString *NMDeviceMachine(void) {
+    struct utsname systemInfo;
+    if (uname(&systemInfo) != 0) return @"Unknown";
+    return [NSString stringWithUTF8String:systemInfo.machine] ?: @"Unknown";
+}
+
+static NSString *NMIndent(NSUInteger level) {
+    return [@"  " stringByPaddingToLength:level * 2 withString:@"  " startingAtIndex:0];
+}
+
+static UIWindow *NMActiveWindow(void) {
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if (![scene isKindOfClass:UIWindowScene.class]) continue;
+        if (scene.activationState != UISceneActivationStateForegroundActive &&
+            scene.activationState != UISceneActivationStateForegroundInactive) continue;
+        for (UIWindow *window in ((UIWindowScene *)scene).windows) {
+            if (window.isKeyWindow) return window;
+        }
+    }
+    return UIApplication.sharedApplication.windows.firstObject;
+}
+
+static UIViewController *NMTopControllerFrom(UIViewController *controller) {
+    if (!controller) return nil;
+    if (controller.presentedViewController) return NMTopControllerFrom(controller.presentedViewController);
+    if ([controller isKindOfClass:UINavigationController.class]) {
+        return NMTopControllerFrom(((UINavigationController *)controller).visibleViewController);
+    }
+    if ([controller isKindOfClass:UITabBarController.class]) {
+        return NMTopControllerFrom(((UITabBarController *)controller).selectedViewController);
+    }
+    return controller;
+}
+
+static NSString *NMSafeFrameDescription(CGRect frame) {
+    if (CGRectIsNull(frame)) return @"null";
+    if (CGRectIsInfinite(frame)) return @"infinite";
+    return [NSString stringWithFormat:@"x=%.1f y=%.1f w=%.1f h=%.1f",
+            frame.origin.x, frame.origin.y, frame.size.width, frame.size.height];
+}
+
+static void NMAppendControllerTree(NSMutableString *output, UIViewController *controller, NSUInteger depth, NSMutableSet *visited) {
+    if (!controller || depth > 12 || [visited containsObject:controller]) return;
+    [visited addObject:controller];
+
+    NSString *className = NSStringFromClass(controller.class) ?: @"UnknownController";
+    [output appendFormat:@"%@- %@ viewLoaded=%@ presented=%@ children=%lu\n",
+     NMIndent(depth), className, controller.isViewLoaded ? @"YES" : @"NO",
+     controller.presentedViewController ? NSStringFromClass(controller.presentedViewController.class) : @"none",
+     (unsigned long)controller.childViewControllers.count];
+
+    if ([controller isKindOfClass:UINavigationController.class]) {
+        UINavigationController *navigation = (UINavigationController *)controller;
+        [output appendFormat:@"%@  navigation stack: %@\n", NMIndent(depth),
+         [navigation.viewControllers valueForKey:@"class"]];
+    }
+
+    for (UIViewController *child in controller.childViewControllers) {
+        NMAppendControllerTree(output, child, depth + 1, visited);
+    }
+    if (controller.presentedViewController) {
+        NMAppendControllerTree(output, controller.presentedViewController, depth + 1, visited);
+    }
+}
+
+static void NMAppendViewTree(NSMutableString *output, UIView *view, NSUInteger depth, NSUInteger *count) {
+    if (!view || depth > 16 || *count >= 1000) return;
+    (*count)++;
+
+    NSString *className = NSStringFromClass(view.class) ?: @"UnknownView";
+    NSString *identifier = view.accessibilityIdentifier.length > 0 ? view.accessibilityIdentifier : @"-";
+    if (identifier.length > 80) identifier = [identifier substringToIndex:80];
+
+    [output appendFormat:@"%@- %@ frame={%@} hidden=%@ alpha=%.2f subviews=%lu identifier=%@\n",
+     NMIndent(depth), className, NMSafeFrameDescription(view.frame),
+     view.hidden ? @"YES" : @"NO", view.alpha,
+     (unsigned long)view.subviews.count, identifier];
+
+    for (UIView *subview in view.subviews) {
+        NMAppendViewTree(output, subview, depth + 1, count);
+        if (*count >= 1000) break;
+    }
+}
+
+static BOOL NMClassNameIsRelevant(NSString *name) {
+    if (name.length == 0) return NO;
+    NSArray<NSString *> *prefixes = @[@"CK", @"IM", @"SMS", @"IDS", @"TU"];
+    for (NSString *prefix in prefixes) if ([name hasPrefix:prefix]) return YES;
+
+    NSArray<NSString *> *terms = @[
+        @"Conversation", @"Transcript", @"Message", @"Balloon", @"Compose",
+        @"Entry", @"Pinned", @"Search", @"Chat", @"Contact", @"Collection"
+    ];
+    for (NSString *term in terms) if ([name localizedCaseInsensitiveContainsString:term]) return YES;
+    return NO;
+}
+
+static NSArray<NSString *> *NMRelevantRuntimeClasses(void) {
+    int classCount = objc_getClassList(NULL, 0);
+    if (classCount <= 0) return @[];
+
+    Class *classes = (__unsafe_unretained Class *)calloc((size_t)classCount, sizeof(Class));
+    classCount = objc_getClassList(classes, classCount);
+    NSMutableArray<NSString *> *names = [NSMutableArray array];
+
+    for (int index = 0; index < classCount; index++) {
+        const char *rawName = class_getName(classes[index]);
+        if (!rawName) continue;
+        NSString *name = [NSString stringWithUTF8String:rawName];
+        if (NMClassNameIsRelevant(name)) [names addObject:name];
+    }
+    free(classes);
+
+    [names sortUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+    if (names.count > 1600) return [names subarrayWithRange:NSMakeRange(0, 1600)];
+    return names;
+}
+
+static void NMAppendMethodsForClass(NSMutableString *output, Class cls) {
+    if (!cls) return;
+    NSString *className = NSStringFromClass(cls) ?: @"Unknown";
+    [output appendFormat:@"\n[%@ instance selectors]\n", className];
+
+    unsigned int methodCount = 0;
+    Method *methods = class_copyMethodList(cls, &methodCount);
+    NSMutableArray<NSString *> *selectors = [NSMutableArray array];
+    for (unsigned int index = 0; index < methodCount; index++) {
+        SEL selector = method_getName(methods[index]);
+        if (selector) [selectors addObject:NSStringFromSelector(selector)];
+    }
+    free(methods);
+    [selectors sortUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+
+    NSUInteger limit = MIN(selectors.count, 240);
+    for (NSUInteger index = 0; index < limit; index++) {
+        [output appendFormat:@"  %@\n", selectors[index]];
+    }
+    if (selectors.count > limit) {
+        [output appendFormat:@"  ... %lu more selectors omitted\n", (unsigned long)(selectors.count - limit)];
+    }
+}
+
+static NSString *NMRuntimeInventory(void) {
+    NSMutableString *output = [NSMutableString stringWithString:@"\n=== RELEVANT RUNTIME CLASSES ===\n"];
+    NSArray<NSString *> *classes = NMRelevantRuntimeClasses();
+    [output appendFormat:@"Relevant class count: %lu\n", (unsigned long)classes.count];
+    for (NSString *name in classes) [output appendFormat:@"%@\n", name];
+    return output;
+}
+
+static NSString *NMDiagnosticEntry(UIViewController *triggerController, BOOL manual) {
+    UIWindow *window = NMActiveWindow();
+    UIViewController *root = window.rootViewController;
+    UIViewController *top = NMTopControllerFrom(root);
+    UIViewController *subject = triggerController ?: top ?: root;
+
+    NSMutableString *output = [NSMutableString string];
+    NSDateFormatter *formatter = [NSDateFormatter new];
+    formatter.dateStyle = NSDateFormatterMediumStyle;
+    formatter.timeStyle = NSDateFormatterLongStyle;
+
+    [output appendString:@"\n\n============================================================\n"];
+    [output appendFormat:@"NEXT MESSAGE DIAGNOSTIC v0.2.1 (%@)\n", manual ? @"MANUAL" : @"AUTOMATIC"];
+    [output appendFormat:@"Captured: %@\n", [formatter stringFromDate:NSDate.date]];
+    [output appendFormat:@"Device: %@\n", NMDeviceMachine()];
+    [output appendFormat:@"iOS: %@\n", UIDevice.currentDevice.systemVersion];
+    [output appendFormat:@"Process: %@ (%@)\n", NSProcessInfo.processInfo.processName, NSBundle.mainBundle.bundleIdentifier];
+    [output appendFormat:@"Application state: %ld\n", (long)UIApplication.sharedApplication.applicationState];
+    [output appendFormat:@"Window: %@ frame={%@}\n", NSStringFromClass(window.class), NMSafeFrameDescription(window.frame)];
+    [output appendFormat:@"Trigger controller: %@\n", NSStringFromClass(subject.class) ?: @"none"];
+    [output appendFormat:@"Top controller: %@\n", NSStringFromClass(top.class) ?: @"none"];
+    [output appendString:@"Privacy: message text, contact names, phone numbers and participant data are not collected.\n"];
+
+    [output appendString:@"\n=== CONTROLLER HIERARCHY ===\n"];
+    NSMutableSet *visited = [NSMutableSet set];
+    NMAppendControllerTree(output, root, 0, visited);
+
+    [output appendString:@"\n=== ACTIVE VIEW HIERARCHY ===\n"];
+    NSUInteger viewCount = 0;
+    NMAppendViewTree(output, subject.view ?: window, 0, &viewCount);
+    [output appendFormat:@"Captured view count: %lu\n", (unsigned long)viewCount];
+
+    NSMutableOrderedSet<Class> *methodClasses = [NSMutableOrderedSet orderedSet];
+    if (subject.class) [methodClasses addObject:subject.class];
+    if (top.class) [methodClasses addObject:top.class];
+    if (root.class) [methodClasses addObject:root.class];
+    for (UIViewController *child in subject.childViewControllers) if (child.class) [methodClasses addObject:child.class];
+
+    [output appendString:@"\n=== ACTIVE CONTROLLER SELECTORS ===\n"];
+    for (Class cls in methodClasses) NMAppendMethodsForClass(output, cls);
+
+    if (!NMRuntimeInventoryWritten) {
+        [output appendString:NMRuntimeInventory()];
+        NMRuntimeInventoryWritten = YES;
+    }
+    return output;
+}
+
+static void NMWriteDiagnosticEntry(NSString *entry, BOOL reset) {
+    if (entry.length == 0) return;
+    NSFileManager *manager = NSFileManager.defaultManager;
+    NSString *directory = NMDiagnosticPath.stringByDeletingLastPathComponent;
+    [manager createDirectoryAtPath:directory withIntermediateDirectories:YES attributes:nil error:nil];
+
+    if (reset || ![manager fileExistsAtPath:NMDiagnosticPath]) {
+        [entry writeToFile:NMDiagnosticPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+        return;
+    }
+
+    NSDictionary *attributes = [manager attributesOfItemAtPath:NMDiagnosticPath error:nil];
+    if ([attributes fileSize] > 1024 * 1024) {
+        [entry writeToFile:NMDiagnosticPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+        return;
+    }
+
+    NSFileHandle *handle = [NSFileHandle fileHandleForWritingAtPath:NMDiagnosticPath];
+    [handle seekToEndOfFile];
+    [handle writeData:[entry dataUsingEncoding:NSUTF8StringEncoding]];
+    [handle closeFile];
+}
+
+static void NMCaptureDiagnostic(UIViewController *controller, BOOL manual) {
+    if (!controller && !NMActiveWindow()) return;
+    dispatch_async(NMDiagnosticQueue, ^{
+        NSString *entry = NMDiagnosticEntry(controller, manual);
+        NMWriteDiagnosticEntry(entry, NO);
+    });
+}
+
+static BOOL NMShouldCaptureController(UIViewController *controller) {
+    NSString *name = NSStringFromClass(controller.class);
+    if (name.length == 0) return NO;
+    if ([name hasPrefix:@"CK"] || [name hasPrefix:@"SMS"] || [name hasPrefix:@"IM"]) return YES;
+    NSArray<NSString *> *terms = @[@"Conversation", @"Transcript", @"Message", @"Chat"];
+    for (NSString *term in terms) if ([name localizedCaseInsensitiveContainsString:term]) return YES;
+    return NO;
+}
+
+static void NMShowManualCaptureConfirmation(void) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) return;
+        UIViewController *top = NMTopControllerFrom(NMActiveWindow().rootViewController);
+        if (!top || top.presentedViewController) return;
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Next Message Diagnostic"
+                                                                       message:@"The privacy-safe runtime report was saved. Open Settings → Next Message → Copy Last Report and paste it into the chat."
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Done" style:UIAlertActionStyleDefault handler:nil]];
+        [top presentViewController:alert animated:YES completion:nil];
+    });
+}
+
+static void NMCaptureNotificationCallback(__unused CFNotificationCenterRef center,
+                                          __unused void *observer,
+                                          __unused CFStringRef name,
+                                          __unused const void *object,
+                                          __unused CFDictionaryRef userInfo) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *top = NMTopControllerFrom(NMActiveWindow().rootViewController);
+        NMCaptureDiagnostic(top, YES);
+        NMShowManualCaptureConfirmation();
+    });
+}
+
+static void NMClearNotificationCallback(__unused CFNotificationCenterRef center,
+                                        __unused void *observer,
+                                        __unused CFStringRef name,
+                                        __unused const void *object,
+                                        __unused CFDictionaryRef userInfo) {
+    dispatch_async(NMDiagnosticQueue, ^{
+        [NSFileManager.defaultManager removeItemAtPath:NMDiagnosticPath error:nil];
+        NMRuntimeInventoryWritten = NO;
+        [NMCapturedControllerClasses removeAllObjects];
+    });
+}
+
+@interface UIViewController (NMDiagnostics)
+- (void)nm_diagnostic_viewDidAppear:(BOOL)animated;
+@end
+
+@implementation UIViewController (NMDiagnostics)
+
+- (void)nm_diagnostic_viewDidAppear:(BOOL)animated {
+    [self nm_diagnostic_viewDidAppear:animated];
+    if (!NMShouldCaptureController(self)) return;
+
+    NSString *className = NSStringFromClass(self.class);
+    @synchronized (NMCapturedControllerClasses) {
+        if ([NMCapturedControllerClasses containsObject:className]) return;
+        [NMCapturedControllerClasses addObject:className];
+    }
+
+    __weak UIViewController *weakController = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.8 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIViewController *controller = weakController;
+        if (controller.view.window) NMCaptureDiagnostic(controller, NO);
+    });
+}
+
+@end
+
+__attribute__((constructor)) static void NMInstallDiagnostics(void) {
+    @autoreleasepool {
+        if (![[NSBundle mainBundle].bundleIdentifier isEqualToString:@"com.apple.MobileSMS"]) return;
+
+        NMDiagnosticQueue = dispatch_queue_create("com.nextsolution.nextmessage.diagnostics", DISPATCH_QUEUE_SERIAL);
+        NMCapturedControllerClasses = [NSMutableSet set];
+
+        Method original = class_getInstanceMethod(UIViewController.class, @selector(viewDidAppear:));
+        Method replacement = class_getInstanceMethod(UIViewController.class, @selector(nm_diagnostic_viewDidAppear:));
+        if (original && replacement) method_exchangeImplementations(original, replacement);
+
+        CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL,
+                                        NMCaptureNotificationCallback, NMCaptureNotification,
+                                        NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
+        CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL,
+                                        NMClearNotificationCallback, NMClearNotification,
+                                        NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
+    }
+}

--- a/NextMessage/NextMessage.plist
+++ b/NextMessage/NextMessage.plist
@@ -1,0 +1,10 @@
+{
+    Filter = {
+        Bundles = (
+            "com.apple.MobileSMS"
+        );
+        Executables = (
+            "MobileSMS"
+        );
+    };
+}

--- a/NextMessage/NextMessagePrefs/Makefile
+++ b/NextMessage/NextMessagePrefs/Makefile
@@ -1,0 +1,12 @@
+include $(THEOS)/makefiles/common.mk
+
+BUNDLE_NAME = NextMessagePrefs
+NextMessagePrefs_FILES = NMRootListController.m
+NextMessagePrefs_CFLAGS = -fobjc-arc
+NextMessagePrefs_FRAMEWORKS = UIKit
+NextMessagePrefs_PRIVATE_FRAMEWORKS = Preferences
+NextMessagePrefs_INSTALL_PATH = /Library/PreferenceBundles
+NextMessagePrefs_RESOURCE_DIRS = Resources
+NextMessagePrefs_CODESIGN_FLAGS = -SNextMessagePrefs.entitlements
+
+include $(THEOS_MAKE_PATH)/bundle.mk

--- a/NextMessage/NextMessagePrefs/NMRootListController.m
+++ b/NextMessage/NextMessagePrefs/NMRootListController.m
@@ -3,7 +3,10 @@
 #import <Preferences/PSSpecifier.h>
 
 static NSString * const NMPrefsDomain = @"com.nextsolution.nextmessage";
+static NSString * const NMDiagnosticPath = @"/var/mobile/Library/Preferences/com.nextsolution.nextmessage.diagnostic.txt";
 static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.nextmessage/preferences.changed");
+static CFStringRef const NMCaptureNotification = CFSTR("com.nextsolution.nextmessage.capturediagnostic");
+static CFStringRef const NMClearNotification = CFSTR("com.nextsolution.nextmessage.cleardiagnostic");
 
 @interface NMRootListController : PSListController
 @end
@@ -51,7 +54,7 @@ static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.ne
 
     UILabel *subtitleLabel = [UILabel new];
     subtitleLabel.translatesAutoresizingMaskIntoConstraints = NO;
-    subtitleLabel.text = @"Concept A — smarter, cleaner messaging";
+    subtitleLabel.text = @"v0.2.1 — iOS 16 diagnostic build";
     subtitleLabel.font = [UIFont systemFontOfSize:13 weight:UIFontWeightRegular];
     subtitleLabel.textColor = UIColor.secondaryLabelColor;
     subtitleLabel.textAlignment = NSTextAlignmentCenter;
@@ -84,6 +87,61 @@ static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.ne
     CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), NMPrefsChangedNotification, NULL, NULL, true);
 }
 
+- (void)showTitle:(NSString *)title message:(NSString *)message {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Done" style:UIAlertActionStyleDefault handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (NSString *)diagnosticReport {
+    NSError *error = nil;
+    NSString *report = [NSString stringWithContentsOfFile:NMDiagnosticPath encoding:NSUTF8StringEncoding error:&error];
+    return report.length > 0 ? report : nil;
+}
+
+- (void)captureDiagnostic {
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), NMCaptureNotification, NULL, NULL, true);
+    [self showTitle:@"Capture Requested"
+            message:@"For the best report, first open the Messages inbox, open one conversation, return to the inbox, and then come back here. Next Message also captures each Messages screen automatically. Wait three seconds, then use Share Last Report."];
+}
+
+- (void)copyDiagnostic {
+    NSString *report = [self diagnosticReport];
+    if (!report) {
+        [self showTitle:@"No Report Yet"
+                message:@"Open Messages and visit the inbox and one conversation. Return here after a few seconds, then try again."];
+        return;
+    }
+    UIPasteboard.generalPasteboard.string = report;
+    [self showTitle:@"Report Copied"
+            message:@"The privacy-safe report is on the clipboard. Paste it into the ChatGPT conversation."];
+}
+
+- (void)shareDiagnostic {
+    NSString *report = [self diagnosticReport];
+    if (!report) {
+        [self showTitle:@"No Report Yet"
+                message:@"Open Messages and visit the inbox and one conversation. Return here after a few seconds, then try again."];
+        return;
+    }
+
+    NSString *temporaryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"NextMessage-Diagnostic-v0.2.1.txt"];
+    [report writeToFile:temporaryPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    NSURL *fileURL = [NSURL fileURLWithPath:temporaryPath];
+    UIActivityViewController *activity = [[UIActivityViewController alloc] initWithActivityItems:@[fileURL] applicationActivities:nil];
+    if (activity.popoverPresentationController) {
+        activity.popoverPresentationController.sourceView = self.view;
+        activity.popoverPresentationController.sourceRect = CGRectMake(CGRectGetMidX(self.view.bounds), CGRectGetMidY(self.view.bounds), 1, 1);
+    }
+    [self presentViewController:activity animated:YES completion:nil];
+}
+
+- (void)clearDiagnostic {
+    [NSFileManager.defaultManager removeItemAtPath:NMDiagnosticPath error:nil];
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), NMClearNotification, NULL, NULL, true);
+    [self showTitle:@"Report Cleared" message:@"Open Messages again to generate a fresh diagnostic report."];
+}
+
 - (void)resetPreferences {
     NSArray<NSString *> *keys = @[
         @"Enabled", @"AppearanceMode", @"RedesignInbox", @"RedesignConversation",
@@ -94,10 +152,7 @@ static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.ne
     CFPreferencesAppSynchronize((__bridge CFStringRef)NMPrefsDomain);
     CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), NMPrefsChangedNotification, NULL, NULL, true);
     [self reloadSpecifiers];
-
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Next Message" message:@"Preferences were reset to their defaults." preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:@"Done" style:UIAlertActionStyleDefault handler:nil]];
-    [self presentViewController:alert animated:YES completion:nil];
+    [self showTitle:@"Next Message" message:@"Preferences were reset to their defaults."];
 }
 
 @end

--- a/NextMessage/NextMessagePrefs/NMRootListController.m
+++ b/NextMessage/NextMessagePrefs/NMRootListController.m
@@ -1,0 +1,117 @@
+#import <UIKit/UIKit.h>
+#import <Preferences/PSListController.h>
+#import <Preferences/PSSpecifier.h>
+
+static NSString * const NMPrefsDomain = @"com.nextsolution.nextmessage";
+static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.nextmessage/preferences.changed");
+
+@interface NMRootListController : PSListController
+@end
+
+@implementation NMRootListController
+
+- (NSArray *)specifiers {
+    if (!_specifiers) {
+        _specifiers = [self loadSpecifiersFromPlistName:@"Root" target:self];
+    }
+    return _specifiers;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Next Message";
+    self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+    [self buildHeader];
+}
+
+- (void)buildHeader {
+    UIView *header = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 154)];
+
+    UIView *iconBackground = [UIView new];
+    iconBackground.translatesAutoresizingMaskIntoConstraints = NO;
+    iconBackground.backgroundColor = [UIColor colorWithRed:0.58 green:0.45 blue:1.0 alpha:1.0];
+    iconBackground.layer.cornerRadius = 22.0;
+    iconBackground.layer.cornerCurve = kCACornerCurveContinuous;
+    iconBackground.layer.shadowColor = [UIColor colorWithRed:0.55 green:0.42 blue:1.0 alpha:1.0].CGColor;
+    iconBackground.layer.shadowOpacity = 0.30;
+    iconBackground.layer.shadowRadius = 14.0;
+    iconBackground.layer.shadowOffset = CGSizeMake(0, 6);
+    [header addSubview:iconBackground];
+
+    UIImageView *icon = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"message.fill"]];
+    icon.translatesAutoresizingMaskIntoConstraints = NO;
+    icon.tintColor = UIColor.whiteColor;
+    icon.preferredSymbolConfiguration = [UIImageSymbolConfiguration configurationWithPointSize:29 weight:UIImageSymbolWeightSemibold];
+    [iconBackground addSubview:icon];
+
+    UILabel *titleLabel = [UILabel new];
+    titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    titleLabel.text = @"Next Message";
+    titleLabel.font = [UIFont systemFontOfSize:22 weight:UIFontWeightBold];
+    titleLabel.textAlignment = NSTextAlignmentCenter;
+    [header addSubview:titleLabel];
+
+    UILabel *subtitleLabel = [UILabel new];
+    subtitleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    subtitleLabel.text = @"A calmer, cleaner Messages experience";
+    subtitleLabel.font = [UIFont systemFontOfSize:13 weight:UIFontWeightRegular];
+    subtitleLabel.textColor = UIColor.secondaryLabelColor;
+    subtitleLabel.textAlignment = NSTextAlignmentCenter;
+    [header addSubview:subtitleLabel];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [iconBackground.topAnchor constraintEqualToAnchor:header.topAnchor constant:12],
+        [iconBackground.centerXAnchor constraintEqualToAnchor:header.centerXAnchor],
+        [iconBackground.widthAnchor constraintEqualToConstant:64],
+        [iconBackground.heightAnchor constraintEqualToConstant:64],
+
+        [icon.centerXAnchor constraintEqualToAnchor:iconBackground.centerXAnchor],
+        [icon.centerYAnchor constraintEqualToAnchor:iconBackground.centerYAnchor],
+        [icon.widthAnchor constraintEqualToConstant:34],
+        [icon.heightAnchor constraintEqualToConstant:34],
+
+        [titleLabel.topAnchor constraintEqualToAnchor:iconBackground.bottomAnchor constant:12],
+        [titleLabel.leadingAnchor constraintEqualToAnchor:header.leadingAnchor constant:16],
+        [titleLabel.trailingAnchor constraintEqualToAnchor:header.trailingAnchor constant:-16],
+
+        [subtitleLabel.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:4],
+        [subtitleLabel.leadingAnchor constraintEqualToAnchor:header.leadingAnchor constant:16],
+        [subtitleLabel.trailingAnchor constraintEqualToAnchor:header.trailingAnchor constant:-16],
+    ]];
+
+    UITableView *tableView = [self valueForKey:@"table"];
+    if ([tableView isKindOfClass:UITableView.class]) {
+        tableView.tableHeaderView = header;
+    }
+}
+
+- (void)setPreferenceValue:(id)value specifier:(PSSpecifier *)specifier {
+    [super setPreferenceValue:value specifier:specifier];
+    CFPreferencesAppSynchronize((__bridge CFStringRef)NMPrefsDomain);
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), NMPrefsChangedNotification, NULL, NULL, true);
+}
+
+- (void)resetPreferences {
+    NSArray<NSString *> *keys = @[
+        @"Enabled",
+        @"AppearanceMode",
+        @"RedesignInbox",
+        @"RedesignConversation",
+        @"EnableToasts",
+        @"EnableInfoAction",
+        @"EnableDeleteAction",
+    ];
+
+    for (NSString *key in keys) {
+        CFPreferencesSetAppValue((__bridge CFStringRef)key, NULL, (__bridge CFStringRef)NMPrefsDomain);
+    }
+    CFPreferencesAppSynchronize((__bridge CFStringRef)NMPrefsDomain);
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), NMPrefsChangedNotification, NULL, NULL, true);
+    [self reloadSpecifiers];
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Next Message" message:@"Preferences were reset to their defaults." preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Done" style:UIAlertActionStyleDefault handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+@end

--- a/NextMessage/NextMessagePrefs/NMRootListController.m
+++ b/NextMessage/NextMessagePrefs/NMRootListController.m
@@ -11,9 +11,7 @@ static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.ne
 @implementation NMRootListController
 
 - (NSArray *)specifiers {
-    if (!_specifiers) {
-        _specifiers = [self loadSpecifiersFromPlistName:@"Root" target:self];
-    }
+    if (!_specifiers) _specifiers = [self loadSpecifiersFromPlistName:@"Root" target:self];
     return _specifiers;
 }
 
@@ -25,16 +23,16 @@ static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.ne
 }
 
 - (void)buildHeader {
-    UIView *header = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 154)];
+    UIView *header = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 158)];
 
     UIView *iconBackground = [UIView new];
     iconBackground.translatesAutoresizingMaskIntoConstraints = NO;
-    iconBackground.backgroundColor = [UIColor colorWithRed:0.58 green:0.45 blue:1.0 alpha:1.0];
+    iconBackground.backgroundColor = [UIColor colorWithRed:0.45 green:0.35 blue:1.0 alpha:1.0];
     iconBackground.layer.cornerRadius = 22.0;
     iconBackground.layer.cornerCurve = kCACornerCurveContinuous;
-    iconBackground.layer.shadowColor = [UIColor colorWithRed:0.55 green:0.42 blue:1.0 alpha:1.0].CGColor;
-    iconBackground.layer.shadowOpacity = 0.30;
-    iconBackground.layer.shadowRadius = 14.0;
+    iconBackground.layer.shadowColor = [UIColor colorWithRed:0.35 green:0.48 blue:1.0 alpha:1.0].CGColor;
+    iconBackground.layer.shadowOpacity = 0.32;
+    iconBackground.layer.shadowRadius = 15.0;
     iconBackground.layer.shadowOffset = CGSizeMake(0, 6);
     [header addSubview:iconBackground];
 
@@ -53,7 +51,7 @@ static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.ne
 
     UILabel *subtitleLabel = [UILabel new];
     subtitleLabel.translatesAutoresizingMaskIntoConstraints = NO;
-    subtitleLabel.text = @"A calmer, cleaner Messages experience";
+    subtitleLabel.text = @"Concept A — smarter, cleaner messaging";
     subtitleLabel.font = [UIFont systemFontOfSize:13 weight:UIFontWeightRegular];
     subtitleLabel.textColor = UIColor.secondaryLabelColor;
     subtitleLabel.textAlignment = NSTextAlignmentCenter;
@@ -64,25 +62,20 @@ static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.ne
         [iconBackground.centerXAnchor constraintEqualToAnchor:header.centerXAnchor],
         [iconBackground.widthAnchor constraintEqualToConstant:64],
         [iconBackground.heightAnchor constraintEqualToConstant:64],
-
         [icon.centerXAnchor constraintEqualToAnchor:iconBackground.centerXAnchor],
         [icon.centerYAnchor constraintEqualToAnchor:iconBackground.centerYAnchor],
         [icon.widthAnchor constraintEqualToConstant:34],
         [icon.heightAnchor constraintEqualToConstant:34],
-
         [titleLabel.topAnchor constraintEqualToAnchor:iconBackground.bottomAnchor constant:12],
         [titleLabel.leadingAnchor constraintEqualToAnchor:header.leadingAnchor constant:16],
         [titleLabel.trailingAnchor constraintEqualToAnchor:header.trailingAnchor constant:-16],
-
         [subtitleLabel.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:4],
         [subtitleLabel.leadingAnchor constraintEqualToAnchor:header.leadingAnchor constant:16],
         [subtitleLabel.trailingAnchor constraintEqualToAnchor:header.trailingAnchor constant:-16],
     ]];
 
     UITableView *tableView = [self valueForKey:@"table"];
-    if ([tableView isKindOfClass:UITableView.class]) {
-        tableView.tableHeaderView = header;
-    }
+    if ([tableView isKindOfClass:UITableView.class]) tableView.tableHeaderView = header;
 }
 
 - (void)setPreferenceValue:(id)value specifier:(PSSpecifier *)specifier {
@@ -93,18 +86,11 @@ static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.ne
 
 - (void)resetPreferences {
     NSArray<NSString *> *keys = @[
-        @"Enabled",
-        @"AppearanceMode",
-        @"RedesignInbox",
-        @"RedesignConversation",
-        @"EnableToasts",
-        @"EnableInfoAction",
-        @"EnableDeleteAction",
+        @"Enabled", @"AppearanceMode", @"RedesignInbox", @"RedesignConversation",
+        @"EnableAuroraBackground", @"EnableConceptHeader", @"EnableBottomDock",
+        @"EnableSmartReplies", @"EnableToasts", @"EnableInfoAction", @"EnableDeleteAction"
     ];
-
-    for (NSString *key in keys) {
-        CFPreferencesSetAppValue((__bridge CFStringRef)key, NULL, (__bridge CFStringRef)NMPrefsDomain);
-    }
+    for (NSString *key in keys) CFPreferencesSetAppValue((__bridge CFStringRef)key, NULL, (__bridge CFStringRef)NMPrefsDomain);
     CFPreferencesAppSynchronize((__bridge CFStringRef)NMPrefsDomain);
     CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), NMPrefsChangedNotification, NULL, NULL, true);
     [self reloadSpecifiers];

--- a/NextMessage/NextMessagePrefs/NextMessagePrefs.entitlements
+++ b/NextMessage/NextMessagePrefs/NextMessagePrefs.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>platform-application</key>
+    <true/>
+    <key>com.apple.private.security.no-sandbox</key>
+    <true/>
+    <key>com.apple.private.security.storage.AppBundles</key>
+    <true/>
+    <key>com.apple.private.security.storage.AppDataContainers</key>
+    <true/>
+</dict>
+</plist>

--- a/NextMessage/NextMessagePrefs/NextMessagePrefs.entitlements
+++ b/NextMessage/NextMessagePrefs/NextMessagePrefs.entitlements
@@ -2,13 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>platform-application</key>
-    <true/>
-    <key>com.apple.private.security.no-sandbox</key>
-    <true/>
-    <key>com.apple.private.security.storage.AppBundles</key>
-    <true/>
-    <key>com.apple.private.security.storage.AppDataContainers</key>
-    <true/>
+    <key>platform-application</key><true/>
+    <key>com.apple.private.security.no-sandbox</key><true/>
+    <key>com.apple.private.security.container-required</key><false/>
+    <key>com.apple.private.security.storage.AppBundles</key><true/>
+    <key>com.apple.private.security.storage.AppDataContainers</key><true/>
+    <key>com.apple.private.security.storage.Preferences</key><true/>
 </dict>
 </plist>

--- a/NextMessage/NextMessagePrefs/Resources/Info.plist
+++ b/NextMessage/NextMessagePrefs/Resources/Info.plist
@@ -2,23 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleDevelopmentRegion</key>
-    <string>en</string>
-    <key>CFBundleExecutable</key>
-    <string>NextMessagePrefs</string>
-    <key>CFBundleIdentifier</key>
-    <string>com.nextsolution.nextmessageprefs</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>CFBundleName</key>
-    <string>NextMessagePrefs</string>
-    <key>CFBundlePackageType</key>
-    <string>BNDL</string>
-    <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
-    <key>CFBundleVersion</key>
-    <string>1</string>
-    <key>NSPrincipalClass</key>
-    <string>NMRootListController</string>
+    <key>CFBundleDevelopmentRegion</key><string>en</string>
+    <key>CFBundleDisplayName</key><string>Next Message</string>
+    <key>CFBundleExecutable</key><string>NextMessagePrefs</string>
+    <key>CFBundleIdentifier</key><string>com.nextsolution.nextmessageprefs</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>CFBundleName</key><string>NextMessagePrefs</string>
+    <key>CFBundlePackageType</key><string>BNDL</string>
+    <key>CFBundleShortVersionString</key><string>0.2.0</string>
+    <key>CFBundleVersion</key><string>2</string>
+    <key>CFBundleSupportedPlatforms</key><array><string>iPhoneOS</string></array>
+    <key>DTPlatformName</key><string>iphoneos</string>
+    <key>MinimumOSVersion</key><string>15.0</string>
+    <key>NSPrincipalClass</key><string>NMRootListController</string>
 </dict>
 </plist>

--- a/NextMessage/NextMessagePrefs/Resources/Info.plist
+++ b/NextMessage/NextMessagePrefs/Resources/Info.plist
@@ -9,8 +9,8 @@
     <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
     <key>CFBundleName</key><string>NextMessagePrefs</string>
     <key>CFBundlePackageType</key><string>BNDL</string>
-    <key>CFBundleShortVersionString</key><string>0.2.0</string>
-    <key>CFBundleVersion</key><string>2</string>
+    <key>CFBundleShortVersionString</key><string>0.2.1</string>
+    <key>CFBundleVersion</key><string>3</string>
     <key>CFBundleSupportedPlatforms</key><array><string>iPhoneOS</string></array>
     <key>DTPlatformName</key><string>iphoneos</string>
     <key>MinimumOSVersion</key><string>15.0</string>

--- a/NextMessage/NextMessagePrefs/Resources/Info.plist
+++ b/NextMessage/NextMessagePrefs/Resources/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>NextMessagePrefs</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.nextsolution.nextmessageprefs</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>NextMessagePrefs</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSPrincipalClass</key>
+    <string>NMRootListController</string>
+</dict>
+</plist>

--- a/NextMessage/NextMessagePrefs/Resources/Root.plist
+++ b/NextMessage/NextMessagePrefs/Resources/Root.plist
@@ -3,157 +3,136 @@
 <plist version="1.0">
 <array>
     <dict>
-        <key>cell</key>
-        <string>PSGroupCell</string>
-        <key>label</key>
-        <string>GENERAL</string>
-        <key>footerText</key>
-        <string>Next Message redesigns the stock Messages app while keeping Apple’s original messaging functions.</string>
+        <key>cell</key><string>PSGroupCell</string>
+        <key>label</key><string>NEXT MESSAGE</string>
+        <key>footerText</key><string>Concept A redesign for Apple Messages. Original messaging, attachments, calls, and deletion remain handled by the stock app.</string>
     </dict>
     <dict>
-        <key>cell</key>
-        <string>PSSwitchCell</string>
-        <key>label</key>
-        <string>Enable Next Message</string>
-        <key>defaults</key>
-        <string>com.nextsolution.nextmessage</string>
-        <key>key</key>
-        <string>Enabled</string>
-        <key>default</key>
-        <true/>
-        <key>PostNotification</key>
-        <string>com.nextsolution.nextmessage/preferences.changed</string>
+        <key>cell</key><string>PSSwitchCell</string>
+        <key>label</key><string>Enable Next Message</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>Enabled</string>
+        <key>default</key><true/>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
     </dict>
 
     <dict>
-        <key>cell</key>
-        <string>PSGroupCell</string>
-        <key>label</key>
-        <string>APPEARANCE</string>
-        <key>footerText</key>
-        <string>System follows your iPhone appearance. Black uses a true-black background for OLED displays.</string>
+        <key>cell</key><string>PSGroupCell</string>
+        <key>label</key><string>THEME</string>
+        <key>footerText</key><string>System follows the iPhone appearance. Black uses a true-black OLED canvas.</string>
     </dict>
     <dict>
-        <key>cell</key>
-        <string>PSSegmentCell</string>
-        <key>label</key>
-        <string>Theme</string>
-        <key>defaults</key>
-        <string>com.nextsolution.nextmessage</string>
-        <key>key</key>
-        <string>AppearanceMode</string>
-        <key>default</key>
-        <integer>0</integer>
+        <key>cell</key><string>PSSegmentCell</string>
+        <key>label</key><string>Appearance</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>AppearanceMode</string>
+        <key>default</key><integer>0</integer>
         <key>validTitles</key>
-        <array>
-            <string>System</string>
-            <string>Light</string>
-            <string>Black</string>
-        </array>
+        <array><string>System</string><string>Light</string><string>Black</string></array>
         <key>validValues</key>
-        <array>
-            <integer>0</integer>
-            <integer>1</integer>
-            <integer>2</integer>
-        </array>
-        <key>PostNotification</key>
-        <string>com.nextsolution.nextmessage/preferences.changed</string>
+        <array><integer>0</integer><integer>1</integer><integer>2</integer></array>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
     </dict>
     <dict>
-        <key>cell</key>
-        <string>PSSwitchCell</string>
-        <key>label</key>
-        <string>Conversation Cards</string>
-        <key>defaults</key>
-        <string>com.nextsolution.nextmessage</string>
-        <key>key</key>
-        <string>RedesignInbox</string>
-        <key>default</key>
-        <true/>
-        <key>PostNotification</key>
-        <string>com.nextsolution.nextmessage/preferences.changed</string>
-    </dict>
-    <dict>
-        <key>cell</key>
-        <string>PSSwitchCell</string>
-        <key>label</key>
-        <string>Modern Chat View</string>
-        <key>defaults</key>
-        <string>com.nextsolution.nextmessage</string>
-        <key>key</key>
-        <string>RedesignConversation</string>
-        <key>default</key>
-        <true/>
-        <key>PostNotification</key>
-        <string>com.nextsolution.nextmessage/preferences.changed</string>
+        <key>cell</key><string>PSSwitchCell</string>
+        <key>label</key><string>Aurora Background</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>EnableAuroraBackground</string>
+        <key>default</key><true/>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
     </dict>
 
     <dict>
-        <key>cell</key>
-        <string>PSGroupCell</string>
-        <key>label</key>
-        <string>ACTIONS</string>
-        <key>footerText</key>
-        <string>Swipe a conversation to access Info and Delete. Info opens a quiet toast showing the total messages and the first conversation date.</string>
+        <key>cell</key><string>PSGroupCell</string>
+        <key>label</key><string>CONCEPT A — INBOX</string>
+        <key>footerText</key><string>Adds the Next Message glass header, search, category chips, floating compose button, glass conversation cards, and bottom dock.</string>
     </dict>
     <dict>
-        <key>cell</key>
-        <string>PSSwitchCell</string>
-        <key>label</key>
-        <string>Quiet Toasts</string>
-        <key>defaults</key>
-        <string>com.nextsolution.nextmessage</string>
-        <key>key</key>
-        <string>EnableToasts</string>
-        <key>default</key>
-        <true/>
-        <key>PostNotification</key>
-        <string>com.nextsolution.nextmessage/preferences.changed</string>
+        <key>cell</key><string>PSSwitchCell</string>
+        <key>label</key><string>Redesign Inbox</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>RedesignInbox</string>
+        <key>default</key><true/>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
     </dict>
     <dict>
-        <key>cell</key>
-        <string>PSSwitchCell</string>
-        <key>label</key>
-        <string>Info Swipe Action</string>
-        <key>defaults</key>
-        <string>com.nextsolution.nextmessage</string>
-        <key>key</key>
-        <string>EnableInfoAction</string>
-        <key>default</key>
-        <true/>
-        <key>PostNotification</key>
-        <string>com.nextsolution.nextmessage/preferences.changed</string>
+        <key>cell</key><string>PSSwitchCell</string>
+        <key>label</key><string>Glass Header &amp; Filters</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>EnableConceptHeader</string>
+        <key>default</key><true/>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
     </dict>
     <dict>
-        <key>cell</key>
-        <string>PSSwitchCell</string>
-        <key>label</key>
-        <string>Delete Swipe Action</string>
-        <key>defaults</key>
-        <string>com.nextsolution.nextmessage</string>
-        <key>key</key>
-        <string>EnableDeleteAction</string>
-        <key>default</key>
-        <true/>
-        <key>PostNotification</key>
-        <string>com.nextsolution.nextmessage/preferences.changed</string>
+        <key>cell</key><string>PSSwitchCell</string>
+        <key>label</key><string>Bottom Navigation Dock</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>EnableBottomDock</string>
+        <key>default</key><true/>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
     </dict>
 
     <dict>
-        <key>cell</key>
-        <string>PSGroupCell</string>
-        <key>label</key>
-        <string>MAINTENANCE</string>
-        <key>footerText</key>
-        <string>Next Solution — Zeshan 0727</string>
+        <key>cell</key><string>PSGroupCell</string>
+        <key>label</key><string>CONCEPT A — CHAT</string>
+        <key>footerText</key><string>Uses gradient sent bubbles, glass received bubbles, a modern composer, and smart-reply chips.</string>
     </dict>
     <dict>
-        <key>cell</key>
-        <string>PSButtonCell</string>
-        <key>label</key>
-        <string>Reset Preferences</string>
-        <key>action</key>
-        <string>resetPreferences</string>
+        <key>cell</key><string>PSSwitchCell</string>
+        <key>label</key><string>Redesign Conversation</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>RedesignConversation</string>
+        <key>default</key><true/>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+    <dict>
+        <key>cell</key><string>PSSwitchCell</string>
+        <key>label</key><string>Smart Reply Bar</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>EnableSmartReplies</string>
+        <key>default</key><true/>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+
+    <dict>
+        <key>cell</key><string>PSGroupCell</string>
+        <key>label</key><string>SWIPE ACTIONS</string>
+        <key>footerText</key><string>Info displays the number of messages and the date the conversation first started. Delete preserves Apple’s stock deletion action.</string>
+    </dict>
+    <dict>
+        <key>cell</key><string>PSSwitchCell</string>
+        <key>label</key><string>Conversation Info</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>EnableInfoAction</string>
+        <key>default</key><true/>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+    <dict>
+        <key>cell</key><string>PSSwitchCell</string>
+        <key>label</key><string>Delete</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>EnableDeleteAction</string>
+        <key>default</key><true/>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+    <dict>
+        <key>cell</key><string>PSSwitchCell</string>
+        <key>label</key><string>Quiet Toasts</string>
+        <key>defaults</key><string>com.nextsolution.nextmessage</string>
+        <key>key</key><string>EnableToasts</string>
+        <key>default</key><true/>
+        <key>PostNotification</key><string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+
+    <dict>
+        <key>cell</key><string>PSGroupCell</string>
+        <key>label</key><string>MAINTENANCE</string>
+        <key>footerText</key><string>Next Solution — Zeshan 0727</string>
+    </dict>
+    <dict>
+        <key>cell</key><string>PSButtonCell</string>
+        <key>label</key><string>Reset Preferences</string>
+        <key>action</key><string>resetPreferences</string>
     </dict>
 </array>
 </plist>

--- a/NextMessage/NextMessagePrefs/Resources/Root.plist
+++ b/NextMessage/NextMessagePrefs/Resources/Root.plist
@@ -18,6 +18,32 @@
 
     <dict>
         <key>cell</key><string>PSGroupCell</string>
+        <key>label</key><string>iOS 16 DIAGNOSTIC</string>
+        <key>footerText</key><string>This build automatically records the Messages controller and view classes needed for a real Concept A implementation. It does not collect message text, contact names, phone numbers, or participant information. Open the inbox and one conversation before sharing the report.</string>
+    </dict>
+    <dict>
+        <key>cell</key><string>PSButtonCell</string>
+        <key>label</key><string>Capture Current Messages Screen</string>
+        <key>action</key><string>captureDiagnostic</string>
+    </dict>
+    <dict>
+        <key>cell</key><string>PSButtonCell</string>
+        <key>label</key><string>Share Last Report</string>
+        <key>action</key><string>shareDiagnostic</string>
+    </dict>
+    <dict>
+        <key>cell</key><string>PSButtonCell</string>
+        <key>label</key><string>Copy Last Report</string>
+        <key>action</key><string>copyDiagnostic</string>
+    </dict>
+    <dict>
+        <key>cell</key><string>PSButtonCell</string>
+        <key>label</key><string>Clear Diagnostic Report</string>
+        <key>action</key><string>clearDiagnostic</string>
+    </dict>
+
+    <dict>
+        <key>cell</key><string>PSGroupCell</string>
         <key>label</key><string>THEME</string>
         <key>footerText</key><string>System follows the iPhone appearance. Black uses a true-black OLED canvas.</string>
     </dict>

--- a/NextMessage/NextMessagePrefs/Resources/Root.plist
+++ b/NextMessage/NextMessagePrefs/Resources/Root.plist
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+    <dict>
+        <key>cell</key>
+        <string>PSGroupCell</string>
+        <key>label</key>
+        <string>GENERAL</string>
+        <key>footerText</key>
+        <string>Next Message redesigns the stock Messages app while keeping Apple’s original messaging functions.</string>
+    </dict>
+    <dict>
+        <key>cell</key>
+        <string>PSSwitchCell</string>
+        <key>label</key>
+        <string>Enable Next Message</string>
+        <key>defaults</key>
+        <string>com.nextsolution.nextmessage</string>
+        <key>key</key>
+        <string>Enabled</string>
+        <key>default</key>
+        <true/>
+        <key>PostNotification</key>
+        <string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+
+    <dict>
+        <key>cell</key>
+        <string>PSGroupCell</string>
+        <key>label</key>
+        <string>APPEARANCE</string>
+        <key>footerText</key>
+        <string>System follows your iPhone appearance. Black uses a true-black background for OLED displays.</string>
+    </dict>
+    <dict>
+        <key>cell</key>
+        <string>PSSegmentCell</string>
+        <key>label</key>
+        <string>Theme</string>
+        <key>defaults</key>
+        <string>com.nextsolution.nextmessage</string>
+        <key>key</key>
+        <string>AppearanceMode</string>
+        <key>default</key>
+        <integer>0</integer>
+        <key>validTitles</key>
+        <array>
+            <string>System</string>
+            <string>Light</string>
+            <string>Black</string>
+        </array>
+        <key>validValues</key>
+        <array>
+            <integer>0</integer>
+            <integer>1</integer>
+            <integer>2</integer>
+        </array>
+        <key>PostNotification</key>
+        <string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+    <dict>
+        <key>cell</key>
+        <string>PSSwitchCell</string>
+        <key>label</key>
+        <string>Conversation Cards</string>
+        <key>defaults</key>
+        <string>com.nextsolution.nextmessage</string>
+        <key>key</key>
+        <string>RedesignInbox</string>
+        <key>default</key>
+        <true/>
+        <key>PostNotification</key>
+        <string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+    <dict>
+        <key>cell</key>
+        <string>PSSwitchCell</string>
+        <key>label</key>
+        <string>Modern Chat View</string>
+        <key>defaults</key>
+        <string>com.nextsolution.nextmessage</string>
+        <key>key</key>
+        <string>RedesignConversation</string>
+        <key>default</key>
+        <true/>
+        <key>PostNotification</key>
+        <string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+
+    <dict>
+        <key>cell</key>
+        <string>PSGroupCell</string>
+        <key>label</key>
+        <string>ACTIONS</string>
+        <key>footerText</key>
+        <string>Swipe a conversation to access Info and Delete. Info opens a quiet toast showing the total messages and the first conversation date.</string>
+    </dict>
+    <dict>
+        <key>cell</key>
+        <string>PSSwitchCell</string>
+        <key>label</key>
+        <string>Quiet Toasts</string>
+        <key>defaults</key>
+        <string>com.nextsolution.nextmessage</string>
+        <key>key</key>
+        <string>EnableToasts</string>
+        <key>default</key>
+        <true/>
+        <key>PostNotification</key>
+        <string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+    <dict>
+        <key>cell</key>
+        <string>PSSwitchCell</string>
+        <key>label</key>
+        <string>Info Swipe Action</string>
+        <key>defaults</key>
+        <string>com.nextsolution.nextmessage</string>
+        <key>key</key>
+        <string>EnableInfoAction</string>
+        <key>default</key>
+        <true/>
+        <key>PostNotification</key>
+        <string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+    <dict>
+        <key>cell</key>
+        <string>PSSwitchCell</string>
+        <key>label</key>
+        <string>Delete Swipe Action</string>
+        <key>defaults</key>
+        <string>com.nextsolution.nextmessage</string>
+        <key>key</key>
+        <string>EnableDeleteAction</string>
+        <key>default</key>
+        <true/>
+        <key>PostNotification</key>
+        <string>com.nextsolution.nextmessage/preferences.changed</string>
+    </dict>
+
+    <dict>
+        <key>cell</key>
+        <string>PSGroupCell</string>
+        <key>label</key>
+        <string>MAINTENANCE</string>
+        <key>footerText</key>
+        <string>Next Solution — Zeshan 0727</string>
+    </dict>
+    <dict>
+        <key>cell</key>
+        <string>PSButtonCell</string>
+        <key>label</key>
+        <string>Reset Preferences</string>
+        <key>action</key>
+        <string>resetPreferences</string>
+    </dict>
+</array>
+</plist>

--- a/NextMessage/README.md
+++ b/NextMessage/README.md
@@ -1,0 +1,44 @@
+# Next Message
+
+A Concept H-inspired redesign for Apple Messages.
+
+## Current foundation
+
+- iOS 15 and newer deployment target
+- arm64 and arm64e builds
+- RootHide and rootless packaging
+- Light, Black, and Follow System appearance modes
+- Frosted conversation cards
+- Minimal conversation and composer styling
+- Swipe Info action
+- Stock Delete action preservation with a guarded fallback
+- Conversation information toast showing:
+  - total messages in the selected conversation
+  - first conversation start date
+- PreferenceLoader settings bundle with RootHide entitlements
+- Live preference reload through Darwin notifications
+
+## Package
+
+- Identifier: `com.nextsolution.nextmessage`
+- Name: `Next Message`
+- Author: `Next Solution - Zeshan 0727`
+
+## Build
+
+```sh
+make clean package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME=rootless
+make clean package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME=roothide
+```
+
+The GitHub Actions workflow builds both package schemes on macOS so the arm64e system-app target uses the correct toolchain.
+
+## First device test target
+
+- iPhone 14 Pro Max
+- iOS 16.0
+- RootHide
+
+## Development status
+
+Version `0.1.0` is the first implementation foundation. Private Messages classes can vary across iOS releases, so device testing will be used to confirm and refine the exact conversation-list and chat-view hooks before release.

--- a/NextMessage/Tweak.xm
+++ b/NextMessage/Tweak.xm
@@ -22,6 +22,10 @@ typedef NS_ENUM(NSInteger, NMAppearanceMode) {
 @property (nonatomic, assign) BOOL enableToasts;
 @property (nonatomic, assign) BOOL enableInfoAction;
 @property (nonatomic, assign) BOOL enableDeleteAction;
+@property (nonatomic, assign) BOOL enableConceptHeader;
+@property (nonatomic, assign) BOOL enableBottomDock;
+@property (nonatomic, assign) BOOL enableSmartReplies;
+@property (nonatomic, assign) BOOL enableAuroraBackground;
 @property (nonatomic, assign) NMAppearanceMode appearanceMode;
 + (instancetype)shared;
 - (void)reload;
@@ -46,13 +50,16 @@ static id NMPreferenceValue(NSString *key) {
 
 - (void)reload {
     CFPreferencesAppSynchronize((__bridge CFStringRef)NMPrefsDomain);
-
     NSNumber *enabled = NMPreferenceValue(@"Enabled");
     NSNumber *inbox = NMPreferenceValue(@"RedesignInbox");
     NSNumber *conversation = NMPreferenceValue(@"RedesignConversation");
     NSNumber *toasts = NMPreferenceValue(@"EnableToasts");
     NSNumber *info = NMPreferenceValue(@"EnableInfoAction");
     NSNumber *deleteAction = NMPreferenceValue(@"EnableDeleteAction");
+    NSNumber *header = NMPreferenceValue(@"EnableConceptHeader");
+    NSNumber *dock = NMPreferenceValue(@"EnableBottomDock");
+    NSNumber *replies = NMPreferenceValue(@"EnableSmartReplies");
+    NSNumber *aurora = NMPreferenceValue(@"EnableAuroraBackground");
     NSNumber *appearance = NMPreferenceValue(@"AppearanceMode");
 
     self.enabled = enabled ? enabled.boolValue : YES;
@@ -61,19 +68,28 @@ static id NMPreferenceValue(NSString *key) {
     self.enableToasts = toasts ? toasts.boolValue : YES;
     self.enableInfoAction = info ? info.boolValue : YES;
     self.enableDeleteAction = deleteAction ? deleteAction.boolValue : YES;
+    self.enableConceptHeader = header ? header.boolValue : YES;
+    self.enableBottomDock = dock ? dock.boolValue : YES;
+    self.enableSmartReplies = replies ? replies.boolValue : YES;
+    self.enableAuroraBackground = aurora ? aurora.boolValue : YES;
     self.appearanceMode = appearance ? (NMAppearanceMode)appearance.integerValue : NMAppearanceModeSystem;
 }
 
 @end
 
+static UIColor *NMPurpleColor(void) {
+    return [UIColor colorWithRed:0.45 green:0.35 blue:1.0 alpha:1.0];
+}
+
+static UIColor *NMBlueColor(void) {
+    return [UIColor colorWithRed:0.20 green:0.55 blue:1.0 alpha:1.0];
+}
+
 static UIUserInterfaceStyle NMForcedInterfaceStyle(void) {
     switch ([NMPreferences shared].appearanceMode) {
-        case NMAppearanceModeLight:
-            return UIUserInterfaceStyleLight;
-        case NMAppearanceModeBlack:
-            return UIUserInterfaceStyleDark;
-        default:
-            return UIUserInterfaceStyleUnspecified;
+        case NMAppearanceModeLight: return UIUserInterfaceStyleLight;
+        case NMAppearanceModeBlack: return UIUserInterfaceStyleDark;
+        default: return UIUserInterfaceStyleUnspecified;
     }
 }
 
@@ -85,12 +101,10 @@ static BOOL NMUsesDarkAppearance(UITraitCollection *traits) {
 }
 
 static UIColor *NMCanvasColor(UITraitCollection *traits) {
-    if ([NMPreferences shared].appearanceMode == NMAppearanceModeBlack) {
-        return UIColor.blackColor;
-    }
+    if ([NMPreferences shared].appearanceMode == NMAppearanceModeBlack) return UIColor.blackColor;
     return NMUsesDarkAppearance(traits)
-        ? [UIColor colorWithWhite:0.025 alpha:1.0]
-        : [UIColor colorWithWhite:0.975 alpha:1.0];
+        ? [UIColor colorWithRed:0.015 green:0.035 blue:0.060 alpha:1.0]
+        : [UIColor colorWithRed:0.935 green:0.955 blue:0.980 alpha:1.0];
 }
 
 static UIBlurEffectStyle NMBlurStyle(UITraitCollection *traits) {
@@ -101,19 +115,14 @@ static UIBlurEffectStyle NMBlurStyle(UITraitCollection *traits) {
 
 static id NMSafeValue(id object, NSString *key) {
     if (!object || key.length == 0) return nil;
-    @try {
-        return [object valueForKey:key];
-    } @catch (__unused NSException *exception) {
-        return nil;
-    }
+    @try { return [object valueForKey:key]; }
+    @catch (__unused NSException *exception) { return nil; }
 }
 
 static NSString *NMSafeString(id object, NSArray<NSString *> *keys) {
     for (NSString *key in keys) {
         id value = NMSafeValue(object, key);
-        if ([value isKindOfClass:NSString.class] && [value length] > 0) {
-            return value;
-        }
+        if ([value isKindOfClass:NSString.class] && [value length] > 0) return value;
         if ([value respondsToSelector:@selector(stringValue)]) {
             NSString *string = [value stringValue];
             if (string.length > 0) return string;
@@ -124,51 +133,74 @@ static NSString *NMSafeString(id object, NSArray<NSString *> *keys) {
 
 static UIViewController *NMTopControllerFrom(UIViewController *controller) {
     if (!controller) return nil;
-    if (controller.presentedViewController) {
-        return NMTopControllerFrom(controller.presentedViewController);
-    }
-    if ([controller isKindOfClass:UINavigationController.class]) {
-        return NMTopControllerFrom(((UINavigationController *)controller).visibleViewController);
-    }
-    if ([controller isKindOfClass:UITabBarController.class]) {
-        return NMTopControllerFrom(((UITabBarController *)controller).selectedViewController);
-    }
+    if (controller.presentedViewController) return NMTopControllerFrom(controller.presentedViewController);
+    if ([controller isKindOfClass:UINavigationController.class]) return NMTopControllerFrom(((UINavigationController *)controller).visibleViewController);
+    if ([controller isKindOfClass:UITabBarController.class]) return NMTopControllerFrom(((UITabBarController *)controller).selectedViewController);
     return controller;
 }
 
-static UIViewController *NMTopController(void) {
-    UIWindow *keyWindow = nil;
+static UIWindow *NMKeyWindow(void) {
     for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
         if (scene.activationState != UISceneActivationStateForegroundActive || ![scene isKindOfClass:UIWindowScene.class]) continue;
-        for (UIWindow *window in ((UIWindowScene *)scene).windows) {
-            if (window.isKeyWindow) {
-                keyWindow = window;
-                break;
-            }
-        }
-        if (keyWindow) break;
+        for (UIWindow *window in ((UIWindowScene *)scene).windows) if (window.isKeyWindow) return window;
     }
-    if (!keyWindow) keyWindow = UIApplication.sharedApplication.windows.firstObject;
-    return NMTopControllerFrom(keyWindow.rootViewController);
+    return UIApplication.sharedApplication.windows.firstObject;
+}
+
+static UIViewController *NMTopController(void) {
+    return NMTopControllerFrom(NMKeyWindow().rootViewController);
+}
+
+static UIViewController *NMViewControllerForView(UIView *view) {
+    UIResponder *responder = view;
+    while (responder) {
+        if ([responder isKindOfClass:UIViewController.class]) return (UIViewController *)responder;
+        responder = responder.nextResponder;
+    }
+    return nil;
+}
+
+static NSArray<UIView *> *NMAllSubviews(UIView *root) {
+    if (!root) return @[];
+    NSMutableArray<UIView *> *all = [NSMutableArray array];
+    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:root];
+    while (queue.count) {
+        UIView *view = queue.firstObject;
+        [queue removeObjectAtIndex:0];
+        [all addObject:view];
+        [queue addObjectsFromArray:view.subviews];
+    }
+    return all;
+}
+
+static UITableView *NMFindTableView(UIView *root) {
+    for (UIView *view in NMAllSubviews(root)) if ([view isKindOfClass:UITableView.class]) return (UITableView *)view;
+    return nil;
+}
+
+static UISearchBar *NMFindSearchBar(UIView *root) {
+    for (UIView *view in NMAllSubviews(root)) if ([view isKindOfClass:UISearchBar.class]) return (UISearchBar *)view;
+    return nil;
+}
+
+static UITextView *NMFindTextView(UIView *root) {
+    for (UIView *view in NMAllSubviews(root)) if ([view isKindOfClass:UITextView.class]) return (UITextView *)view;
+    return nil;
 }
 
 static void NMDismissToast(UIView *toast) {
     if (!toast || !toast.superview) return;
     [UIView animateWithDuration:0.22 animations:^{
         toast.alpha = 0.0;
-        toast.transform = CGAffineTransformMakeTranslation(0, 20);
-    } completion:^(__unused BOOL finished) {
-        [toast removeFromSuperview];
-    }];
+        toast.transform = CGAffineTransformMakeTranslation(0, 18);
+    } completion:^(__unused BOOL finished) { [toast removeFromSuperview]; }];
 }
 
 static void NMShowToast(NSString *title, NSString *message, NSTimeInterval duration) {
     if (![NMPreferences shared].enabled || ![NMPreferences shared].enableToasts) return;
-
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController *host = NMTopController();
         if (!host.view) return;
-
         UIView *oldToast = [host.view viewWithTag:NMToastTag];
         if (oldToast) [oldToast removeFromSuperview];
 
@@ -178,16 +210,23 @@ static void NMShowToast(NSString *title, NSString *message, NSTimeInterval durat
         container.layer.cornerRadius = 22.0;
         container.layer.cornerCurve = kCACornerCurveContinuous;
         container.layer.masksToBounds = YES;
-        container.layer.borderWidth = 0.5;
-        container.layer.borderColor = [UIColor colorWithWhite:1 alpha:0.16].CGColor;
+        container.layer.borderWidth = 0.6;
+        container.layer.borderColor = [UIColor colorWithWhite:1 alpha:0.18].CGColor;
 
         UIVisualEffectView *blur = [[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:NMBlurStyle(host.traitCollection)]];
         blur.translatesAutoresizingMaskIntoConstraints = NO;
         [container addSubview:blur];
 
+        CAGradientLayer *accent = [CAGradientLayer layer];
+        accent.colors = @[(__bridge id)NMBlueColor().CGColor, (__bridge id)NMPurpleColor().CGColor];
+        accent.startPoint = CGPointMake(0, 0);
+        accent.endPoint = CGPointMake(1, 1);
+        accent.frame = CGRectMake(0, 0, 5, 120);
+        [container.layer addSublayer:accent];
+
         UIImageView *icon = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"info.circle.fill"]];
         icon.translatesAutoresizingMaskIntoConstraints = NO;
-        icon.tintColor = [UIColor colorWithRed:0.52 green:0.39 blue:1.0 alpha:1.0];
+        icon.tintColor = NMPurpleColor();
         icon.preferredSymbolConfiguration = [UIImageSymbolConfiguration configurationWithPointSize:24 weight:UIImageSymbolWeightSemibold];
         [container addSubview:icon];
 
@@ -195,7 +234,6 @@ static void NMShowToast(NSString *title, NSString *message, NSTimeInterval durat
         titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
         titleLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightSemibold];
         titleLabel.text = title ?: @"Next Message";
-        titleLabel.numberOfLines = 1;
         [container addSubview:titleLabel];
 
         UILabel *messageLabel = [UILabel new];
@@ -218,26 +256,21 @@ static void NMShowToast(NSString *title, NSString *message, NSTimeInterval durat
             [blur.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
             [blur.topAnchor constraintEqualToAnchor:container.topAnchor],
             [blur.bottomAnchor constraintEqualToAnchor:container.bottomAnchor],
-
             [container.leadingAnchor constraintEqualToAnchor:host.view.safeAreaLayoutGuide.leadingAnchor constant:14],
             [container.trailingAnchor constraintEqualToAnchor:host.view.safeAreaLayoutGuide.trailingAnchor constant:-14],
             [container.bottomAnchor constraintEqualToAnchor:host.view.safeAreaLayoutGuide.bottomAnchor constant:-14],
             [container.heightAnchor constraintGreaterThanOrEqualToConstant:92],
-
-            [icon.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:16],
+            [icon.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:17],
             [icon.topAnchor constraintEqualToAnchor:container.topAnchor constant:17],
             [icon.widthAnchor constraintEqualToConstant:28],
             [icon.heightAnchor constraintEqualToConstant:28],
-
             [closeButton.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-14],
             [closeButton.topAnchor constraintEqualToAnchor:container.topAnchor constant:14],
             [closeButton.widthAnchor constraintEqualToConstant:30],
             [closeButton.heightAnchor constraintEqualToConstant:30],
-
             [titleLabel.leadingAnchor constraintEqualToAnchor:icon.trailingAnchor constant:12],
             [titleLabel.trailingAnchor constraintLessThanOrEqualToAnchor:closeButton.leadingAnchor constant:-8],
             [titleLabel.topAnchor constraintEqualToAnchor:container.topAnchor constant:15],
-
             [messageLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
             [messageLabel.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-16],
             [messageLabel.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:5],
@@ -245,20 +278,14 @@ static void NMShowToast(NSString *title, NSString *message, NSTimeInterval durat
         ]];
 
         __weak UIView *weakToast = container;
-        [closeButton addAction:[UIAction actionWithHandler:^(__unused UIAction *action) {
-            NMDismissToast(weakToast);
-        }] forControlEvents:UIControlEventTouchUpInside];
-
+        [closeButton addAction:[UIAction actionWithHandler:^(__unused UIAction *action) { NMDismissToast(weakToast); }] forControlEvents:UIControlEventTouchUpInside];
         container.alpha = 0.0;
-        container.transform = CGAffineTransformMakeTranslation(0, 24);
-        [UIView animateWithDuration:0.28 delay:0 usingSpringWithDamping:0.84 initialSpringVelocity:0.3 options:UIViewAnimationOptionCurveEaseOut animations:^{
+        container.transform = CGAffineTransformMakeTranslation(0, 22);
+        [UIView animateWithDuration:0.3 delay:0 usingSpringWithDamping:0.85 initialSpringVelocity:0.3 options:UIViewAnimationOptionCurveEaseOut animations:^{
             container.alpha = 1.0;
             container.transform = CGAffineTransformIdentity;
         } completion:nil];
-
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(duration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            NMDismissToast(weakToast);
-        });
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(duration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ NMDismissToast(weakToast); });
     });
 }
 
@@ -276,9 +303,7 @@ static id NMChatObjectFromConversation(id conversation) {
 static NSString *NMConversationIdentifier(id conversation) {
     id chat = NMChatObjectFromConversation(conversation);
     NSString *identifier = NMSafeString(chat, @[@"guid", @"chatGUID", @"chatIdentifier", @"identifier"]);
-    if (!identifier) {
-        identifier = NMSafeString(conversation, @[@"guid", @"chatGUID", @"chatIdentifier", @"identifier"]);
-    }
+    if (!identifier) identifier = NMSafeString(conversation, @[@"guid", @"chatGUID", @"chatIdentifier", @"identifier"]);
     return identifier;
 }
 
@@ -287,24 +312,17 @@ static NSString *NMConversationDisplayName(id conversation, UITableViewCell *cel
     NSString *name = NMSafeString(conversation, @[@"displayName", @"name", @"title"]);
     if (!name) name = NMSafeString(chat, @[@"displayName", @"name", @"title"]);
     if (!name) name = cell.textLabel.text;
-    return name.length > 0 ? name : @"Conversation details";
+    return name.length ? name : @"Conversation details";
 }
 
 static NSDictionary<NSString *, id> *NMConversationStats(id conversation) {
     NSString *identifier = NMConversationIdentifier(conversation);
     long long count = 0;
     NSDate *firstDate = nil;
-
-    if (identifier.length > 0) {
+    if (identifier.length) {
         sqlite3 *database = NULL;
-        NSString *databasePath = @"/var/mobile/Library/SMS/sms.db";
-        if (sqlite3_open_v2(databasePath.fileSystemRepresentation, &database, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, NULL) == SQLITE_OK) {
-            const char *query =
-                "SELECT COUNT(m.ROWID), MIN(CASE WHEN m.date > 0 THEN m.date ELSE NULL END) "
-                "FROM chat c "
-                "LEFT JOIN chat_message_join cmj ON cmj.chat_id = c.ROWID "
-                "LEFT JOIN message m ON m.ROWID = cmj.message_id "
-                "WHERE c.guid = ?1 OR c.chat_identifier = ?1";
+        if (sqlite3_open_v2("/var/mobile/Library/SMS/sms.db", &database, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, NULL) == SQLITE_OK) {
+            const char *query = "SELECT COUNT(m.ROWID), MIN(CASE WHEN m.date > 0 THEN m.date ELSE NULL END) FROM chat c LEFT JOIN chat_message_join cmj ON cmj.chat_id = c.ROWID LEFT JOIN message m ON m.ROWID = cmj.message_id WHERE c.guid = ?1 OR c.chat_identifier = ?1";
             sqlite3_stmt *statement = NULL;
             if (sqlite3_prepare_v2(database, query, -1, &statement, NULL) == SQLITE_OK) {
                 sqlite3_bind_text(statement, 1, identifier.UTF8String, -1, SQLITE_TRANSIENT);
@@ -317,278 +335,688 @@ static NSDictionary<NSString *, id> *NMConversationStats(id conversation) {
         }
         if (database) sqlite3_close(database);
     }
-
     if (count <= 0) {
         id fallbackCount = NMSafeValue(conversation, @"messageCount") ?: NMSafeValue(NMChatObjectFromConversation(conversation), @"messageCount");
         if ([fallbackCount respondsToSelector:@selector(longLongValue)]) count = [fallbackCount longLongValue];
     }
-
     if (!firstDate) {
         id fallbackDate = NMSafeValue(conversation, @"firstMessageDate") ?: NMSafeValue(NMChatObjectFromConversation(conversation), @"firstMessageDate");
         if ([fallbackDate isKindOfClass:NSDate.class]) firstDate = fallbackDate;
     }
-
-    return @{
-        @"count": @(MAX(count, 0)),
-        @"firstDate": firstDate ?: NSNull.null,
-        @"identifier": identifier ?: @"Unavailable",
-    };
+    return @{@"count": @(MAX(count, 0)), @"firstDate": firstDate ?: NSNull.null, @"identifier": identifier ?: @"Unavailable"};
 }
 
 static void NMShowConversationInfo(id conversation, UITableViewCell *cell) {
     NSDictionary *stats = NMConversationStats(conversation);
-    NSNumber *count = stats[@"count"];
-    id dateObject = stats[@"firstDate"];
-
     NSString *dateText = @"Not available";
+    id dateObject = stats[@"firstDate"];
     if ([dateObject isKindOfClass:NSDate.class]) {
         NSDateFormatter *formatter = [NSDateFormatter new];
         formatter.dateStyle = NSDateFormatterMediumStyle;
         formatter.timeStyle = NSDateFormatterShortStyle;
         dateText = [formatter stringFromDate:dateObject];
     }
-
-    NSString *message = [NSString stringWithFormat:@"Messages in this conversation: %@\nFirst conversation date: %@", count, dateText];
+    NSString *message = [NSString stringWithFormat:@"Messages in this conversation: %@\nFirst conversation date: %@", stats[@"count"], dateText];
     NMShowToast(NMConversationDisplayName(conversation, cell), message, 8.0);
 }
 
+@interface NMAuroraView : UIView
+@property (nonatomic, strong) CAGradientLayer *gradientLayer;
+@end
+
+@implementation NMAuroraView
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.userInteractionEnabled = NO;
+        self.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        _gradientLayer = [CAGradientLayer layer];
+        _gradientLayer.startPoint = CGPointMake(0.0, 0.0);
+        _gradientLayer.endPoint = CGPointMake(1.0, 1.0);
+        [self.layer addSublayer:_gradientLayer];
+    }
+    return self;
+}
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.gradientLayer.frame = self.bounds;
+    BOOL dark = NMUsesDarkAppearance(self.traitCollection);
+    self.gradientLayer.colors = dark
+        ? @[(id)[UIColor colorWithRed:0.015 green:0.040 blue:0.075 alpha:1.0].CGColor,
+            (id)[UIColor colorWithRed:0.015 green:0.120 blue:0.180 alpha:1.0].CGColor,
+            (id)[UIColor colorWithRed:0.155 green:0.080 blue:0.280 alpha:1.0].CGColor]
+        : @[(id)[UIColor colorWithRed:0.92 green:0.96 blue:1.0 alpha:1.0].CGColor,
+            (id)[UIColor colorWithRed:0.82 green:0.92 blue:0.98 alpha:1.0].CGColor,
+            (id)[UIColor colorWithRed:0.91 green:0.86 blue:1.0 alpha:1.0].CGColor];
+    self.gradientLayer.locations = @[@0.0, @0.56, @1.0];
+}
+@end
+
+static const void *NMBackgroundKey = &NMBackgroundKey;
+static const void *NMInboxChromeKey = &NMInboxChromeKey;
+static const void *NMDockKey = &NMDockKey;
+static const void *NMComposeKey = &NMComposeKey;
+static const void *NMFilterKey = &NMFilterKey;
+static const void *NMCardKey = &NMCardKey;
+static const void *NMBalloonGradientKey = &NMBalloonGradientKey;
+static const void *NMSmartBarKey = &NMSmartBarKey;
+
+static void NMInstallBackground(UIViewController *controller) {
+    if (!controller.view || ![NMPreferences shared].enableAuroraBackground) return;
+    NMAuroraView *background = objc_getAssociatedObject(controller, NMBackgroundKey);
+    if (!background) {
+        background = [[NMAuroraView alloc] initWithFrame:controller.view.bounds];
+        [controller.view insertSubview:background atIndex:0];
+        objc_setAssociatedObject(controller, NMBackgroundKey, background, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    background.frame = controller.view.bounds;
+    [background setNeedsLayout];
+}
+
+static void NMOpenPreferences(void) {
+    NSArray<NSString *> *urls = @[@"App-Prefs:root=NextMessage", @"App-Prefs:root=NextMessagePrefs", @"prefs:root=NextMessage"];
+    for (NSString *string in urls) {
+        NSURL *url = [NSURL URLWithString:string];
+        if ([UIApplication.sharedApplication canOpenURL:url]) {
+            [UIApplication.sharedApplication openURL:url options:@{} completionHandler:nil];
+            return;
+        }
+    }
+    NMShowToast(@"Next Message", @"Open Settings and select Next Message.", 4.0);
+}
+
+static BOOL NMInvokeFirstSelector(id target, NSArray<NSString *> *selectorNames, id argument) {
+    for (NSString *name in selectorNames) {
+        SEL selector = NSSelectorFromString(name);
+        if (![target respondsToSelector:selector]) continue;
+        NSMethodSignature *signature = [target methodSignatureForSelector:selector];
+        if (signature.numberOfArguments > 2) ((void (*)(id, SEL, id))objc_msgSend)(target, selector, argument);
+        else ((void (*)(id, SEL))objc_msgSend)(target, selector);
+        return YES;
+    }
+    return NO;
+}
+
+@interface NMInboxChromeView : UIVisualEffectView <UITextFieldDelegate>
+@property (nonatomic, weak) UIViewController *controller;
+@property (nonatomic, strong) UILabel *titleLabel;
+@property (nonatomic, strong) UITextField *searchField;
+@property (nonatomic, strong) UIStackView *chipStack;
+@property (nonatomic, copy) NSString *selectedFilter;
+- (instancetype)initWithController:(UIViewController *)controller;
+@end
+
+@implementation NMInboxChromeView
+
+- (instancetype)initWithController:(UIViewController *)controller {
+    self = [super initWithEffect:[UIBlurEffect effectWithStyle:NMBlurStyle(controller.traitCollection)]];
+    if (!self) return nil;
+    self.controller = controller;
+    self.layer.cornerRadius = 26.0;
+    self.layer.cornerCurve = kCACornerCurveContinuous;
+    self.layer.masksToBounds = YES;
+    self.layer.borderWidth = 0.6;
+    self.layer.borderColor = [UIColor colorWithWhite:1 alpha:0.16].CGColor;
+
+    _titleLabel = [UILabel new];
+    _titleLabel.font = [UIFont systemFontOfSize:30 weight:UIFontWeightBold];
+    _titleLabel.text = @"Next Message";
+    _titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.contentView addSubview:_titleLabel];
+
+    UIButton *moreButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    moreButton.translatesAutoresizingMaskIntoConstraints = NO;
+    moreButton.backgroundColor = [UIColor.secondarySystemFillColor colorWithAlphaComponent:0.55];
+    moreButton.layer.cornerRadius = 19;
+    [moreButton setImage:[UIImage systemImageNamed:@"ellipsis"] forState:UIControlStateNormal];
+    moreButton.tintColor = UIColor.labelColor;
+    [moreButton addAction:[UIAction actionWithHandler:^(__unused UIAction *action) { NMOpenPreferences(); }] forControlEvents:UIControlEventTouchUpInside];
+    [self.contentView addSubview:moreButton];
+
+    _searchField = [UITextField new];
+    _searchField.translatesAutoresizingMaskIntoConstraints = NO;
+    _searchField.placeholder = @"Search conversations";
+    _searchField.font = [UIFont systemFontOfSize:16 weight:UIFontWeightRegular];
+    _searchField.backgroundColor = [UIColor.secondarySystemFillColor colorWithAlphaComponent:0.62];
+    _searchField.layer.cornerRadius = 18;
+    _searchField.layer.cornerCurve = kCACornerCurveContinuous;
+    _searchField.clearButtonMode = UITextFieldViewModeWhileEditing;
+    _searchField.returnKeyType = UIReturnKeySearch;
+    _searchField.delegate = self;
+    UIImageView *searchIcon = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"magnifyingglass"]];
+    searchIcon.tintColor = UIColor.secondaryLabelColor;
+    searchIcon.contentMode = UIViewContentModeCenter;
+    searchIcon.frame = CGRectMake(0, 0, 38, 36);
+    _searchField.leftView = searchIcon;
+    _searchField.leftViewMode = UITextFieldViewModeAlways;
+    [_searchField addTarget:self action:@selector(searchChanged:) forControlEvents:UIControlEventEditingChanged];
+    [self.contentView addSubview:_searchField];
+
+    _chipStack = [UIStackView new];
+    _chipStack.translatesAutoresizingMaskIntoConstraints = NO;
+    _chipStack.axis = UILayoutConstraintAxisHorizontal;
+    _chipStack.spacing = 8;
+    _chipStack.distribution = UIStackViewDistributionFillEqually;
+    [self.contentView addSubview:_chipStack];
+
+    for (NSString *name in @[@"All", @"Personal", @"Work", @"Unread", @"More"]) {
+        UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+        button.accessibilityLabel = name;
+        button.titleLabel.font = [UIFont systemFontOfSize:13 weight:UIFontWeightSemibold];
+        button.layer.cornerRadius = 15;
+        button.layer.cornerCurve = kCACornerCurveContinuous;
+        button.layer.borderWidth = 0.6;
+        [button setTitle:name forState:UIControlStateNormal];
+        [button addTarget:self action:@selector(filterTapped:) forControlEvents:UIControlEventTouchUpInside];
+        [_chipStack addArrangedSubview:button];
+    }
+    self.selectedFilter = @"All";
+    [self refreshChips];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [_titleLabel.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:18],
+        [_titleLabel.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:13],
+        [moreButton.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-15],
+        [moreButton.centerYAnchor constraintEqualToAnchor:_titleLabel.centerYAnchor],
+        [moreButton.widthAnchor constraintEqualToConstant:38],
+        [moreButton.heightAnchor constraintEqualToConstant:38],
+        [_titleLabel.trailingAnchor constraintLessThanOrEqualToAnchor:moreButton.leadingAnchor constant:-10],
+        [_searchField.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:14],
+        [_searchField.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-14],
+        [_searchField.topAnchor constraintEqualToAnchor:_titleLabel.bottomAnchor constant:8],
+        [_searchField.heightAnchor constraintEqualToConstant:37],
+        [_chipStack.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:14],
+        [_chipStack.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-14],
+        [_chipStack.topAnchor constraintEqualToAnchor:_searchField.bottomAnchor constant:9],
+        [_chipStack.heightAnchor constraintEqualToConstant:31],
+    ]];
+    return self;
+}
+
+- (void)refreshChips {
+    for (UIButton *button in self.chipStack.arrangedSubviews) {
+        BOOL selected = [button.accessibilityLabel isEqualToString:self.selectedFilter];
+        button.backgroundColor = selected ? NMPurpleColor() : [UIColor.secondarySystemFillColor colorWithAlphaComponent:0.42];
+        button.layer.borderColor = selected ? [UIColor colorWithWhite:1 alpha:0.28].CGColor : [UIColor.separatorColor colorWithAlphaComponent:0.35].CGColor;
+        [button setTitleColor:selected ? UIColor.whiteColor : UIColor.labelColor forState:UIControlStateNormal];
+        button.layer.shadowOpacity = selected ? 0.25 : 0.0;
+        button.layer.shadowColor = NMPurpleColor().CGColor;
+        button.layer.shadowRadius = 8;
+    }
+}
+
+- (void)filterTapped:(UIButton *)sender {
+    self.selectedFilter = sender.accessibilityLabel ?: @"All";
+    objc_setAssociatedObject(self.controller, NMFilterKey, self.selectedFilter, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    [self refreshChips];
+    UITableView *tableView = NMFindTableView(self.controller.view);
+    for (UITableViewCell *cell in tableView.visibleCells) [cell setNeedsLayout];
+    if (![self.selectedFilter isEqualToString:@"All"]) NMShowToast([NSString stringWithFormat:@"%@ filter", self.selectedFilter], @"Visible conversations are highlighted using the selected category.", 2.8);
+}
+
+- (void)searchChanged:(UITextField *)sender {
+    UISearchBar *nativeSearch = NMFindSearchBar(self.controller.view);
+    if (nativeSearch && nativeSearch != (id)sender) {
+        nativeSearch.text = sender.text;
+        if ([nativeSearch.delegate respondsToSelector:@selector(searchBar:textDidChange:)]) [nativeSearch.delegate searchBar:nativeSearch textDidChange:sender.text ?: @""];
+    }
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+    [textField resignFirstResponder];
+    UISearchBar *nativeSearch = NMFindSearchBar(self.controller.view);
+    if (nativeSearch && [nativeSearch.delegate respondsToSelector:@selector(searchBarSearchButtonClicked:)]) [nativeSearch.delegate searchBarSearchButtonClicked:nativeSearch];
+    return YES;
+}
+@end
+
+@interface NMBottomDockView : UIVisualEffectView
+@property (nonatomic, weak) UIViewController *controller;
+- (instancetype)initWithController:(UIViewController *)controller;
+@end
+
+@implementation NMBottomDockView
+- (instancetype)initWithController:(UIViewController *)controller {
+    self = [super initWithEffect:[UIBlurEffect effectWithStyle:NMBlurStyle(controller.traitCollection)]];
+    if (!self) return nil;
+    self.controller = controller;
+    self.layer.cornerRadius = 25;
+    self.layer.cornerCurve = kCACornerCurveContinuous;
+    self.layer.masksToBounds = YES;
+    self.layer.borderWidth = 0.6;
+    self.layer.borderColor = [UIColor colorWithWhite:1 alpha:0.16].CGColor;
+
+    UIStackView *stack = [UIStackView new];
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    stack.axis = UILayoutConstraintAxisHorizontal;
+    stack.distribution = UIStackViewDistributionFillEqually;
+    [self.contentView addSubview:stack];
+
+    NSArray *items = @[
+        @[@"message.fill", @"Messages"],
+        @[@"person.2.fill", @"Pinned"],
+        @[@"bell.fill", @"Alerts"],
+        @[@"gearshape.fill", @"Settings"],
+    ];
+    for (NSArray *item in items) {
+        UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+        button.accessibilityLabel = item[1];
+        button.tintColor = [item[1] isEqualToString:@"Messages"] ? NMPurpleColor() : UIColor.secondaryLabelColor;
+        [button setImage:[UIImage systemImageNamed:item[0]] forState:UIControlStateNormal];
+        button.imageView.contentMode = UIViewContentModeScaleAspectFit;
+        [button addTarget:self action:@selector(itemTapped:) forControlEvents:UIControlEventTouchUpInside];
+        [stack addArrangedSubview:button];
+    }
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:8],
+        [stack.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-8],
+        [stack.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:5],
+        [stack.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:-5],
+    ]];
+    return self;
+}
+- (void)itemTapped:(UIButton *)sender {
+    NSString *name = sender.accessibilityLabel;
+    if ([name isEqualToString:@"Settings"]) NMOpenPreferences();
+    else if ([name isEqualToString:@"Pinned"]) {
+        UITableView *table = NMFindTableView(self.controller.view);
+        [table setContentOffset:CGPointMake(0, -table.adjustedContentInset.top) animated:YES];
+    } else if ([name isEqualToString:@"Alerts"]) NMShowToast(@"Quiet notifications", @"Next Message uses minimal, non-intrusive alerts.", 3.2);
+}
+@end
+
+@interface NMSmartReplyBar : UIVisualEffectView
+@property (nonatomic, weak) UIView *entryView;
+- (instancetype)initWithEntryView:(UIView *)entryView;
+@end
+
+@implementation NMSmartReplyBar
+- (instancetype)initWithEntryView:(UIView *)entryView {
+    self = [super initWithEffect:[UIBlurEffect effectWithStyle:NMBlurStyle(entryView.traitCollection)]];
+    if (!self) return nil;
+    self.entryView = entryView;
+    self.layer.cornerRadius = 19;
+    self.layer.cornerCurve = kCACornerCurveContinuous;
+    self.layer.masksToBounds = YES;
+    self.layer.borderWidth = 0.5;
+    self.layer.borderColor = [UIColor colorWithWhite:1 alpha:0.14].CGColor;
+
+    UILabel *label = [UILabel new];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.text = @"✦ Smart Reply";
+    label.font = [UIFont systemFontOfSize:11 weight:UIFontWeightSemibold];
+    label.textColor = NMPurpleColor();
+    [self.contentView addSubview:label];
+
+    UIStackView *stack = [UIStackView new];
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    stack.axis = UILayoutConstraintAxisHorizontal;
+    stack.spacing = 6;
+    stack.distribution = UIStackViewDistributionFillEqually;
+    [self.contentView addSubview:stack];
+
+    for (NSString *reply in @[@"Me too!", @"Sounds perfect", @"See you then!"]) {
+        UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+        button.accessibilityLabel = reply;
+        button.titleLabel.font = [UIFont systemFontOfSize:12 weight:UIFontWeightMedium];
+        button.backgroundColor = [UIColor.secondarySystemFillColor colorWithAlphaComponent:0.55];
+        button.layer.cornerRadius = 13;
+        [button setTitle:reply forState:UIControlStateNormal];
+        [button addTarget:self action:@selector(replyTapped:) forControlEvents:UIControlEventTouchUpInside];
+        [stack addArrangedSubview:button];
+    }
+    [NSLayoutConstraint activateConstraints:@[
+        [label.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:12],
+        [label.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:5],
+        [stack.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:8],
+        [stack.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-8],
+        [stack.topAnchor constraintEqualToAnchor:label.bottomAnchor constant:3],
+        [stack.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:-6],
+    ]];
+    return self;
+}
+- (void)replyTapped:(UIButton *)sender {
+    UITextView *textView = NMFindTextView(self.entryView);
+    if (!textView) textView = NMFindTextView(self.entryView.superview);
+    if (textView) {
+        textView.text = sender.accessibilityLabel;
+        [textView becomeFirstResponder];
+        [textView.delegate textViewDidChange:textView];
+        [[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:textView];
+    } else NMShowToast(@"Smart Reply", sender.accessibilityLabel, 2.0);
+}
+@end
+
 static void NMApplyControllerStyle(UIViewController *controller) {
-    if (![NMPreferences shared].enabled) return;
-
+    if (![NMPreferences shared].enabled || !controller.view) return;
     controller.overrideUserInterfaceStyle = NMForcedInterfaceStyle();
-    controller.view.backgroundColor = NMCanvasColor(controller.traitCollection);
+    controller.view.backgroundColor = UIColor.clearColor;
+    NMInstallBackground(controller);
 
-    UINavigationBar *navigationBar = controller.navigationController.navigationBar;
-    if (navigationBar) {
+    UINavigationBar *bar = controller.navigationController.navigationBar;
+    if (bar) {
         UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
         [appearance configureWithTransparentBackground];
         appearance.backgroundEffect = [UIBlurEffect effectWithStyle:NMBlurStyle(controller.traitCollection)];
-        appearance.backgroundColor = [NMCanvasColor(controller.traitCollection) colorWithAlphaComponent:0.72];
+        appearance.backgroundColor = [NMCanvasColor(controller.traitCollection) colorWithAlphaComponent:0.55];
         appearance.shadowColor = UIColor.clearColor;
         appearance.titleTextAttributes = @{NSForegroundColorAttributeName: UIColor.labelColor};
         appearance.largeTitleTextAttributes = @{NSForegroundColorAttributeName: UIColor.labelColor};
-        navigationBar.standardAppearance = appearance;
-        navigationBar.scrollEdgeAppearance = appearance;
-        navigationBar.compactAppearance = appearance;
-        navigationBar.tintColor = [UIColor colorWithRed:0.48 green:0.36 blue:1.0 alpha:1.0];
+        bar.standardAppearance = appearance;
+        bar.scrollEdgeAppearance = appearance;
+        bar.compactAppearance = appearance;
+        bar.tintColor = NMPurpleColor();
     }
 
-    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:controller.view];
-    while (queue.count > 0) {
-        UIView *view = queue.firstObject;
-        [queue removeObjectAtIndex:0];
-        [queue addObjectsFromArray:view.subviews];
-
+    for (UIView *view in NMAllSubviews(controller.view)) {
         if ([view isKindOfClass:UITableView.class]) {
-            UITableView *tableView = (UITableView *)view;
-            tableView.backgroundColor = UIColor.clearColor;
-            tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+            UITableView *table = (UITableView *)view;
+            table.backgroundColor = UIColor.clearColor;
+            table.separatorStyle = UITableViewCellSeparatorStyleNone;
         } else if ([view isKindOfClass:UICollectionView.class]) {
-            ((UICollectionView *)view).backgroundColor = UIColor.clearColor;
+            UICollectionView *collection = (UICollectionView *)view;
+            collection.backgroundColor = UIColor.clearColor;
+            collection.layer.cornerRadius = 22;
+            collection.layer.cornerCurve = kCACornerCurveContinuous;
+        } else if ([view isKindOfClass:UISearchBar.class]) {
+            UISearchBar *search = (UISearchBar *)view;
+            search.searchTextField.backgroundColor = [UIColor.secondarySystemFillColor colorWithAlphaComponent:0.55];
+            search.searchTextField.layer.cornerRadius = 17;
+            search.searchTextField.layer.cornerCurve = kCACornerCurveContinuous;
         }
     }
+}
+
+static void NMInstallInboxChrome(UIViewController *controller) {
+    NMPreferences *prefs = [NMPreferences shared];
+    if (!prefs.enabled || !prefs.redesignInbox || !controller.view) return;
+    controller.navigationItem.title = @"";
+
+    NMInboxChromeView *header = objc_getAssociatedObject(controller, NMInboxChromeKey);
+    if (prefs.enableConceptHeader && !header) {
+        header = [[NMInboxChromeView alloc] initWithController:controller];
+        [controller.view addSubview:header];
+        objc_setAssociatedObject(controller, NMInboxChromeKey, header, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    NMBottomDockView *dock = objc_getAssociatedObject(controller, NMDockKey);
+    if (prefs.enableBottomDock && !dock) {
+        dock = [[NMBottomDockView alloc] initWithController:controller];
+        [controller.view addSubview:dock];
+        objc_setAssociatedObject(controller, NMDockKey, dock, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    UIButton *compose = objc_getAssociatedObject(controller, NMComposeKey);
+    if (!compose) {
+        compose = [UIButton buttonWithType:UIButtonTypeSystem];
+        compose.backgroundColor = NMPurpleColor();
+        compose.tintColor = UIColor.whiteColor;
+        compose.layer.cornerRadius = 28;
+        compose.layer.shadowOpacity = 0.35;
+        compose.layer.shadowRadius = 12;
+        compose.layer.shadowColor = NMPurpleColor().CGColor;
+        compose.layer.shadowOffset = CGSizeMake(0, 5);
+        [compose setImage:[UIImage systemImageNamed:@"square.and.pencil"] forState:UIControlStateNormal];
+        compose.imageView.preferredSymbolConfiguration = [UIImageSymbolConfiguration configurationWithPointSize:21 weight:UIImageSymbolWeightSemibold];
+        __weak UIViewController *weakController = controller;
+        [compose addAction:[UIAction actionWithHandler:^(__unused UIAction *action) {
+            BOOL invoked = NMInvokeFirstSelector(weakController, @[@"composeButtonClicked:", @"composeButtonPressed:", @"showNewMessageComposition", @"newMessage:", @"composeNewMessage:", @"_composeNewMessage"], compose);
+            if (!invoked) NMShowToast(@"New Message", @"Use the stock compose button for this iOS build.", 3.0);
+        }] forControlEvents:UIControlEventTouchUpInside];
+        [controller.view addSubview:compose];
+        objc_setAssociatedObject(controller, NMComposeKey, compose, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    UIWindow *window = controller.view.window ?: NMKeyWindow();
+    CGFloat top = MAX(window.safeAreaInsets.top, 44.0) + 4.0;
+    CGFloat bottom = MAX(window.safeAreaInsets.bottom, 8.0);
+    CGFloat width = controller.view.bounds.size.width;
+    header.hidden = !prefs.enableConceptHeader;
+    dock.hidden = !prefs.enableBottomDock;
+    if (!header.hidden) header.frame = CGRectMake(12, top, width - 24, 150);
+    if (!dock.hidden) dock.frame = CGRectMake(18, controller.view.bounds.size.height - bottom - 62, width - 36, 56);
+    compose.frame = CGRectMake(width - 76, controller.view.bounds.size.height - bottom - 132, 56, 56);
+    [controller.view bringSubviewToFront:header];
+    [controller.view bringSubviewToFront:dock];
+    [controller.view bringSubviewToFront:compose];
+
+    UIEdgeInsets insets = controller.additionalSafeAreaInsets;
+    insets.top = prefs.enableConceptHeader ? 155 : 0;
+    insets.bottom = prefs.enableBottomDock ? 72 : 0;
+    controller.additionalSafeAreaInsets = insets;
 }
 
 static id NMConversationFromCell(UITableViewCell *cell) {
-    return NMSafeValue(cell, @"conversation")
-        ?: NMSafeValue(cell, @"representedConversation")
-        ?: NMSafeValue(cell, @"chat")
-        ?: NMSafeValue(cell, @"representedObject");
+    return NMSafeValue(cell, @"conversation") ?: NMSafeValue(cell, @"representedConversation") ?: NMSafeValue(cell, @"chat") ?: NMSafeValue(cell, @"representedObject");
+}
+
+static BOOL NMConversationLooksUnread(id conversation) {
+    id value = NMSafeValue(conversation, @"unreadCount") ?: NMSafeValue(NMChatObjectFromConversation(conversation), @"unreadCount") ?: NMSafeValue(conversation, @"hasUnreadMessages");
+    return [value respondsToSelector:@selector(integerValue)] && [value integerValue] > 0;
+}
+
+static BOOL NMConversationMatchesFilter(id conversation, UITableViewCell *cell, NSString *filter) {
+    if (!filter.length || [filter isEqualToString:@"All"] || [filter isEqualToString:@"More"]) return YES;
+    if ([filter isEqualToString:@"Unread"]) return NMConversationLooksUnread(conversation);
+    NSString *combined = [NSString stringWithFormat:@"%@ %@", NMConversationDisplayName(conversation, cell), cell.detailTextLabel.text ?: @""].lowercaseString;
+    NSArray *workTerms = @[@"team", @"project", @"work", @"office", @"client", @"bank", @"company", @"business", @"otp"];
+    BOOL work = NO;
+    for (NSString *term in workTerms) if ([combined containsString:term]) { work = YES; break; }
+    return [filter isEqualToString:@"Work"] ? work : !work;
 }
 
 static BOOL NMInvokeDelete(id controller, NSIndexPath *indexPath, id conversation) {
-    NSArray<NSString *> *indexSelectors = @[@"deleteConversationAtIndexPath:", @"_deleteConversationAtIndexPath:", @"removeConversationAtIndexPath:"];
-    for (NSString *selectorName in indexSelectors) {
-        SEL selector = NSSelectorFromString(selectorName);
-        if ([controller respondsToSelector:selector]) {
-            ((void (*)(id, SEL, id))objc_msgSend)(controller, selector, indexPath);
-            return YES;
-        }
+    for (NSString *name in @[@"deleteConversationAtIndexPath:", @"_deleteConversationAtIndexPath:", @"removeConversationAtIndexPath:"]) {
+        SEL selector = NSSelectorFromString(name);
+        if ([controller respondsToSelector:selector]) { ((void (*)(id, SEL, id))objc_msgSend)(controller, selector, indexPath); return YES; }
     }
-
-    NSArray<NSString *> *conversationSelectors = @[@"deleteConversation:", @"_deleteConversation:", @"removeConversation:"];
-    for (NSString *selectorName in conversationSelectors) {
-        SEL selector = NSSelectorFromString(selectorName);
-        if (conversation && [controller respondsToSelector:selector]) {
-            ((void (*)(id, SEL, id))objc_msgSend)(controller, selector, conversation);
-            return YES;
-        }
+    for (NSString *name in @[@"deleteConversation:", @"_deleteConversation:", @"removeConversation:"]) {
+        SEL selector = NSSelectorFromString(name);
+        if (conversation && [controller respondsToSelector:selector]) { ((void (*)(id, SEL, id))objc_msgSend)(controller, selector, conversation); return YES; }
     }
     return NO;
 }
 
 static UIContextualAction *NMFallbackDeleteAction(id controller, NSIndexPath *indexPath, id conversation) {
-    UIContextualAction *deleteAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive title:@"Delete" handler:^(__unused UIContextualAction *action, __unused UIView *sourceView, void (^completionHandler)(BOOL)) {
+    UIContextualAction *action = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive title:@"Delete" handler:^(__unused UIContextualAction *contextAction, __unused UIView *source, void (^completion)(BOOL)) {
         UIViewController *host = [controller isKindOfClass:UIViewController.class] ? controller : NMTopController();
-        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Delete Conversation?" message:@"This uses the stock Messages deletion method and cannot be undone." preferredStyle:UIAlertControllerStyleAlert];
-        [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(__unused UIAlertAction *cancelAction) {
-            completionHandler(NO);
-        }]];
-        [alert addAction:[UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(__unused UIAlertAction *confirmAction) {
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Delete Conversation?" message:@"This cannot be undone." preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(__unused UIAlertAction *cancel) { completion(NO); }]];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(__unused UIAlertAction *confirm) {
             BOOL deleted = NMInvokeDelete(controller, indexPath, conversation);
-            completionHandler(deleted);
+            completion(deleted);
             if (!deleted) NMShowToast(@"Next Message", @"Delete is not available on this Messages build.", 4.0);
         }]];
         [host presentViewController:alert animated:YES completion:nil];
     }];
-    deleteAction.image = [UIImage systemImageNamed:@"trash"];
-    return deleteAction;
+    action.image = [UIImage systemImageNamed:@"trash"];
+    return action;
 }
 
-static const void *NMConversationCardKey = &NMConversationCardKey;
-
 %hook CKConversationListCell
-
 - (void)layoutSubviews {
     %orig;
-
-    NMPreferences *preferences = [NMPreferences shared];
+    NMPreferences *prefs = [NMPreferences shared];
     UITableViewCell *cell = (UITableViewCell *)self;
-    UIVisualEffectView *card = objc_getAssociatedObject(self, NMConversationCardKey);
-
-    if (!preferences.enabled || !preferences.redesignInbox) {
+    UIVisualEffectView *card = objc_getAssociatedObject(self, NMCardKey);
+    if (!prefs.enabled || !prefs.redesignInbox) {
         [card removeFromSuperview];
-        objc_setAssociatedObject(self, NMConversationCardKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self, NMCardKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         return;
     }
-
     cell.backgroundColor = UIColor.clearColor;
     cell.contentView.backgroundColor = UIColor.clearColor;
     cell.clipsToBounds = NO;
     cell.contentView.clipsToBounds = NO;
     cell.separatorInset = UIEdgeInsetsMake(0, CGRectGetWidth(cell.bounds) + 1000, 0, 0);
-
     if (!card) {
         card = [[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:NMBlurStyle(cell.traitCollection)]];
         card.userInteractionEnabled = NO;
-        card.layer.cornerRadius = 18.0;
+        card.layer.cornerRadius = 20;
         card.layer.cornerCurve = kCACornerCurveContinuous;
         card.layer.masksToBounds = YES;
-        card.layer.borderWidth = 0.5;
-        card.layer.borderColor = [UIColor colorWithWhite:1 alpha:0.12].CGColor;
+        card.layer.borderWidth = 0.6;
+        card.layer.borderColor = [UIColor colorWithWhite:1 alpha:0.15].CGColor;
         [cell.contentView insertSubview:card atIndex:0];
-        objc_setAssociatedObject(self, NMConversationCardKey, card, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self, NMCardKey, card, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     } else {
         card.effect = [UIBlurEffect effectWithStyle:NMBlurStyle(cell.traitCollection)];
         [cell.contentView sendSubviewToBack:card];
     }
-
-    card.frame = UIEdgeInsetsInsetRect(cell.contentView.bounds, UIEdgeInsetsMake(4, 9, 4, 9));
+    card.frame = UIEdgeInsetsInsetRect(cell.contentView.bounds, UIEdgeInsetsMake(3, 9, 3, 9));
+    UIViewController *controller = NMViewControllerForView(cell);
+    NSString *filter = objc_getAssociatedObject(controller, NMFilterKey) ?: @"All";
+    BOOL match = NMConversationMatchesFilter(NMConversationFromCell(cell), cell, filter);
+    cell.contentView.alpha = match ? 1.0 : 0.22;
 }
-
 %end
 
 %hook CKConversationListController
-
 - (void)viewDidLoad {
     %orig;
-    if ([NMPreferences shared].redesignInbox) NMApplyControllerStyle((UIViewController *)self);
+    if ([NMPreferences shared].redesignInbox) {
+        NMApplyControllerStyle((UIViewController *)self);
+        NMInstallInboxChrome((UIViewController *)self);
+    }
 }
-
 - (void)viewWillAppear:(BOOL)animated {
     %orig(animated);
-    if ([NMPreferences shared].redesignInbox) NMApplyControllerStyle((UIViewController *)self);
+    if ([NMPreferences shared].redesignInbox) {
+        UIViewController *controller = (UIViewController *)self;
+        [controller setNeedsStatusBarAppearanceUpdate];
+        controller.navigationController.navigationBarHidden = YES;
+        NMApplyControllerStyle(controller);
+        NMInstallInboxChrome(controller);
+    }
 }
-
+- (void)viewDidLayoutSubviews {
+    %orig;
+    if ([NMPreferences shared].redesignInbox) NMInstallInboxChrome((UIViewController *)self);
+}
+- (void)viewWillDisappear:(BOOL)animated {
+    %orig(animated);
+    ((UIViewController *)self).navigationController.navigationBarHidden = NO;
+}
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
     %orig(previousTraitCollection);
     if ([NMPreferences shared].appearanceMode == NMAppearanceModeSystem && [NMPreferences shared].redesignInbox) {
         NMApplyControllerStyle((UIViewController *)self);
+        NMInstallInboxChrome((UIViewController *)self);
     }
 }
-
 - (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
     UISwipeActionsConfiguration *original = %orig;
-    NMPreferences *preferences = [NMPreferences shared];
-    if (!preferences.enabled || (!preferences.enableInfoAction && !preferences.enableDeleteAction)) return original;
-
+    NMPreferences *prefs = [NMPreferences shared];
+    if (!prefs.enabled || (!prefs.enableInfoAction && !prefs.enableDeleteAction)) return original;
     UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
     id conversation = NMConversationFromCell(cell);
     NSMutableArray<UIContextualAction *> *actions = [NSMutableArray array];
-
-    if (preferences.enableInfoAction) {
-        UIContextualAction *infoAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal title:@"Info" handler:^(__unused UIContextualAction *action, __unused UIView *sourceView, void (^completionHandler)(BOOL)) {
+    if (prefs.enableInfoAction) {
+        UIContextualAction *info = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal title:@"Info" handler:^(__unused UIContextualAction *action, __unused UIView *source, void (^completion)(BOOL)) {
             NMShowConversationInfo(conversation, cell);
-            completionHandler(YES);
+            completion(YES);
         }];
-        infoAction.image = [UIImage systemImageNamed:@"info.circle"];
-        infoAction.backgroundColor = [UIColor colorWithRed:0.48 green:0.36 blue:1.0 alpha:1.0];
-        [actions addObject:infoAction];
+        info.image = [UIImage systemImageNamed:@"info.circle"];
+        info.backgroundColor = NMPurpleColor();
+        [actions addObject:info];
     }
-
     BOOL hasDelete = NO;
     for (UIContextualAction *action in original.actions ?: @[]) {
-        if (action.style == UIContextualActionStyleDestructive || [action.title localizedCaseInsensitiveCompare:@"Delete"] == NSOrderedSame) {
-            hasDelete = YES;
-        }
+        if (action.style == UIContextualActionStyleDestructive || [action.title localizedCaseInsensitiveCompare:@"Delete"] == NSOrderedSame) hasDelete = YES;
         [actions addObject:action];
     }
-
-    if (preferences.enableDeleteAction && !hasDelete) {
-        [actions addObject:NMFallbackDeleteAction(self, indexPath, conversation)];
-    }
-
+    if (prefs.enableDeleteAction && !hasDelete) [actions addObject:NMFallbackDeleteAction(self, indexPath, conversation)];
     UISwipeActionsConfiguration *configuration = [UISwipeActionsConfiguration configurationWithActions:actions];
     configuration.performsFirstActionWithFullSwipe = NO;
     return configuration;
 }
-
 %end
 
 %hook CKTranscriptCollectionViewController
-
 - (void)viewDidLoad {
     %orig;
     if ([NMPreferences shared].redesignConversation) NMApplyControllerStyle((UIViewController *)self);
 }
-
 - (void)viewWillAppear:(BOOL)animated {
     %orig(animated);
+    UIViewController *controller = (UIViewController *)self;
+    controller.navigationController.navigationBarHidden = NO;
+    if ([NMPreferences shared].redesignConversation) NMApplyControllerStyle(controller);
+}
+- (void)viewDidLayoutSubviews {
+    %orig;
     if ([NMPreferences shared].redesignConversation) NMApplyControllerStyle((UIViewController *)self);
 }
-
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
     %orig(previousTraitCollection);
-    if ([NMPreferences shared].appearanceMode == NMAppearanceModeSystem && [NMPreferences shared].redesignConversation) {
-        NMApplyControllerStyle((UIViewController *)self);
-    }
+    if ([NMPreferences shared].appearanceMode == NMAppearanceModeSystem && [NMPreferences shared].redesignConversation) NMApplyControllerStyle((UIViewController *)self);
 }
-
 %end
 
 %hook CKBalloonView
-
 - (void)layoutSubviews {
     %orig;
     if (![NMPreferences shared].enabled || ![NMPreferences shared].redesignConversation) return;
     UIView *view = (UIView *)self;
-    view.layer.cornerRadius = 19.0;
+    view.layer.cornerRadius = 21;
     view.layer.cornerCurve = kCACornerCurveContinuous;
     view.layer.masksToBounds = YES;
+    BOOL outgoing = CGRectGetMidX(view.frame) > CGRectGetWidth(view.superview.bounds) * 0.52;
+    CAGradientLayer *gradient = objc_getAssociatedObject(self, NMBalloonGradientKey);
+    if (!gradient) {
+        gradient = [CAGradientLayer layer];
+        gradient.startPoint = CGPointMake(0, 0);
+        gradient.endPoint = CGPointMake(1, 1);
+        [view.layer insertSublayer:gradient atIndex:0];
+        objc_setAssociatedObject(self, NMBalloonGradientKey, gradient, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    gradient.frame = view.bounds;
+    gradient.cornerRadius = 21;
+    gradient.colors = outgoing
+        ? @[(id)NMBlueColor().CGColor, (id)NMPurpleColor().CGColor]
+        : @[(id)[UIColor colorWithWhite:0.20 alpha:0.72].CGColor, (id)[UIColor colorWithWhite:0.12 alpha:0.62].CGColor];
+    gradient.opacity = outgoing ? 0.88 : 0.40;
+    view.layer.borderWidth = 0.5;
+    view.layer.borderColor = [UIColor colorWithWhite:1 alpha:outgoing ? 0.20 : 0.10].CGColor;
 }
-
 %end
 
 %hook CKMessageEntryView
-
 - (void)layoutSubviews {
     %orig;
-    if (![NMPreferences shared].enabled || ![NMPreferences shared].redesignConversation) return;
-    UIView *view = (UIView *)self;
-    view.layer.cornerRadius = 22.0;
-    view.layer.cornerCurve = kCACornerCurveContinuous;
-    view.layer.masksToBounds = YES;
-}
+    NMPreferences *prefs = [NMPreferences shared];
+    if (!prefs.enabled || !prefs.redesignConversation) return;
+    UIView *entry = (UIView *)self;
+    entry.layer.cornerRadius = 23;
+    entry.layer.cornerCurve = kCACornerCurveContinuous;
+    entry.layer.masksToBounds = NO;
+    entry.layer.borderWidth = 0.5;
+    entry.layer.borderColor = [UIColor colorWithWhite:1 alpha:0.14].CGColor;
+    entry.backgroundColor = [UIColor.secondarySystemBackgroundColor colorWithAlphaComponent:0.72];
 
+    NMSmartReplyBar *bar = objc_getAssociatedObject(self, NMSmartBarKey);
+    if (prefs.enableSmartReplies && entry.superview) {
+        if (!bar) {
+            bar = [[NMSmartReplyBar alloc] initWithEntryView:entry];
+            [entry.superview addSubview:bar];
+            objc_setAssociatedObject(self, NMSmartBarKey, bar, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+        bar.hidden = NO;
+        bar.frame = CGRectMake(12, MAX(0, CGRectGetMinY(entry.frame) - 61), CGRectGetWidth(entry.superview.bounds) - 24, 55);
+        [entry.superview bringSubviewToFront:bar];
+        [entry.superview bringSubviewToFront:entry];
+    } else bar.hidden = YES;
+}
 %end
 
 static void NMPreferencesDidChange(__unused CFNotificationCenterRef center, __unused void *observer, __unused CFStringRef name, __unused const void *object, __unused CFDictionaryRef userInfo) {
     [[NMPreferences shared] reload];
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController *controller = NMTopController();
-        if (controller) NMApplyControllerStyle(controller);
-        [controller.view setNeedsLayout];
-        [controller.view layoutIfNeeded];
+        if (controller) {
+            controller.overrideUserInterfaceStyle = NMForcedInterfaceStyle();
+            NMApplyControllerStyle(controller);
+            [controller.view setNeedsLayout];
+            [controller.view layoutIfNeeded];
+        }
     });
 }
 

--- a/NextMessage/Tweak.xm
+++ b/NextMessage/Tweak.xm
@@ -1,0 +1,601 @@
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+#import <sqlite3.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+static NSString * const NMPrefsDomain = @"com.nextsolution.nextmessage";
+static CFStringRef const NMPrefsChangedNotification = CFSTR("com.nextsolution.nextmessage/preferences.changed");
+static NSInteger const NMToastTag = 7270727;
+
+typedef NS_ENUM(NSInteger, NMAppearanceMode) {
+    NMAppearanceModeSystem = 0,
+    NMAppearanceModeLight = 1,
+    NMAppearanceModeBlack = 2,
+};
+
+@interface NMPreferences : NSObject
+@property (nonatomic, assign) BOOL enabled;
+@property (nonatomic, assign) BOOL redesignInbox;
+@property (nonatomic, assign) BOOL redesignConversation;
+@property (nonatomic, assign) BOOL enableToasts;
+@property (nonatomic, assign) BOOL enableInfoAction;
+@property (nonatomic, assign) BOOL enableDeleteAction;
+@property (nonatomic, assign) NMAppearanceMode appearanceMode;
++ (instancetype)shared;
+- (void)reload;
+@end
+
+static id NMPreferenceValue(NSString *key) {
+    CFPropertyListRef value = CFPreferencesCopyAppValue((__bridge CFStringRef)key, (__bridge CFStringRef)NMPrefsDomain);
+    return CFBridgingRelease(value);
+}
+
+@implementation NMPreferences
+
++ (instancetype)shared {
+    static NMPreferences *preferences;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        preferences = [NMPreferences new];
+        [preferences reload];
+    });
+    return preferences;
+}
+
+- (void)reload {
+    CFPreferencesAppSynchronize((__bridge CFStringRef)NMPrefsDomain);
+
+    NSNumber *enabled = NMPreferenceValue(@"Enabled");
+    NSNumber *inbox = NMPreferenceValue(@"RedesignInbox");
+    NSNumber *conversation = NMPreferenceValue(@"RedesignConversation");
+    NSNumber *toasts = NMPreferenceValue(@"EnableToasts");
+    NSNumber *info = NMPreferenceValue(@"EnableInfoAction");
+    NSNumber *deleteAction = NMPreferenceValue(@"EnableDeleteAction");
+    NSNumber *appearance = NMPreferenceValue(@"AppearanceMode");
+
+    self.enabled = enabled ? enabled.boolValue : YES;
+    self.redesignInbox = inbox ? inbox.boolValue : YES;
+    self.redesignConversation = conversation ? conversation.boolValue : YES;
+    self.enableToasts = toasts ? toasts.boolValue : YES;
+    self.enableInfoAction = info ? info.boolValue : YES;
+    self.enableDeleteAction = deleteAction ? deleteAction.boolValue : YES;
+    self.appearanceMode = appearance ? (NMAppearanceMode)appearance.integerValue : NMAppearanceModeSystem;
+}
+
+@end
+
+static UIUserInterfaceStyle NMForcedInterfaceStyle(void) {
+    switch ([NMPreferences shared].appearanceMode) {
+        case NMAppearanceModeLight:
+            return UIUserInterfaceStyleLight;
+        case NMAppearanceModeBlack:
+            return UIUserInterfaceStyleDark;
+        default:
+            return UIUserInterfaceStyleUnspecified;
+    }
+}
+
+static BOOL NMUsesDarkAppearance(UITraitCollection *traits) {
+    NMAppearanceMode mode = [NMPreferences shared].appearanceMode;
+    if (mode == NMAppearanceModeBlack) return YES;
+    if (mode == NMAppearanceModeLight) return NO;
+    return traits.userInterfaceStyle == UIUserInterfaceStyleDark;
+}
+
+static UIColor *NMCanvasColor(UITraitCollection *traits) {
+    if ([NMPreferences shared].appearanceMode == NMAppearanceModeBlack) {
+        return UIColor.blackColor;
+    }
+    return NMUsesDarkAppearance(traits)
+        ? [UIColor colorWithWhite:0.025 alpha:1.0]
+        : [UIColor colorWithWhite:0.975 alpha:1.0];
+}
+
+static UIBlurEffectStyle NMBlurStyle(UITraitCollection *traits) {
+    return NMUsesDarkAppearance(traits)
+        ? UIBlurEffectStyleSystemUltraThinMaterialDark
+        : UIBlurEffectStyleSystemUltraThinMaterialLight;
+}
+
+static id NMSafeValue(id object, NSString *key) {
+    if (!object || key.length == 0) return nil;
+    @try {
+        return [object valueForKey:key];
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static NSString *NMSafeString(id object, NSArray<NSString *> *keys) {
+    for (NSString *key in keys) {
+        id value = NMSafeValue(object, key);
+        if ([value isKindOfClass:NSString.class] && [value length] > 0) {
+            return value;
+        }
+        if ([value respondsToSelector:@selector(stringValue)]) {
+            NSString *string = [value stringValue];
+            if (string.length > 0) return string;
+        }
+    }
+    return nil;
+}
+
+static UIViewController *NMTopControllerFrom(UIViewController *controller) {
+    if (!controller) return nil;
+    if (controller.presentedViewController) {
+        return NMTopControllerFrom(controller.presentedViewController);
+    }
+    if ([controller isKindOfClass:UINavigationController.class]) {
+        return NMTopControllerFrom(((UINavigationController *)controller).visibleViewController);
+    }
+    if ([controller isKindOfClass:UITabBarController.class]) {
+        return NMTopControllerFrom(((UITabBarController *)controller).selectedViewController);
+    }
+    return controller;
+}
+
+static UIViewController *NMTopController(void) {
+    UIWindow *keyWindow = nil;
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if (scene.activationState != UISceneActivationStateForegroundActive || ![scene isKindOfClass:UIWindowScene.class]) continue;
+        for (UIWindow *window in ((UIWindowScene *)scene).windows) {
+            if (window.isKeyWindow) {
+                keyWindow = window;
+                break;
+            }
+        }
+        if (keyWindow) break;
+    }
+    if (!keyWindow) keyWindow = UIApplication.sharedApplication.windows.firstObject;
+    return NMTopControllerFrom(keyWindow.rootViewController);
+}
+
+static void NMDismissToast(UIView *toast) {
+    if (!toast || !toast.superview) return;
+    [UIView animateWithDuration:0.22 animations:^{
+        toast.alpha = 0.0;
+        toast.transform = CGAffineTransformMakeTranslation(0, 20);
+    } completion:^(__unused BOOL finished) {
+        [toast removeFromSuperview];
+    }];
+}
+
+static void NMShowToast(NSString *title, NSString *message, NSTimeInterval duration) {
+    if (![NMPreferences shared].enabled || ![NMPreferences shared].enableToasts) return;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *host = NMTopController();
+        if (!host.view) return;
+
+        UIView *oldToast = [host.view viewWithTag:NMToastTag];
+        if (oldToast) [oldToast removeFromSuperview];
+
+        UIView *container = [UIView new];
+        container.tag = NMToastTag;
+        container.translatesAutoresizingMaskIntoConstraints = NO;
+        container.layer.cornerRadius = 22.0;
+        container.layer.cornerCurve = kCACornerCurveContinuous;
+        container.layer.masksToBounds = YES;
+        container.layer.borderWidth = 0.5;
+        container.layer.borderColor = [UIColor colorWithWhite:1 alpha:0.16].CGColor;
+
+        UIVisualEffectView *blur = [[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:NMBlurStyle(host.traitCollection)]];
+        blur.translatesAutoresizingMaskIntoConstraints = NO;
+        [container addSubview:blur];
+
+        UIImageView *icon = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"info.circle.fill"]];
+        icon.translatesAutoresizingMaskIntoConstraints = NO;
+        icon.tintColor = [UIColor colorWithRed:0.52 green:0.39 blue:1.0 alpha:1.0];
+        icon.preferredSymbolConfiguration = [UIImageSymbolConfiguration configurationWithPointSize:24 weight:UIImageSymbolWeightSemibold];
+        [container addSubview:icon];
+
+        UILabel *titleLabel = [UILabel new];
+        titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        titleLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightSemibold];
+        titleLabel.text = title ?: @"Next Message";
+        titleLabel.numberOfLines = 1;
+        [container addSubview:titleLabel];
+
+        UILabel *messageLabel = [UILabel new];
+        messageLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        messageLabel.font = [UIFont systemFontOfSize:13 weight:UIFontWeightRegular];
+        messageLabel.textColor = UIColor.secondaryLabelColor;
+        messageLabel.text = message ?: @"";
+        messageLabel.numberOfLines = 0;
+        [container addSubview:messageLabel];
+
+        UIButton *closeButton = [UIButton buttonWithType:UIButtonTypeSystem];
+        closeButton.translatesAutoresizingMaskIntoConstraints = NO;
+        [closeButton setImage:[UIImage systemImageNamed:@"xmark"] forState:UIControlStateNormal];
+        closeButton.tintColor = UIColor.secondaryLabelColor;
+        [container addSubview:closeButton];
+
+        [host.view addSubview:container];
+        [NSLayoutConstraint activateConstraints:@[
+            [blur.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
+            [blur.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
+            [blur.topAnchor constraintEqualToAnchor:container.topAnchor],
+            [blur.bottomAnchor constraintEqualToAnchor:container.bottomAnchor],
+
+            [container.leadingAnchor constraintEqualToAnchor:host.view.safeAreaLayoutGuide.leadingAnchor constant:14],
+            [container.trailingAnchor constraintEqualToAnchor:host.view.safeAreaLayoutGuide.trailingAnchor constant:-14],
+            [container.bottomAnchor constraintEqualToAnchor:host.view.safeAreaLayoutGuide.bottomAnchor constant:-14],
+            [container.heightAnchor constraintGreaterThanOrEqualToConstant:92],
+
+            [icon.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:16],
+            [icon.topAnchor constraintEqualToAnchor:container.topAnchor constant:17],
+            [icon.widthAnchor constraintEqualToConstant:28],
+            [icon.heightAnchor constraintEqualToConstant:28],
+
+            [closeButton.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-14],
+            [closeButton.topAnchor constraintEqualToAnchor:container.topAnchor constant:14],
+            [closeButton.widthAnchor constraintEqualToConstant:30],
+            [closeButton.heightAnchor constraintEqualToConstant:30],
+
+            [titleLabel.leadingAnchor constraintEqualToAnchor:icon.trailingAnchor constant:12],
+            [titleLabel.trailingAnchor constraintLessThanOrEqualToAnchor:closeButton.leadingAnchor constant:-8],
+            [titleLabel.topAnchor constraintEqualToAnchor:container.topAnchor constant:15],
+
+            [messageLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
+            [messageLabel.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-16],
+            [messageLabel.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:5],
+            [messageLabel.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-15],
+        ]];
+
+        __weak UIView *weakToast = container;
+        [closeButton addAction:[UIAction actionWithHandler:^(__unused UIAction *action) {
+            NMDismissToast(weakToast);
+        }] forControlEvents:UIControlEventTouchUpInside];
+
+        container.alpha = 0.0;
+        container.transform = CGAffineTransformMakeTranslation(0, 24);
+        [UIView animateWithDuration:0.28 delay:0 usingSpringWithDamping:0.84 initialSpringVelocity:0.3 options:UIViewAnimationOptionCurveEaseOut animations:^{
+            container.alpha = 1.0;
+            container.transform = CGAffineTransformIdentity;
+        } completion:nil];
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(duration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            NMDismissToast(weakToast);
+        });
+    });
+}
+
+static NSDate *NMDateFromMessagesValue(double rawValue) {
+    if (rawValue <= 0) return nil;
+    double seconds = rawValue;
+    if (seconds > 100000000000.0) seconds /= 1000000000.0;
+    return [NSDate dateWithTimeIntervalSinceReferenceDate:seconds];
+}
+
+static id NMChatObjectFromConversation(id conversation) {
+    return NMSafeValue(conversation, @"chat") ?: NMSafeValue(conversation, @"representedChat") ?: conversation;
+}
+
+static NSString *NMConversationIdentifier(id conversation) {
+    id chat = NMChatObjectFromConversation(conversation);
+    NSString *identifier = NMSafeString(chat, @[@"guid", @"chatGUID", @"chatIdentifier", @"identifier"]);
+    if (!identifier) {
+        identifier = NMSafeString(conversation, @[@"guid", @"chatGUID", @"chatIdentifier", @"identifier"]);
+    }
+    return identifier;
+}
+
+static NSString *NMConversationDisplayName(id conversation, UITableViewCell *cell) {
+    id chat = NMChatObjectFromConversation(conversation);
+    NSString *name = NMSafeString(conversation, @[@"displayName", @"name", @"title"]);
+    if (!name) name = NMSafeString(chat, @[@"displayName", @"name", @"title"]);
+    if (!name) name = cell.textLabel.text;
+    return name.length > 0 ? name : @"Conversation details";
+}
+
+static NSDictionary<NSString *, id> *NMConversationStats(id conversation) {
+    NSString *identifier = NMConversationIdentifier(conversation);
+    long long count = 0;
+    NSDate *firstDate = nil;
+
+    if (identifier.length > 0) {
+        sqlite3 *database = NULL;
+        NSString *databasePath = @"/var/mobile/Library/SMS/sms.db";
+        if (sqlite3_open_v2(databasePath.fileSystemRepresentation, &database, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, NULL) == SQLITE_OK) {
+            const char *query =
+                "SELECT COUNT(m.ROWID), MIN(CASE WHEN m.date > 0 THEN m.date ELSE NULL END) "
+                "FROM chat c "
+                "LEFT JOIN chat_message_join cmj ON cmj.chat_id = c.ROWID "
+                "LEFT JOIN message m ON m.ROWID = cmj.message_id "
+                "WHERE c.guid = ?1 OR c.chat_identifier = ?1";
+            sqlite3_stmt *statement = NULL;
+            if (sqlite3_prepare_v2(database, query, -1, &statement, NULL) == SQLITE_OK) {
+                sqlite3_bind_text(statement, 1, identifier.UTF8String, -1, SQLITE_TRANSIENT);
+                if (sqlite3_step(statement) == SQLITE_ROW) {
+                    count = sqlite3_column_int64(statement, 0);
+                    firstDate = NMDateFromMessagesValue(sqlite3_column_double(statement, 1));
+                }
+            }
+            if (statement) sqlite3_finalize(statement);
+        }
+        if (database) sqlite3_close(database);
+    }
+
+    if (count <= 0) {
+        id fallbackCount = NMSafeValue(conversation, @"messageCount") ?: NMSafeValue(NMChatObjectFromConversation(conversation), @"messageCount");
+        if ([fallbackCount respondsToSelector:@selector(longLongValue)]) count = [fallbackCount longLongValue];
+    }
+
+    if (!firstDate) {
+        id fallbackDate = NMSafeValue(conversation, @"firstMessageDate") ?: NMSafeValue(NMChatObjectFromConversation(conversation), @"firstMessageDate");
+        if ([fallbackDate isKindOfClass:NSDate.class]) firstDate = fallbackDate;
+    }
+
+    return @{
+        @"count": @(MAX(count, 0)),
+        @"firstDate": firstDate ?: NSNull.null,
+        @"identifier": identifier ?: @"Unavailable",
+    };
+}
+
+static void NMShowConversationInfo(id conversation, UITableViewCell *cell) {
+    NSDictionary *stats = NMConversationStats(conversation);
+    NSNumber *count = stats[@"count"];
+    id dateObject = stats[@"firstDate"];
+
+    NSString *dateText = @"Not available";
+    if ([dateObject isKindOfClass:NSDate.class]) {
+        NSDateFormatter *formatter = [NSDateFormatter new];
+        formatter.dateStyle = NSDateFormatterMediumStyle;
+        formatter.timeStyle = NSDateFormatterShortStyle;
+        dateText = [formatter stringFromDate:dateObject];
+    }
+
+    NSString *message = [NSString stringWithFormat:@"Messages in this conversation: %@\nFirst conversation date: %@", count, dateText];
+    NMShowToast(NMConversationDisplayName(conversation, cell), message, 8.0);
+}
+
+static void NMApplyControllerStyle(UIViewController *controller) {
+    if (![NMPreferences shared].enabled) return;
+
+    controller.overrideUserInterfaceStyle = NMForcedInterfaceStyle();
+    controller.view.backgroundColor = NMCanvasColor(controller.traitCollection);
+
+    UINavigationBar *navigationBar = controller.navigationController.navigationBar;
+    if (navigationBar) {
+        UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
+        [appearance configureWithTransparentBackground];
+        appearance.backgroundEffect = [UIBlurEffect effectWithStyle:NMBlurStyle(controller.traitCollection)];
+        appearance.backgroundColor = [NMCanvasColor(controller.traitCollection) colorWithAlphaComponent:0.72];
+        appearance.shadowColor = UIColor.clearColor;
+        appearance.titleTextAttributes = @{NSForegroundColorAttributeName: UIColor.labelColor};
+        appearance.largeTitleTextAttributes = @{NSForegroundColorAttributeName: UIColor.labelColor};
+        navigationBar.standardAppearance = appearance;
+        navigationBar.scrollEdgeAppearance = appearance;
+        navigationBar.compactAppearance = appearance;
+        navigationBar.tintColor = [UIColor colorWithRed:0.48 green:0.36 blue:1.0 alpha:1.0];
+    }
+
+    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:controller.view];
+    while (queue.count > 0) {
+        UIView *view = queue.firstObject;
+        [queue removeObjectAtIndex:0];
+        [queue addObjectsFromArray:view.subviews];
+
+        if ([view isKindOfClass:UITableView.class]) {
+            UITableView *tableView = (UITableView *)view;
+            tableView.backgroundColor = UIColor.clearColor;
+            tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+        } else if ([view isKindOfClass:UICollectionView.class]) {
+            ((UICollectionView *)view).backgroundColor = UIColor.clearColor;
+        }
+    }
+}
+
+static id NMConversationFromCell(UITableViewCell *cell) {
+    return NMSafeValue(cell, @"conversation")
+        ?: NMSafeValue(cell, @"representedConversation")
+        ?: NMSafeValue(cell, @"chat")
+        ?: NMSafeValue(cell, @"representedObject");
+}
+
+static BOOL NMInvokeDelete(id controller, NSIndexPath *indexPath, id conversation) {
+    NSArray<NSString *> *indexSelectors = @[@"deleteConversationAtIndexPath:", @"_deleteConversationAtIndexPath:", @"removeConversationAtIndexPath:"];
+    for (NSString *selectorName in indexSelectors) {
+        SEL selector = NSSelectorFromString(selectorName);
+        if ([controller respondsToSelector:selector]) {
+            ((void (*)(id, SEL, id))objc_msgSend)(controller, selector, indexPath);
+            return YES;
+        }
+    }
+
+    NSArray<NSString *> *conversationSelectors = @[@"deleteConversation:", @"_deleteConversation:", @"removeConversation:"];
+    for (NSString *selectorName in conversationSelectors) {
+        SEL selector = NSSelectorFromString(selectorName);
+        if (conversation && [controller respondsToSelector:selector]) {
+            ((void (*)(id, SEL, id))objc_msgSend)(controller, selector, conversation);
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static UIContextualAction *NMFallbackDeleteAction(id controller, NSIndexPath *indexPath, id conversation) {
+    UIContextualAction *deleteAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive title:@"Delete" handler:^(__unused UIContextualAction *action, __unused UIView *sourceView, void (^completionHandler)(BOOL)) {
+        UIViewController *host = [controller isKindOfClass:UIViewController.class] ? controller : NMTopController();
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Delete Conversation?" message:@"This uses the stock Messages deletion method and cannot be undone." preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(__unused UIAlertAction *cancelAction) {
+            completionHandler(NO);
+        }]];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(__unused UIAlertAction *confirmAction) {
+            BOOL deleted = NMInvokeDelete(controller, indexPath, conversation);
+            completionHandler(deleted);
+            if (!deleted) NMShowToast(@"Next Message", @"Delete is not available on this Messages build.", 4.0);
+        }]];
+        [host presentViewController:alert animated:YES completion:nil];
+    }];
+    deleteAction.image = [UIImage systemImageNamed:@"trash"];
+    return deleteAction;
+}
+
+static const void *NMConversationCardKey = &NMConversationCardKey;
+
+%hook CKConversationListCell
+
+- (void)layoutSubviews {
+    %orig;
+
+    NMPreferences *preferences = [NMPreferences shared];
+    UITableViewCell *cell = (UITableViewCell *)self;
+    UIVisualEffectView *card = objc_getAssociatedObject(self, NMConversationCardKey);
+
+    if (!preferences.enabled || !preferences.redesignInbox) {
+        [card removeFromSuperview];
+        objc_setAssociatedObject(self, NMConversationCardKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
+    cell.backgroundColor = UIColor.clearColor;
+    cell.contentView.backgroundColor = UIColor.clearColor;
+    cell.clipsToBounds = NO;
+    cell.contentView.clipsToBounds = NO;
+    cell.separatorInset = UIEdgeInsetsMake(0, CGRectGetWidth(cell.bounds) + 1000, 0, 0);
+
+    if (!card) {
+        card = [[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:NMBlurStyle(cell.traitCollection)]];
+        card.userInteractionEnabled = NO;
+        card.layer.cornerRadius = 18.0;
+        card.layer.cornerCurve = kCACornerCurveContinuous;
+        card.layer.masksToBounds = YES;
+        card.layer.borderWidth = 0.5;
+        card.layer.borderColor = [UIColor colorWithWhite:1 alpha:0.12].CGColor;
+        [cell.contentView insertSubview:card atIndex:0];
+        objc_setAssociatedObject(self, NMConversationCardKey, card, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    } else {
+        card.effect = [UIBlurEffect effectWithStyle:NMBlurStyle(cell.traitCollection)];
+        [cell.contentView sendSubviewToBack:card];
+    }
+
+    card.frame = UIEdgeInsetsInsetRect(cell.contentView.bounds, UIEdgeInsetsMake(4, 9, 4, 9));
+}
+
+%end
+
+%hook CKConversationListController
+
+- (void)viewDidLoad {
+    %orig;
+    if ([NMPreferences shared].redesignInbox) NMApplyControllerStyle((UIViewController *)self);
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig(animated);
+    if ([NMPreferences shared].redesignInbox) NMApplyControllerStyle((UIViewController *)self);
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    %orig(previousTraitCollection);
+    if ([NMPreferences shared].appearanceMode == NMAppearanceModeSystem && [NMPreferences shared].redesignInbox) {
+        NMApplyControllerStyle((UIViewController *)self);
+    }
+}
+
+- (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UISwipeActionsConfiguration *original = %orig;
+    NMPreferences *preferences = [NMPreferences shared];
+    if (!preferences.enabled || (!preferences.enableInfoAction && !preferences.enableDeleteAction)) return original;
+
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    id conversation = NMConversationFromCell(cell);
+    NSMutableArray<UIContextualAction *> *actions = [NSMutableArray array];
+
+    if (preferences.enableInfoAction) {
+        UIContextualAction *infoAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal title:@"Info" handler:^(__unused UIContextualAction *action, __unused UIView *sourceView, void (^completionHandler)(BOOL)) {
+            NMShowConversationInfo(conversation, cell);
+            completionHandler(YES);
+        }];
+        infoAction.image = [UIImage systemImageNamed:@"info.circle"];
+        infoAction.backgroundColor = [UIColor colorWithRed:0.48 green:0.36 blue:1.0 alpha:1.0];
+        [actions addObject:infoAction];
+    }
+
+    BOOL hasDelete = NO;
+    for (UIContextualAction *action in original.actions ?: @[]) {
+        if (action.style == UIContextualActionStyleDestructive || [action.title localizedCaseInsensitiveCompare:@"Delete"] == NSOrderedSame) {
+            hasDelete = YES;
+        }
+        [actions addObject:action];
+    }
+
+    if (preferences.enableDeleteAction && !hasDelete) {
+        [actions addObject:NMFallbackDeleteAction(self, indexPath, conversation)];
+    }
+
+    UISwipeActionsConfiguration *configuration = [UISwipeActionsConfiguration configurationWithActions:actions];
+    configuration.performsFirstActionWithFullSwipe = NO;
+    return configuration;
+}
+
+%end
+
+%hook CKTranscriptCollectionViewController
+
+- (void)viewDidLoad {
+    %orig;
+    if ([NMPreferences shared].redesignConversation) NMApplyControllerStyle((UIViewController *)self);
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig(animated);
+    if ([NMPreferences shared].redesignConversation) NMApplyControllerStyle((UIViewController *)self);
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    %orig(previousTraitCollection);
+    if ([NMPreferences shared].appearanceMode == NMAppearanceModeSystem && [NMPreferences shared].redesignConversation) {
+        NMApplyControllerStyle((UIViewController *)self);
+    }
+}
+
+%end
+
+%hook CKBalloonView
+
+- (void)layoutSubviews {
+    %orig;
+    if (![NMPreferences shared].enabled || ![NMPreferences shared].redesignConversation) return;
+    UIView *view = (UIView *)self;
+    view.layer.cornerRadius = 19.0;
+    view.layer.cornerCurve = kCACornerCurveContinuous;
+    view.layer.masksToBounds = YES;
+}
+
+%end
+
+%hook CKMessageEntryView
+
+- (void)layoutSubviews {
+    %orig;
+    if (![NMPreferences shared].enabled || ![NMPreferences shared].redesignConversation) return;
+    UIView *view = (UIView *)self;
+    view.layer.cornerRadius = 22.0;
+    view.layer.cornerCurve = kCACornerCurveContinuous;
+    view.layer.masksToBounds = YES;
+}
+
+%end
+
+static void NMPreferencesDidChange(__unused CFNotificationCenterRef center, __unused void *observer, __unused CFStringRef name, __unused const void *object, __unused CFDictionaryRef userInfo) {
+    [[NMPreferences shared] reload];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *controller = NMTopController();
+        if (controller) NMApplyControllerStyle(controller);
+        [controller.view setNeedsLayout];
+        [controller.view layoutIfNeeded];
+    });
+}
+
+%ctor {
+    @autoreleasepool {
+        if (![[NSBundle mainBundle].bundleIdentifier isEqualToString:@"com.apple.MobileSMS"]) return;
+        [NMPreferences shared];
+        CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, NMPreferencesDidChange, NMPrefsChangedNotification, NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
+    }
+}

--- a/NextMessage/control
+++ b/NextMessage/control
@@ -1,0 +1,10 @@
+Package: com.nextsolution.nextmessage
+Name: Next Message
+Version: 0.1.0
+Architecture: iphoneos-arm64
+Description: A minimal Concept H redesign for the stock Messages app with light, black, and system-followed themes, swipe actions, and conversation info toasts.
+Maintainer: Next Solution - Zeshan 0727
+Author: Next Solution - Zeshan 0727
+Section: Tweaks
+Depends: mobilesubstrate, preferenceloader, firmware (>= 15.0)
+Icon: https://zeshan0727.github.io/CydiaIcon.png

--- a/NextMessage/control
+++ b/NextMessage/control
@@ -1,8 +1,8 @@
 Package: com.nextsolution.nextmessage
 Name: Next Message
-Version: 0.1.0
+Version: 0.2.0
 Architecture: iphoneos-arm64
-Description: A minimal Concept H redesign for the stock Messages app with light, black, and system-followed themes, swipe actions, and conversation info toasts.
+Description: Concept A redesign for Apple Messages with glass header, filters, conversation cards, modern chat bubbles, smart replies, System/Light/Black themes, Info and Delete swipe actions.
 Maintainer: Next Solution - Zeshan 0727
 Author: Next Solution - Zeshan 0727
 Section: Tweaks

--- a/NextMessage/control
+++ b/NextMessage/control
@@ -1,10 +1,11 @@
 Package: com.nextsolution.nextmessage
 Name: Next Message
-Version: 0.2.0
+Version: 0.2.1
 Architecture: iphoneos-arm64
-Description: Concept A redesign for Apple Messages with glass header, filters, conversation cards, modern chat bubbles, smart replies, System/Light/Black themes, Info and Delete swipe actions.
+Description: Diagnostic release for the Concept A Messages redesign. Captures privacy-safe iOS 16 controller and view hierarchy data without collecting message text, contact names, phone numbers, or participant information. Includes System, Light and Black themes, Info and Delete swipe actions, and a working Settings pane.
 Maintainer: Next Solution - Zeshan 0727
 Author: Next Solution - Zeshan 0727
 Section: Tweaks
 Depends: mobilesubstrate, preferenceloader, firmware (>= 15.0)
+Homepage: https://zeshan0727.github.io/
 Icon: https://zeshan0727.github.io/CydiaIcon.png

--- a/NextMessage/layout/DEBIAN/postinst
+++ b/NextMessage/layout/DEBIAN/postinst
@@ -1,4 +1,0 @@
-#!/bin/sh
-killall -9 MobileSMS 2>/dev/null || true
-killall -9 Preferences 2>/dev/null || true
-exit 0

--- a/NextMessage/layout/DEBIAN/postinst
+++ b/NextMessage/layout/DEBIAN/postinst
@@ -1,0 +1,5 @@
+#!/bin/sh
+uicache -a >/dev/null 2>&1 || true
+killall -9 Preferences >/dev/null 2>&1 || true
+killall -9 MobileSMS >/dev/null 2>&1 || true
+exit 0

--- a/NextMessage/layout/DEBIAN/postinst
+++ b/NextMessage/layout/DEBIAN/postinst
@@ -1,0 +1,4 @@
+#!/bin/sh
+killall -9 MobileSMS 2>/dev/null || true
+killall -9 Preferences 2>/dev/null || true
+exit 0

--- a/NextMessage/layout/DEBIAN/postrm
+++ b/NextMessage/layout/DEBIAN/postrm
@@ -1,0 +1,5 @@
+#!/bin/sh
+uicache -a >/dev/null 2>&1 || true
+killall -9 Preferences >/dev/null 2>&1 || true
+killall -9 MobileSMS >/dev/null 2>&1 || true
+exit 0

--- a/NextMessage/layout/Library/PreferenceLoader/Preferences/NextMessage.plist
+++ b/NextMessage/layout/Library/PreferenceLoader/Preferences/NextMessage.plist
@@ -1,0 +1,8 @@
+{
+    entry = {
+        bundle = NextMessagePrefs;
+        cell = PSLinkCell;
+        detail = NMRootListController;
+        label = "Next Message";
+    };
+}

--- a/NextMessage/layout/Library/PreferenceLoader/Preferences/NextMessage.plist
+++ b/NextMessage/layout/Library/PreferenceLoader/Preferences/NextMessage.plist
@@ -3,6 +3,8 @@
         bundle = NextMessagePrefs;
         cell = PSLinkCell;
         detail = NMRootListController;
+        executable = NextMessagePrefs;
+        isController = 1;
         label = "Next Message";
     };
 }


### PR DESCRIPTION
## Purpose

This is the diagnostic release required before the real Concept A rebuild for iPhone 14 Pro Max on iOS 16.0 RootHide.

## Added in v0.2.1

- Automatically captures the active Messages controller hierarchy and view hierarchy.
- Records relevant runtime class names and active controller selectors.
- Adds manual Capture, Share, Copy, and Clear Report controls in Settings → Next Message.
- Limits reports to class names, hierarchy, frames, visibility, identifiers, and selectors.
- Does **not** collect message text, contact names, phone numbers, or participant information.
- Keeps System, Light and Black themes plus Info and Delete swipe actions.
- Builds RootHide and standard rootless packages for iOS 15+.

## Test sequence

1. Install v0.2.1 and respring.
2. Open the Messages inbox.
3. Open one conversation and return to the inbox.
4. Open Settings → Next Message.
5. Use Share Last Report and send the TXT report back for the v0.3.0 implementation.
