### PR TITLE
Recover and build Daily Ledger 1.3.24

### DIFF
--- a/.github/workflows/build-tipa.yml
+++ b/.github/workflows/build-tipa.yml
@@ -44,15 +44,17 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             build
 
-      - name: Package for TrollStore
+      - name: Package IPA and TIPA
         run: |
           APP_PATH="$(find build/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -print -quit)"
           test -n "$APP_PATH"
           rm -rf Payload
           mkdir -p Payload
           cp -R "$APP_PATH" Payload/
-          ditto -c -k --sequesterRsrc --keepParent Payload DailyLedger-1.3.23.tipa
-          shasum -a 256 DailyLedger-1.3.23.tipa > DailyLedger-1.3.23.sha256
+          ditto -c -k --sequesterRsrc --keepParent Payload DailyLedger-1.3.24.ipa
+          cp DailyLedger-1.3.24.ipa DailyLedger-1.3.24.tipa
+          shasum -a 256 DailyLedger-1.3.24.ipa > DailyLedger-1.3.24.ipa.sha256
+          shasum -a 256 DailyLedger-1.3.24.tipa > DailyLedger-1.3.24.tipa.sha256
 
       - name: Test SMS parser
         run: |
@@ -82,13 +84,15 @@ jobs:
           cp RootHideSMSImport/packages/*.deb DailyLedgerSMSImport-1.4.0-roothide.deb
           shasum -a 256 DailyLedgerSMSImport-1.4.0-roothide.deb > DailyLedgerSMSImport-1.4.0-roothide.sha256
 
-      - name: Upload TIPA
+      - name: Upload install files
         uses: actions/upload-artifact@v4
         with:
-          name: DailyLedger-TrollStore
+          name: DailyLedger-1.3.24-Install-Files
           path: |
-            DailyLedger-1.3.23.tipa
-            DailyLedger-1.3.23.sha256
+            DailyLedger-1.3.24.ipa
+            DailyLedger-1.3.24.tipa
+            DailyLedger-1.3.24.ipa.sha256
+            DailyLedger-1.3.24.tipa.sha256
             DailyLedgerSMSImport-1.4.0-roothide.deb
             DailyLedgerSMSImport-1.4.0-roothide.sha256
           if-no-files-found: error

--- a/DailyLedger/Services/VendorRuleRecovery.swift
+++ b/DailyLedger/Services/VendorRuleRecovery.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+extension LedgerStore {
+    @discardableResult
+    func backfillVendorRulesFromTransactions() -> Int {
+        var knownKeywords = Set(
+            settings.vendorRules.map {
+                $0.keyword
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+                    .lowercased()
+            }
+        )
+
+        var additions: [VendorCategoryRule] = []
+
+        for transaction in transactions where transaction.type != .transfer {
+            let category = transaction.category.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard isUsefulRecoveredCategory(category),
+                  let keyword = recoveredVendorKeyword(for: transaction) else { continue }
+
+            let normalized = keyword
+                .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+                .lowercased()
+
+            guard !knownKeywords.contains(normalized) else { continue }
+            knownKeywords.insert(normalized)
+            additions.append(VendorCategoryRule(keyword: keyword, category: category))
+        }
+
+        for rule in additions {
+            saveVendorRule(rule)
+        }
+
+        return additions.count
+    }
+
+    private func isUsefulRecoveredCategory(_ category: String) -> Bool {
+        guard !category.isEmpty else { return false }
+        let blocked = ["transfer", "uncategorized", "z-ip-14pm-16.0", "other"]
+        return !blocked.contains { category.caseInsensitiveCompare($0) == .orderedSame }
+    }
+
+    private func recoveredVendorKeyword(for transaction: LedgerTransaction) -> String? {
+        var merchant = transaction.vendor?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if merchant.isEmpty {
+            let pattern = #"\bat\s+(.+?)\s+at\s+\d{1,2}:\d{2}"#
+            if let expression = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+               let match = expression.firstMatch(
+                    in: transaction.details,
+                    range: NSRange(transaction.details.startIndex..., in: transaction.details)
+               ),
+               let range = Range(match.range(at: 1), in: transaction.details) {
+                merchant = String(transaction.details[range])
+            }
+        }
+
+        let ignored = Set([
+            "al", "new", "the", "merchant", "store", "trading", "wll", "llc",
+            "company", "co", "qatar", "doha", "branch", "payment", "card"
+        ])
+
+        let words = merchant
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.count >= 3 && !ignored.contains($0.lowercased()) }
+
+        guard let first = words.first else { return nil }
+        if words.count > 1 {
+            return [first, words[1]].joined(separator: " ")
+        }
+        return first
+    }
+}

--- a/DailyLedger/Theme/RecoveredTheme.swift
+++ b/DailyLedger/Theme/RecoveredTheme.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+enum LedgerVisualTheme: String, CaseIterable, Identifiable {
+    case classic = "Native Classic"
+    case glass = "iOS 26 Glass Style"
+
+    var id: String { rawValue }
+
+    var subtitle: String {
+        switch self {
+        case .classic:
+            return "Native iOS cards with maximum clarity and speed"
+        case .glass:
+            return "Layered translucent cards inspired by iOS 26"
+        }
+    }
+}
+
+private struct RecoveredSurfaceModifier: ViewModifier {
+    @AppStorage("DailyLedgerVisualTheme") private var visualTheme = LedgerVisualTheme.glass.rawValue
+    let tint: Color
+    let cornerRadius: CGFloat
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if visualTheme == LedgerVisualTheme.classic.rawValue {
+            content
+                .background(
+                    Color(uiColor: .secondarySystemGroupedBackground),
+                    in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(Color.primary.opacity(0.06), lineWidth: 0.7)
+                }
+        } else {
+            content
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(.white.opacity(0.30), lineWidth: 0.8)
+                }
+                .shadow(color: tint.opacity(0.16), radius: 14, y: 7)
+        }
+    }
+}
+
+extension View {
+    func recoveredSurface(
+        tint: Color = AppTheme.purple,
+        cornerRadius: CGFloat = 22
+    ) -> some View {
+        modifier(RecoveredSurfaceModifier(tint: tint, cornerRadius: cornerRadius))
+    }
+}

--- a/DailyLedger/Views/AppRootView.swift
+++ b/DailyLedger/Views/AppRootView.swift
@@ -79,10 +79,17 @@ struct AppRootView: View {
             TransferView()
                 .environmentObject(store)
         }
-        .onAppear(perform: consumeShortcutRequest)
+        .onAppear {
+            consumeShortcutRequest()
+            store.backfillVendorRulesFromTransactions()
+        }
+        .onChange(of: store.transactions.count) { _ in
+            store.backfillVendorRulesFromTransactions()
+        }
         .onChange(of: scenePhase) { phase in
             guard phase == .active else { return }
             store.reload()
+            store.backfillVendorRulesFromTransactions()
             consumeShortcutRequest()
         }
         .alert("Daily Ledger", isPresented: errorBinding) {

--- a/DailyLedger/Views/DashboardV124View.swift
+++ b/DailyLedger/Views/DashboardV124View.swift
@@ -1,0 +1,376 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+private enum RecoveredSpendCard: String, CaseIterable, Identifiable {
+    case today = "Today"
+    case yesterday = "Yesterday"
+    case thisWeek = "This Week"
+    case lastWeek = "Last Week"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .today: return "clock.fill"
+        case .yesterday: return "sun.haze.fill"
+        case .thisWeek: return "calendar.badge.clock"
+        case .lastWeek: return "calendar"
+        }
+    }
+
+    var colors: [Color] {
+        switch self {
+        case .today: return [AppTheme.orange, AppTheme.red]
+        case .yesterday: return [AppTheme.purple, AppTheme.blue]
+        case .thisWeek: return [AppTheme.teal, AppTheme.green]
+        case .lastWeek: return [AppTheme.blue, AppTheme.purple]
+        }
+    }
+}
+
+private struct RecoveredSpendSelection: Identifiable {
+    let id = UUID()
+    let title: String
+    let interval: DateInterval
+}
+
+struct DashboardV124View: View {
+    @EnvironmentObject private var store: LedgerStore
+    let onAdd: (TransactionType) -> Void
+    let onTransfer: () -> Void
+
+    @AppStorage("DashboardSpendCardOrderV124") private var storedOrder = ""
+    @State private var cardOrder = RecoveredSpendCard.allCases
+    @State private var draggingCard: RecoveredSpendCard?
+    @State private var editingCards = false
+    @State private var selectedPeriod: RecoveredSpendSelection?
+
+    private let grid = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12)
+    ]
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 20) {
+                    header
+                    spendCards
+                    balanceSection
+                    quickActions
+                    recentTransactions
+                }
+                .padding(.horizontal, 18)
+                .padding(.bottom, 30)
+            }
+            .background(AppTheme.page)
+            .navigationBarHidden(true)
+            .onAppear {
+                loadOrder()
+            }
+            .onChange(of: cardOrder) { _ in
+                saveOrder()
+            }
+            .sheet(item: $selectedPeriod) { selection in
+                NavigationStack {
+                    PeriodTransactionsView(kind: .expenses, interval: selection.interval)
+                        .navigationTitle(selection.title)
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Close") { selectedPeriod = nil }
+                            }
+                        }
+                }
+                .environmentObject(store)
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Daily Ledger")
+                    .font(.system(size: 29, weight: .bold, design: .rounded))
+                Text("Your money at a glance")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Image(systemName: "wallet.pass.fill")
+                .font(.system(size: 21, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 48, height: 48)
+                .background(AppTheme.balanceGradient, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        }
+        .padding(.top, 16)
+    }
+
+    private var spendCards: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Spending pulse")
+                        .font(.headline)
+                    Text(editingCards ? "Drag cards to rearrange" : "Tap any card to open its transactions")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button(editingCards ? "Done" : "Edit") {
+                    withAnimation(.snappy) { editingCards.toggle() }
+                }
+                .font(.subheadline.weight(.semibold))
+            }
+
+            LazyVGrid(columns: grid, spacing: 12) {
+                ForEach(cardOrder) { card in
+                    spendCard(card)
+                        .onDrag {
+                            draggingCard = card
+                            return NSItemProvider(object: card.rawValue as NSString)
+                        }
+                        .onDrop(
+                            of: [UTType.text],
+                            delegate: RecoveredSpendDropDelegate(
+                                item: card,
+                                items: $cardOrder,
+                                dragging: $draggingCard,
+                                enabled: editingCards
+                            )
+                        )
+                        .scaleEffect(draggingCard == card ? 1.03 : 1)
+                        .animation(.easeInOut(duration: 0.16), value: draggingCard)
+                }
+            }
+        }
+    }
+
+    private func spendCard(_ card: RecoveredSpendCard) -> some View {
+        Button {
+            guard !editingCards, let interval = interval(for: card) else { return }
+            selectedPeriod = RecoveredSpendSelection(title: "\(card.rawValue) Expenses", interval: interval)
+        } label: {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Image(systemName: card.icon)
+                        .font(.headline)
+                        .frame(width: 34, height: 34)
+                        .background(.white.opacity(0.18), in: Circle())
+                    Spacer()
+                    if editingCards {
+                        Image(systemName: "line.3.horizontal")
+                            .font(.caption.bold())
+                    }
+                }
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(card.rawValue)
+                        .font(.caption.weight(.semibold))
+                    Text(DisplayFormat.currency(expense(for: card), code: store.currencyCode))
+                        .font(.headline)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.65)
+                }
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity, minHeight: 104, alignment: .leading)
+            .padding(14)
+            .background(
+                LinearGradient(colors: card.colors, startPoint: .topLeading, endPoint: .bottomTrailing),
+                in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+            )
+            .overlay(alignment: .topTrailing) {
+                if editingCards {
+                    Image(systemName: "hand.draw.fill")
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.82))
+                        .padding(10)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var balanceSection: some View {
+        let interval = Calendar.current.dateInterval(of: .month, for: Date())!
+        let totals = store.totals(in: interval)
+        return BalanceCard(
+            balance: store.remainingBalance(),
+            income: totals.income,
+            expense: totals.expense,
+            loan: totals.loan,
+            currencyCode: store.currencyCode,
+            accountSummary: "All \(store.currencyCode) accounts",
+            action: {}
+        )
+    }
+
+    private var quickActions: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Quick add")
+                .font(.headline)
+            HStack(spacing: 12) {
+                recoveredAction(
+                    title: "Income",
+                    subtitle: "Money received",
+                    icon: "plus",
+                    colors: [AppTheme.green, AppTheme.teal]
+                ) { onAdd(.income) }
+
+                recoveredAction(
+                    title: "Expense",
+                    subtitle: "Money spent",
+                    icon: "minus",
+                    colors: [AppTheme.orange, AppTheme.red]
+                ) { onAdd(.expense) }
+            }
+
+            recoveredAction(
+                title: "Transfer",
+                subtitle: "Move money between accounts",
+                icon: "arrow.left.arrow.right",
+                colors: [AppTheme.purple, AppTheme.blue]
+            ) { onTransfer() }
+        }
+    }
+
+    private func recoveredAction(
+        title: String,
+        subtitle: String,
+        icon: String,
+        colors: [Color],
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 12) {
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .bold))
+                    .frame(width: 34, height: 34)
+                    .background(.white.opacity(0.20), in: Circle())
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title).font(.headline)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.80))
+                }
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(
+                LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing),
+                in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var recentTransactions: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Recent transactions")
+                    .font(.headline)
+                Spacer()
+                Text("Latest 8")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if visibleTransactions.isEmpty {
+                EmptyLedgerView(
+                    title: "No transactions yet",
+                    message: "Use the quick-add buttons to record your first entry."
+                )
+                .padding(12)
+                .recoveredSurface(tint: AppTheme.purple)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(Array(visibleTransactions.prefix(8).enumerated()), id: \.element.id) { index, transaction in
+                        TransactionRow(transaction: transaction)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                        if index < min(visibleTransactions.count, 8) - 1 {
+                            Divider().padding(.leading, 68)
+                        }
+                    }
+                }
+                .padding(.vertical, 6)
+                .recoveredSurface(tint: AppTheme.blue)
+            }
+        }
+    }
+
+    private var visibleTransactions: [LedgerTransaction] {
+        store.transactions.filter {
+            guard let account = store.account(withID: $0.accountID) else { return true }
+            return account.currencyCode == store.currencyCode
+        }
+    }
+
+    private func interval(for card: RecoveredSpendCard) -> DateInterval? {
+        let calendar = Calendar.current
+        switch card {
+        case .today:
+            return calendar.dateInterval(of: .day, for: Date())
+        case .yesterday:
+            let date = calendar.date(byAdding: .day, value: -1, to: Date()) ?? Date()
+            return calendar.dateInterval(of: .day, for: date)
+        case .thisWeek:
+            return calendar.dateInterval(of: .weekOfYear, for: Date())
+        case .lastWeek:
+            let date = calendar.date(byAdding: .weekOfYear, value: -1, to: Date()) ?? Date()
+            return calendar.dateInterval(of: .weekOfYear, for: date)
+        }
+    }
+
+    private func expense(for card: RecoveredSpendCard) -> Decimal {
+        guard let interval = interval(for: card) else { return 0 }
+        return store.transactions.lazy.filter {
+            $0.type == .expense &&
+            interval.contains($0.date) &&
+            (store.account(withID: $0.accountID)?.currencyCode ?? store.currencyCode) == store.currencyCode
+        }.reduce(Decimal.zero) { $0 + $1.amount }
+    }
+
+    private func loadOrder() {
+        let decoded = storedOrder
+            .split(separator: ",")
+            .compactMap { RecoveredSpendCard(rawValue: String($0)) }
+        let missing = RecoveredSpendCard.allCases.filter { !decoded.contains($0) }
+        cardOrder = decoded.isEmpty ? RecoveredSpendCard.allCases : decoded + missing
+    }
+
+    private func saveOrder() {
+        storedOrder = cardOrder.map(\.rawValue).joined(separator: ",")
+    }
+}
+
+private struct RecoveredSpendDropDelegate: DropDelegate {
+    let item: RecoveredSpendCard
+    @Binding var items: [RecoveredSpendCard]
+    @Binding var dragging: RecoveredSpendCard?
+    let enabled: Bool
+
+    func dropEntered(info: DropInfo) {
+        guard enabled,
+              let dragging,
+              dragging != item,
+              let from = items.firstIndex(of: dragging),
+              let to = items.firstIndex(of: item) else { return }
+
+        withAnimation(.snappy) {
+            items.move(
+                fromOffsets: IndexSet(integer: from),
+                toOffset: to > from ? to + 1 : to
+            )
+        }
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: enabled ? .move : .cancel)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        dragging = nil
+        return enabled
+    }
+}

--- a/DailyLedger/Views/DashboardV124View.swift
+++ b/DailyLedger/Views/DashboardV124View.swift
@@ -117,7 +117,7 @@ struct DashboardV124View: View {
                 }
                 Spacer()
                 Button(editingCards ? "Done" : "Edit") {
-                    withAnimation(.snappy) { editingCards.toggle() }
+                    withAnimation(.easeInOut(duration: 0.20)) { editingCards.toggle() }
                 }
                 .font(.subheadline.weight(.semibold))
             }
@@ -357,7 +357,7 @@ private struct RecoveredSpendDropDelegate: DropDelegate {
               let from = items.firstIndex(of: dragging),
               let to = items.firstIndex(of: item) else { return }
 
-        withAnimation(.snappy) {
+        withAnimation(.easeInOut(duration: 0.20)) {
             items.move(
                 fromOffsets: IndexSet(integer: from),
                 toOffset: to > from ? to + 1 : to

--- a/DailyLedger/Views/InsightsV124Host.swift
+++ b/DailyLedger/Views/InsightsV124Host.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+struct InsightsV124Host: View {
+    @EnvironmentObject private var store: LedgerStore
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: insight.icon)
+                    .font(.title3)
+                    .foregroundStyle(insight.color)
+                    .frame(width: 40, height: 40)
+                    .background(insight.color.opacity(0.12), in: RoundedRectangle(cornerRadius: 12))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Today's Ledger Insight")
+                            .font(.headline)
+                        Spacer()
+                        Text("Rotates daily")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(insight.message)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(14)
+            .background(AppTheme.page)
+
+            Divider()
+            InsightsView()
+        }
+    }
+
+    private var insight: (message: String, icon: String, color: Color) {
+        let options = insightOptions
+        let day = Calendar.current.ordinality(of: .day, in: .year, for: Date()) ?? 0
+        return options[day % max(options.count, 1)]
+    }
+
+    private var insightOptions: [(message: String, icon: String, color: Color)] {
+        var options: [(String, String, Color)] = []
+        let expenses = currentMonthExpenses
+        let total = expenses.reduce(Decimal.zero) { $0 + $1.amount }
+
+        if let highest = Dictionary(grouping: expenses, by: \.category)
+            .map({ key, value in (key, value.reduce(Decimal.zero) { $0 + $1.amount }) })
+            .max(by: { $0.1 < $1.1 }) {
+            options.append((
+                "\(highest.0) is your largest category this month at \(DisplayFormat.currency(highest.1, code: store.currencyCode)).",
+                "chart.pie.fill",
+                AppTheme.orange
+            ))
+        }
+
+        let elapsedDays = max(Calendar.current.component(.day, from: Date()), 1)
+        let dailyAverage = total / Decimal(elapsedDays)
+        options.append((
+            "Your current daily spending average is \(DisplayFormat.currency(dailyAverage, code: store.currencyCode)).",
+            "speedometer",
+            AppTheme.teal
+        ))
+
+        let smallPurchases = expenses.filter { $0.amount <= 50 }
+        if smallPurchases.count >= 3 {
+            let amount = smallPurchases.reduce(Decimal.zero) { $0 + $1.amount }
+            options.append((
+                "\(smallPurchases.count) purchases of \(store.currencyCode) 50 or less total \(DisplayFormat.currency(amount, code: store.currencyCode)).",
+                "cup.and.saucer.fill",
+                AppTheme.purple
+            ))
+        }
+
+        let previousTotal = previousMonthExpenses.reduce(Decimal.zero) { $0 + $1.amount }
+        if previousTotal > 0 {
+            let difference = total - previousTotal
+            options.append((
+                difference > 0
+                    ? "Spending is \(DisplayFormat.currency(difference, code: store.currencyCode)) above last month so far."
+                    : "Spending is \(DisplayFormat.currency(abs(difference), code: store.currencyCode)) below last month so far.",
+                difference > 0 ? "arrow.up.right.circle.fill" : "arrow.down.right.circle.fill",
+                difference > 0 ? AppTheme.red : AppTheme.green
+            ))
+        }
+
+        if options.isEmpty {
+            options.append((
+                "Record a few expenses to unlock personalized spending insights.",
+                "sparkles",
+                AppTheme.blue
+            ))
+        }
+
+        return options
+    }
+
+    private var currentMonthExpenses: [LedgerTransaction] {
+        expenses(in: Calendar.current.dateInterval(of: .month, for: Date())!)
+    }
+
+    private var previousMonthExpenses: [LedgerTransaction] {
+        let previous = Calendar.current.date(byAdding: .month, value: -1, to: Date()) ?? Date()
+        return expenses(in: Calendar.current.dateInterval(of: .month, for: previous)!)
+    }
+
+    private func expenses(in interval: DateInterval) -> [LedgerTransaction] {
+        store.transactions.filter {
+            $0.type == .expense &&
+            interval.contains($0.date) &&
+            (store.account(withID: $0.accountID)?.currencyCode ?? store.currencyCode) == store.currencyCode
+        }
+    }
+}

--- a/DailyLedger/Views/PersistentTabHost.swift
+++ b/DailyLedger/Views/PersistentTabHost.swift
@@ -10,12 +10,12 @@ struct PersistentTabHost: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> PersistentTabViewController {
         let controller = PersistentTabViewController()
         controller.install([
-            .home: host(DashboardView(onAdd: onAdd, onTransfer: onTransfer)),
+            .home: host(DashboardV124View(onAdd: onAdd, onTransfer: onTransfer)),
             .accounts: host(AccountsView()),
             .transactions: host(TransactionsView(onAdd: onAdd, onTransfer: onTransfer)),
-            .insights: host(InsightsView()),
-            .reports: host(ReportsView()),
-            .settings: host(SettingsView())
+            .insights: host(InsightsV124Host()),
+            .reports: host(ReportsV124View()),
+            .settings: host(SettingsV124View())
         ])
         controller.show(selectedTab)
         return controller

--- a/DailyLedger/Views/ReportsV124View.swift
+++ b/DailyLedger/Views/ReportsV124View.swift
@@ -1,0 +1,457 @@
+import Charts
+import SwiftUI
+
+private enum RecoveredComparePeriod: String, CaseIterable, Identifiable {
+    case day = "Daily"
+    case month = "Monthly"
+    case year = "Yearly"
+
+    var id: String { rawValue }
+}
+
+private enum RecoveredCompareMetric: String, CaseIterable, Identifiable {
+    case income = "Income"
+    case expenses = "Expenses"
+    case net = "Net Result"
+
+    var id: String { rawValue }
+    var color: Color {
+        switch self {
+        case .income: return AppTheme.green
+        case .expenses: return AppTheme.red
+        case .net: return AppTheme.purple
+        }
+    }
+}
+
+private struct RecoveredComparisonBar: Identifiable {
+    let id: String
+    let title: String
+    let value: Double
+}
+
+struct ReportsV124View: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    NavigationLink {
+                        CompareReportsV124View()
+                    } label: {
+                        recoveredReportRow(
+                            title: "Compare Reports",
+                            subtitle: "Compare daily, monthly, or yearly income and expenses",
+                            icon: "chart.bar.xaxis.ascending",
+                            color: AppTheme.purple
+                        )
+                    }
+
+                    NavigationLink {
+                        BudgetPlannerV124View()
+                    } label: {
+                        recoveredReportRow(
+                            title: "Budget Planner",
+                            subtitle: "Set a monthly budget and track actual spending",
+                            icon: "target",
+                            color: AppTheme.orange
+                        )
+                    }
+                } header: {
+                    Text("Planning & comparison")
+                }
+
+                Section {
+                    NavigationLink {
+                        ReportsView()
+                    } label: {
+                        recoveredReportRow(
+                            title: "Detailed Reports",
+                            subtitle: "Financial summary, income, expenses, transfers, and categories",
+                            icon: "doc.text.magnifyingglass",
+                            color: AppTheme.blue
+                        )
+                    }
+                } header: {
+                    Text("Detailed reporting")
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Reports")
+        }
+    }
+
+    private func recoveredReportRow(
+        title: String,
+        subtitle: String,
+        icon: String,
+        color: Color
+    ) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title).font(.headline)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 5)
+        } icon: {
+            Image(systemName: icon)
+                .foregroundStyle(color)
+        }
+    }
+}
+
+private struct CompareReportsV124View: View {
+    @EnvironmentObject private var store: LedgerStore
+    @State private var period = RecoveredComparePeriod.month
+    @State private var metric = RecoveredCompareMetric.expenses
+    @State private var anchorDate = Date()
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 18) {
+                Picker("Period", selection: $period) {
+                    ForEach(RecoveredComparePeriod.allCases) { option in
+                        Text(option.rawValue).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Picker("Metric", selection: $metric) {
+                    ForEach(RecoveredCompareMetric.allCases) { option in
+                        Text(option.rawValue).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                periodNavigator
+                comparisonCards
+                comparisonChart
+                changeSummary
+            }
+            .padding(16)
+            .padding(.bottom, 24)
+        }
+        .background(AppTheme.page)
+        .navigationTitle("Compare Reports")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var periodNavigator: some View {
+        HStack {
+            Button {
+                moveAnchor(-1)
+            } label: {
+                Image(systemName: "chevron.left")
+                    .frame(width: 42, height: 42)
+                    .recoveredSurface(tint: AppTheme.blue, cornerRadius: 21)
+            }
+            Spacer()
+            VStack(spacing: 2) {
+                Text(currentTitle)
+                    .font(.headline)
+                Text("Compared with \(previousTitle)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button {
+                moveAnchor(1)
+            } label: {
+                Image(systemName: "chevron.right")
+                    .frame(width: 42, height: 42)
+                    .recoveredSurface(tint: AppTheme.blue, cornerRadius: 21)
+            }
+            .disabled(currentInterval.contains(Date()))
+            .opacity(currentInterval.contains(Date()) ? 0.35 : 1)
+        }
+    }
+
+    private var comparisonCards: some View {
+        HStack(spacing: 12) {
+            comparisonCard(title: "Current", value: currentValue, color: metric.color)
+            comparisonCard(title: "Previous", value: previousValue, color: AppTheme.blue)
+        }
+    }
+
+    private func comparisonCard(title: String, value: Decimal, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(DisplayFormat.currency(value, code: store.currencyCode))
+                .font(.title3.bold())
+                .lineLimit(1)
+                .minimumScaleFactor(0.62)
+            Text(metric.rawValue)
+                .font(.caption)
+                .foregroundStyle(color)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(15)
+        .recoveredSurface(tint: color)
+    }
+
+    private var comparisonChart: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Side-by-side comparison")
+                .font(.headline)
+
+            Chart(comparisonBars) { item in
+                BarMark(
+                    x: .value("Period", item.title),
+                    y: .value(metric.rawValue, item.value)
+                )
+                .foregroundStyle(by: .value("Period", item.title))
+                .cornerRadius(6)
+            }
+            .chartLegend(.hidden)
+            .frame(height: 250)
+        }
+        .padding(16)
+        .recoveredSurface(tint: metric.color)
+    }
+
+    private var changeSummary: some View {
+        let change = currentValue - previousValue
+        let isPositiveForUser = metric == .expenses ? change <= 0 : change >= 0
+        return HStack(alignment: .top, spacing: 12) {
+            Image(systemName: change == 0 ? "equal.circle.fill" : (change > 0 ? "arrow.up.right.circle.fill" : "arrow.down.right.circle.fill"))
+                .font(.title2)
+                .foregroundStyle(isPositiveForUser ? AppTheme.green : AppTheme.red)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(change == 0 ? "No change" : "\(DisplayFormat.currency(abs(change), code: store.currencyCode)) difference")
+                    .font(.headline)
+                Text(summaryText(change: change))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(16)
+        .recoveredSurface(tint: isPositiveForUser ? AppTheme.green : AppTheme.red)
+    }
+
+    private var comparisonBars: [RecoveredComparisonBar] {
+        [
+            RecoveredComparisonBar(
+                id: "previous",
+                title: "Previous",
+                value: NSDecimalNumber(decimal: previousValue).doubleValue
+            ),
+            RecoveredComparisonBar(
+                id: "current",
+                title: "Current",
+                value: NSDecimalNumber(decimal: currentValue).doubleValue
+            )
+        ]
+    }
+
+    private var currentTotals: LedgerTotals { store.totals(in: currentInterval) }
+    private var previousTotals: LedgerTotals { store.totals(in: previousInterval) }
+
+    private var currentValue: Decimal { value(from: currentTotals) }
+    private var previousValue: Decimal { value(from: previousTotals) }
+
+    private func value(from totals: LedgerTotals) -> Decimal {
+        switch metric {
+        case .income: return totals.income
+        case .expenses: return totals.expense
+        case .net: return totals.income - totals.expense
+        }
+    }
+
+    private var currentInterval: DateInterval {
+        interval(containing: anchorDate)
+    }
+
+    private var previousInterval: DateInterval {
+        let date: Date
+        switch period {
+        case .day:
+            date = Calendar.current.date(byAdding: .day, value: -1, to: currentInterval.start) ?? currentInterval.start
+        case .month:
+            date = Calendar.current.date(byAdding: .month, value: -1, to: currentInterval.start) ?? currentInterval.start
+        case .year:
+            date = Calendar.current.date(byAdding: .year, value: -1, to: currentInterval.start) ?? currentInterval.start
+        }
+        return interval(containing: date)
+    }
+
+    private func interval(containing date: Date) -> DateInterval {
+        let calendar = Calendar.current
+        switch period {
+        case .day:
+            return calendar.dateInterval(of: .day, for: date)!
+        case .month:
+            return calendar.dateInterval(of: .month, for: date)!
+        case .year:
+            return calendar.dateInterval(of: .year, for: date)!
+        }
+    }
+
+    private var currentTitle: String { title(for: currentInterval.start) }
+    private var previousTitle: String { title(for: previousInterval.start) }
+
+    private func title(for date: Date) -> String {
+        switch period {
+        case .day: return DisplayFormat.day.string(from: date)
+        case .month: return DisplayFormat.monthYear.string(from: date)
+        case .year: return DisplayFormat.year.string(from: date)
+        }
+    }
+
+    private func moveAnchor(_ direction: Int) {
+        let component: Calendar.Component
+        switch period {
+        case .day: component = .day
+        case .month: component = .month
+        case .year: component = .year
+        }
+        anchorDate = Calendar.current.date(byAdding: component, value: direction, to: anchorDate) ?? anchorDate
+    }
+
+    private func summaryText(change: Decimal) -> String {
+        guard change != 0 else { return "The selected metric matches the previous period." }
+        let direction = change > 0 ? "higher" : "lower"
+        return "\(metric.rawValue) is \(direction) than \(previousTitle)."
+    }
+}
+
+private struct BudgetPlannerV124View: View {
+    @EnvironmentObject private var store: LedgerStore
+    @AppStorage("DailyLedgerMonthlyBudgetV124") private var monthlyBudget = 0.0
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 18) {
+                budgetInput
+                budgetStatus
+                categoryPlan
+            }
+            .padding(16)
+            .padding(.bottom, 24)
+        }
+        .background(AppTheme.page)
+        .navigationTitle("Budget Planner")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var budgetInput: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Monthly spending budget", systemImage: "target")
+                .font(.headline)
+            TextField("Enter budget", value: $monthlyBudget, format: .number.precision(.fractionLength(0...2)))
+                .keyboardType(.decimalPad)
+                .font(.title2.bold())
+                .padding(13)
+                .background(Color(uiColor: .tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 14))
+            Text("This value is stored locally and can be changed at any time.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .recoveredSurface(tint: AppTheme.orange)
+    }
+
+    private var budgetStatus: some View {
+        let budget = Decimal(monthlyBudget)
+        let remaining = budget - currentMonthExpense
+        let ratio = monthlyBudget > 0
+            ? min(max(NSDecimalNumber(decimal: currentMonthExpense).doubleValue / monthlyBudget, 0), 1)
+            : 0
+
+        return VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Spent this month")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(DisplayFormat.currency(currentMonthExpense, code: store.currencyCode))
+                        .font(.title2.bold())
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 3) {
+                    Text(remaining >= 0 ? "Remaining" : "Over budget")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(DisplayFormat.currency(abs(remaining), code: store.currencyCode))
+                        .font(.headline)
+                        .foregroundStyle(remaining >= 0 ? AppTheme.green : AppTheme.red)
+                }
+            }
+            ProgressView(value: ratio)
+                .tint(ratio >= 1 ? AppTheme.red : AppTheme.green)
+            Text(monthlyBudget > 0 ? "\(Int(ratio * 100))% of the monthly budget used" : "Enter a monthly budget to start tracking progress")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .recoveredSurface(tint: remaining >= 0 ? AppTheme.green : AppTheme.red)
+    }
+
+    private var categoryPlan: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Category spending")
+                .font(.headline)
+
+            if categoryTotals.isEmpty {
+                Text("Expense categories will appear after transactions are recorded this month.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 16)
+            } else {
+                ForEach(categoryTotals, id: \.name) { item in
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Label(item.name, systemImage: AppTheme.categoryIcon(item.name))
+                                .font(.subheadline.weight(.semibold))
+                            Spacer()
+                            Text(DisplayFormat.currency(item.amount, code: store.currencyCode))
+                                .font(.subheadline.bold())
+                        }
+                        ProgressView(value: categoryRatio(item.amount))
+                            .tint(AppTheme.categoryColor(item.name))
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .recoveredSurface(tint: AppTheme.purple)
+    }
+
+    private var currentMonth: DateInterval {
+        Calendar.current.dateInterval(of: .month, for: Date())!
+    }
+
+    private var currentMonthExpenses: [LedgerTransaction] {
+        store.transactions.filter {
+            $0.type == .expense &&
+            currentMonth.contains($0.date) &&
+            (store.account(withID: $0.accountID)?.currencyCode ?? store.currencyCode) == store.currencyCode
+        }
+    }
+
+    private var currentMonthExpense: Decimal {
+        currentMonthExpenses.reduce(Decimal.zero) { $0 + $1.amount }
+    }
+
+    private var categoryTotals: [(name: String, amount: Decimal)] {
+        Dictionary(grouping: currentMonthExpenses, by: \.category)
+            .map { key, value in
+                (key, value.reduce(Decimal.zero) { $0 + $1.amount })
+            }
+            .sorted { $0.1 > $1.1 }
+            .prefix(8)
+            .map { $0 }
+    }
+
+    private func categoryRatio(_ amount: Decimal) -> Double {
+        guard currentMonthExpense > 0 else { return 0 }
+        return min(
+            NSDecimalNumber(decimal: amount).doubleValue /
+            NSDecimalNumber(decimal: currentMonthExpense).doubleValue,
+            1
+        )
+    }
+}

--- a/DailyLedger/Views/SettingsV124View.swift
+++ b/DailyLedger/Views/SettingsV124View.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct SettingsV124View: View {
+    @AppStorage("DailyLedgerVisualTheme") private var visualTheme = LedgerVisualTheme.glass.rawValue
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Label("App Theme", systemImage: "paintbrush.fill")
+                        .font(.headline)
+                    Spacer()
+                    Text("v1.3.24")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+
+                Picker("App Theme", selection: $visualTheme) {
+                    ForEach(LedgerVisualTheme.allCases) { theme in
+                        Text(theme.rawValue).tag(theme.rawValue)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Text(selectedTheme.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(14)
+            .background(AppTheme.page)
+
+            Divider()
+            SettingsView()
+        }
+    }
+
+    private var selectedTheme: LedgerVisualTheme {
+        LedgerVisualTheme(rawValue: visualTheme) ?? .glass
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -11,8 +11,8 @@ settings:
     TARGETED_DEVICE_FAMILY: "1"
     SUPPORTS_MACCATALYST: "NO"
     CODE_SIGN_STYLE: Automatic
-    MARKETING_VERSION: "1.3.23"
-    CURRENT_PROJECT_VERSION: "27"
+    MARKETING_VERSION: "1.3.24"
+    CURRENT_PROJECT_VERSION: "28"
 targets:
   DailyLedger:
     type: application


### PR DESCRIPTION
Recreates the lost local 3803b0d work from the validated Daily Ledger 1.3.23 branch. Includes four rearrangeable spending cards, daily/monthly/yearly comparisons, budget planner, selectable classic/glass themes, rotating insights, automatic vendor-rule backfill, and versioned IPA/TIPA packaging. Build-only recovery branch; main should remain untouched.