### PR TITLE
Add Next Job 1.0.0 accounting work tracker

### DIFF
--- a/.github/workflows/build-next-job.yml
+++ b/.github/workflows/build-next-job.yml
@@ -1,0 +1,65 @@
+name: Build Next Job TIPA
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "agent/next-job-*"
+    paths:
+      - "NextJob/**"
+      - ".github/workflows/build-next-job.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "NextJob/**"
+      - ".github/workflows/build-next-job.yml"
+
+jobs:
+  build:
+    runs-on: macos-15
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        working-directory: NextJob
+        run: xcodegen generate
+
+      - name: Build unsigned iPhone app
+        working-directory: NextJob
+        run: |
+          xcodebuild \
+            -project NextJob.xcodeproj \
+            -scheme NextJob \
+            -configuration Release \
+            -sdk iphoneos \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
+
+      - name: Package for TrollStore
+        working-directory: NextJob
+        run: |
+          APP_PATH="$(find build/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -print -quit)"
+          test -n "$APP_PATH"
+          rm -rf Payload
+          mkdir -p Payload
+          cp -R "$APP_PATH" Payload/
+          ditto -c -k --sequesterRsrc --keepParent Payload NextJob-1.0.0.tipa
+          shasum -a 256 NextJob-1.0.0.tipa > NextJob-1.0.0.sha256
+
+      - name: Upload TIPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: NextJob-TrollStore
+          path: |
+            NextJob/NextJob-1.0.0.tipa
+            NextJob/NextJob-1.0.0.sha256
+          if-no-files-found: error

--- a/NextJob/App/JobDetail.swift
+++ b/NextJob/App/JobDetail.swift
@@ -1,0 +1,405 @@
+import MessageUI
+import SwiftUI
+import UIKit
+
+struct AddJobScreen: View {
+    @State private var savedMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            JobEditorView(job: nil, dismissAfterSave: false) { job in
+                savedMessage = "\(job.title) was added."
+            }
+            .navigationTitle("Add Job")
+            .alert("Job Saved", isPresented: Binding(
+                get: { savedMessage != nil },
+                set: { if !$0 { savedMessage = nil } }
+            )) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(savedMessage ?? "")
+            }
+        }
+    }
+}
+
+struct JobDetailView: View {
+    @EnvironmentObject private var store: JobStore
+    @State private var showingEdit = false
+    @State private var pickerKind: AttachmentKind?
+    @State private var mailDraft: MailDraft?
+    @State private var sharePayload: SharePayload?
+    @State private var previewPayload: PreviewPayload?
+    @State private var notice: String?
+
+    let jobID: UUID
+
+    private var job: AccountingJob? { store.job(id: jobID) }
+
+    var body: some View {
+        Group {
+            if let job {
+                ScrollView {
+                    VStack(spacing: 18) {
+                        jobHeader(job)
+                        statusSection(job)
+                        detailSection(job)
+                        documentSection(job, kind: .sourceDocument)
+                        documentSection(job, kind: .completedWork)
+                        emailSection(job)
+                        notesSection(job)
+                    }
+                    .padding(16)
+                    .padding(.bottom, 20)
+                }
+                .background(Color(uiColor: .systemGroupedBackground).ignoresSafeArea())
+                .navigationTitle("Job Details")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Edit") { showingEdit = true }
+                    }
+                }
+                .sheet(isPresented: $showingEdit) {
+                    NavigationStack {
+                        JobEditorView(job: job, dismissAfterSave: true) { _ in }
+                    }
+                }
+                .sheet(item: $pickerKind) { kind in
+                    DocumentPicker(allowsMultipleSelection: true) { result in
+                        pickerKind = nil
+                        do {
+                            let urls = try result.get()
+                            try store.importFiles(urls, to: job.id, kind: kind)
+                        } catch {
+                            if error is DocumentPickerError { return }
+                            notice = error.localizedDescription
+                        }
+                    }
+                }
+                .sheet(item: $mailDraft) { draft in
+                    MailComposer(draft: draft) {
+                        mailDraft = nil
+                    }
+                }
+                .sheet(item: $sharePayload) { payload in
+                    ActivityView(items: payload.items)
+                }
+                .sheet(item: $previewPayload) { payload in
+                    QuickLookPreview(url: payload.url)
+                }
+                .alert("Next Job", isPresented: Binding(
+                    get: { notice != nil },
+                    set: { if !$0 { notice = nil } }
+                )) {
+                    Button("OK", role: .cancel) {}
+                } message: {
+                    Text(notice ?? "")
+                }
+            } else {
+                EmptyStateView(
+                    icon: "exclamationmark.triangle",
+                    title: "Job unavailable",
+                    message: "This job may have been deleted."
+                )
+                .padding()
+            }
+        }
+    }
+
+    private func jobHeader(_ job: AccountingJob) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(job.title)
+                        .font(.title2.bold())
+                    Text(store.typeName(for: job))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    if !job.clientReference.isEmpty {
+                        Label(job.clientReference, systemImage: "person.text.rectangle")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                StatusBadge(status: job.status)
+            }
+
+            HStack(spacing: 12) {
+                valuePill(icon: "banknote.fill", text: "\(store.settings.currency) \(job.price, specifier: "%.2f")", tint: AppPalette.green)
+                valuePill(icon: "target", text: "\(job.targetHours, specifier: "%.1f")h target", tint: AppPalette.purple)
+                valuePill(icon: "timer", text: "\(job.actualHours, specifier: "%.1f")h actual", tint: AppPalette.cyan)
+            }
+        }
+        .glassCard()
+    }
+
+    private func valuePill(icon: String, text: String, tint: Color) -> some View {
+        Label(text, systemImage: icon)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 7)
+            .background(tint.opacity(0.11), in: Capsule())
+    }
+
+    private func statusSection(_ job: AccountingJob) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionHeader("Status")
+            Picker("Job Status", selection: Binding(
+                get: { job.status },
+                set: { store.setStatus($0, for: job.id) }
+            )) {
+                ForEach(JobStatus.allCases) { status in
+                    Label(status.title, systemImage: status.icon).tag(status)
+                }
+            }
+            .pickerStyle(.menu)
+
+            if job.status != .completed {
+                Button {
+                    store.setStatus(.completed, for: job.id)
+                } label: {
+                    Label("Mark Job Completed", systemImage: "checkmark.seal.fill")
+                }
+                .buttonStyle(PrimaryActionButtonStyle())
+            }
+        }
+        .glassCard()
+    }
+
+    private func detailSection(_ job: AccountingJob) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            SectionHeader("Schedule")
+            detailRow("Assigned", value: DateFormatter.mediumDate.string(from: job.assignedDate), icon: "calendar.badge.plus")
+            detailRow("Due", value: DateFormatter.mediumDate.string(from: job.dueDate), icon: "calendar.badge.clock")
+            detailRow(
+                "Completed",
+                value: job.completionDate.map { DateFormatter.mediumDate.string(from: $0) } ?? "Not completed",
+                icon: "calendar.badge.checkmark"
+            )
+        }
+        .glassCard()
+    }
+
+    private func detailRow(_ title: String, value: String, icon: String) -> some View {
+        HStack {
+            Label(title, systemImage: icon)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .fontWeight(.semibold)
+        }
+        .font(.subheadline)
+    }
+
+    private func documentSection(_ job: AccountingJob, kind: AttachmentKind) -> some View {
+        let files = job.attachments.filter { $0.kind == kind }
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                SectionHeader(kind.title, subtitle: "\(files.count) file\(files.count == 1 ? "" : "s")")
+                Button {
+                    pickerKind = kind
+                } label: {
+                    Label(kind == .sourceDocument ? "Add" : "Upload", systemImage: "plus")
+                        .font(.subheadline.weight(.semibold))
+                }
+            }
+
+            if files.isEmpty {
+                Text(kind == .sourceDocument
+                     ? "Add documents received for this job."
+                     : "Upload spreadsheets, reports, PDFs or other completed work files.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
+            } else {
+                ForEach(files) { attachment in
+                    HStack(spacing: 11) {
+                        Image(systemName: "doc.fill")
+                            .foregroundStyle(kind == .sourceDocument ? AppPalette.orange : AppPalette.green)
+                            .frame(width: 34, height: 34)
+                            .background(
+                                (kind == .sourceDocument ? AppPalette.orange : AppPalette.green).opacity(0.12),
+                                in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            )
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(attachment.originalName)
+                                .font(.subheadline.weight(.semibold))
+                                .lineLimit(1)
+                            Text(ByteCountFormatter.string(fromByteCount: attachment.byteCount, countStyle: .file))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Menu {
+                            Button {
+                                previewPayload = PreviewPayload(url: store.fileURL(for: attachment, jobID: job.id))
+                            } label: {
+                                Label("Preview", systemImage: "eye")
+                            }
+                            Button(role: .destructive) {
+                                store.removeAttachment(attachment, from: job.id)
+                            } label: {
+                                Label("Remove", systemImage: "trash")
+                            }
+                        } label: {
+                            Image(systemName: "ellipsis.circle")
+                                .font(.title3)
+                        }
+                    }
+                    if attachment.id != files.last?.id { Divider() }
+                }
+            }
+        }
+        .glassCard()
+    }
+
+    private func emailSection(_ job: AccountingJob) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionHeader("Documents & Email", subtitle: "Prepare requests and completion packages")
+
+            Button {
+                requestDocuments(job)
+            } label: {
+                Label("Request Documents", systemImage: "envelope.badge")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.bordered)
+
+            Button {
+                createAndShareZip(job)
+            } label: {
+                Label("Create & Share Job ZIP", systemImage: "doc.zipper")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.bordered)
+
+            Button {
+                prepareCompletionEmail(job)
+            } label: {
+                Label("Completion Email with ZIP", systemImage: "paperplane.fill")
+            }
+            .buttonStyle(PrimaryActionButtonStyle())
+        }
+        .glassCard()
+    }
+
+    @ViewBuilder
+    private func notesSection(_ job: AccountingJob) -> some View {
+        if !job.requirements.isEmpty || !job.notes.isEmpty {
+            VStack(alignment: .leading, spacing: 14) {
+                if !job.requirements.isEmpty {
+                    SectionHeader("Required Documents")
+                    Text(job.requirements)
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                if !job.notes.isEmpty {
+                    if !job.requirements.isEmpty { Divider() }
+                    SectionHeader("Work Notes")
+                    Text(job.notes)
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .glassCard()
+        }
+    }
+
+    private func requestDocuments(_ job: AccountingJob) {
+        guard validateCompanyEmail() else { return }
+        let requested = job.requirements.isEmpty
+            ? "Please provide the documents required to complete this job."
+            : "Please provide the following documents:\n\n\(job.requirements)"
+        let body = """
+        Dear \(store.settings.companyName),
+
+        I am working on the following job:
+
+        Job: \(job.title)
+        Client / Reference: \(job.clientReference.isEmpty ? "Not provided" : job.clientReference)
+        Due Date: \(DateFormatter.mediumDate.string(from: job.dueDate))
+
+        \(requested)
+
+        Kind regards,
+        \(store.settings.senderName)
+        """
+        let draft = MailDraft(
+            recipients: [store.settings.companyEmail],
+            subject: "Documents Required - \(job.title)",
+            body: body,
+            attachments: []
+        )
+        presentMailOrFallback(draft: draft, fallbackItems: [body])
+        store.setStatus(.waitingForDocuments, for: job.id)
+    }
+
+    private func createAndShareZip(_ job: AccountingJob) {
+        do {
+            let url = try store.makeJobPackage(jobID: job.id)
+            sharePayload = SharePayload(items: [url])
+        } catch {
+            notice = error.localizedDescription
+        }
+    }
+
+    private func prepareCompletionEmail(_ job: AccountingJob) {
+        guard validateCompanyEmail() else { return }
+        do {
+            let zipURL = try store.makeJobPackage(jobID: job.id)
+            let zipData = try Data(contentsOf: zipURL)
+            let body = """
+            Dear \(store.settings.companyName),
+
+            The following job has been completed:
+
+            Job: \(job.title)
+            Client / Reference: \(job.clientReference.isEmpty ? "Not provided" : job.clientReference)
+            Job Type: \(store.typeName(for: job))
+            Completion Date: \(DateFormatter.mediumDate.string(from: job.completionDate ?? Date()))
+
+            The completed work and related documents are included in the attached ZIP file.
+
+            Kind regards,
+            \(store.settings.senderName)
+            """
+            let draft = MailDraft(
+                recipients: [store.settings.companyEmail],
+                subject: "Job Completed - \(job.title)",
+                body: body,
+                attachments: [
+                    MailAttachment(
+                        data: zipData,
+                        mimeType: "application/zip",
+                        fileName: zipURL.lastPathComponent
+                    )
+                ]
+            )
+            presentMailOrFallback(draft: draft, fallbackItems: [body, zipURL])
+            store.setStatus(.completed, for: job.id)
+        } catch {
+            notice = error.localizedDescription
+        }
+    }
+
+    private func validateCompanyEmail() -> Bool {
+        let email = store.settings.companyEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !email.isEmpty else {
+            notice = "Add the KB Accountants email address in Settings before preparing an email."
+            return false
+        }
+        return true
+    }
+
+    private func presentMailOrFallback(draft: MailDraft, fallbackItems: [Any]) {
+        if MFMailComposeViewController.canSendMail() {
+            mailDraft = draft
+        } else {
+            sharePayload = SharePayload(items: fallbackItems)
+            notice = "Apple Mail is not configured on this iPhone. The Share Sheet has been opened instead."
+        }
+    }
+}

--- a/NextJob/App/JobDetail.swift
+++ b/NextJob/App/JobDetail.swift
@@ -127,9 +127,9 @@ struct JobDetailView: View {
             }
 
             HStack(spacing: 12) {
-                valuePill(icon: "banknote.fill", text: "\(store.settings.currency) \(job.price, specifier: "%.2f")", tint: AppPalette.green)
-                valuePill(icon: "target", text: "\(job.targetHours, specifier: "%.1f")h target", tint: AppPalette.purple)
-                valuePill(icon: "timer", text: "\(job.actualHours, specifier: "%.1f")h actual", tint: AppPalette.cyan)
+                valuePill(icon: "banknote.fill", text: "\(store.settings.currency) " + String(format: "%.2f", job.price), tint: AppPalette.green)
+                valuePill(icon: "target", text: String(format: "%.1fh target", job.targetHours), tint: AppPalette.purple)
+                valuePill(icon: "timer", text: String(format: "%.1fh actual", job.actualHours), tint: AppPalette.cyan)
             }
         }
         .glassCard()

--- a/NextJob/App/JobEditor.swift
+++ b/NextJob/App/JobEditor.swift
@@ -1,0 +1,159 @@
+import MessageUI
+import SwiftUI
+import UIKit
+
+struct JobEditorView: View {
+    @EnvironmentObject private var store: JobStore
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft: JobDraft
+    @State private var didApplyDefaultType = false
+
+    let dismissAfterSave: Bool
+    let onSaved: (AccountingJob) -> Void
+
+    init(
+        job: AccountingJob?,
+        dismissAfterSave: Bool,
+        onSaved: @escaping (AccountingJob) -> Void
+    ) {
+        _draft = State(initialValue: job.map { JobDraft(job: $0) } ?? JobDraft())
+        self.dismissAfterSave = dismissAfterSave
+        self.onSaved = onSaved
+    }
+
+    private var canSave: Bool {
+        !draft.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        Form {
+            Section("Job") {
+                TextField("Job title", text: $draft.title)
+                TextField("Client / reference", text: $draft.clientReference)
+                Picker("Job type", selection: $draft.jobTypeID) {
+                    Text("Custom / Unspecified").tag(UUID?.none)
+                    ForEach(store.jobTypes.filter { !$0.isArchived }) { type in
+                        Text(type.name).tag(Optional(type.id))
+                    }
+                }
+                if draft.jobTypeID == nil {
+                    TextField("Custom job type", text: $draft.customTypeName)
+                }
+                Picker("Status", selection: $draft.status) {
+                    ForEach(JobStatus.allCases) { status in
+                        Text(status.title).tag(status)
+                    }
+                }
+            }
+
+            Section("Schedule") {
+                DatePicker("Assigned date", selection: $draft.assignedDate, displayedComponents: .date)
+                DatePicker("Due date", selection: $draft.dueDate, displayedComponents: .date)
+                Toggle("Record completion date", isOn: $draft.completionDateEnabled)
+                if draft.completionDateEnabled {
+                    DatePicker("Completion date", selection: $draft.completionDate, displayedComponents: .date)
+                }
+            }
+
+            Section("Price & Time") {
+                HStack {
+                    Text("Job price")
+                    Spacer()
+                    Text(store.settings.currency)
+                        .foregroundStyle(.secondary)
+                    TextField("0.00", value: $draft.price, format: .number.precision(.fractionLength(0...2)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxWidth: 110)
+                }
+                HStack {
+                    Text("Target hours")
+                    Spacer()
+                    TextField("0", value: $draft.targetHours, format: .number.precision(.fractionLength(0...1)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxWidth: 110)
+                }
+                HStack {
+                    Text("Actual hours")
+                    Spacer()
+                    TextField("0", value: $draft.actualHours, format: .number.precision(.fractionLength(0...1)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxWidth: 110)
+                }
+            }
+
+            Section("Required Documents") {
+                TextEditor(text: $draft.requirements)
+                    .frame(minHeight: 90)
+            }
+
+            Section("Work Notes") {
+                TextEditor(text: $draft.notes)
+                    .frame(minHeight: 110)
+            }
+
+            Section {
+                Button {
+                    save()
+                } label: {
+                    Label(draft.id == nil ? "Add Job" : "Save Changes", systemImage: "checkmark.circle.fill")
+                }
+                .disabled(!canSave)
+            }
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .navigationTitle(draft.id == nil ? "New Job" : "Edit Job")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if dismissAfterSave {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Save") { save() }
+                    .disabled(!canSave)
+            }
+        }
+        .onAppear {
+            applyDefaultTypeIfNeeded()
+        }
+        .onChange(of: draft.jobTypeID) { newValue in
+            guard didApplyDefaultType, let type = store.type(id: newValue) else { return }
+            draft.price = type.defaultPrice
+            draft.targetHours = type.targetHours
+        }
+        .onChange(of: draft.status) { newValue in
+            if newValue == .completed {
+                draft.completionDateEnabled = true
+                if draft.completionDate > Date() { draft.completionDate = Date() }
+            }
+        }
+    }
+
+    private func applyDefaultTypeIfNeeded() {
+        guard !didApplyDefaultType else { return }
+        didApplyDefaultType = true
+        if draft.id == nil, draft.jobTypeID == nil, let first = store.jobTypes.first(where: { !$0.isArchived }) {
+            draft.jobTypeID = first.id
+            draft.price = first.defaultPrice
+            draft.targetHours = first.targetHours
+        }
+    }
+
+    private func save() {
+        guard canSave else { return }
+        let job = draft.makeJob()
+        store.upsert(job)
+        onSaved(job)
+        if dismissAfterSave {
+            dismiss()
+        } else {
+            draft = JobDraft()
+            didApplyDefaultType = false
+            applyDefaultTypeIfNeeded()
+        }
+    }
+}

--- a/NextJob/App/JobsList.swift
+++ b/NextJob/App/JobsList.swift
@@ -1,0 +1,164 @@
+import MessageUI
+import SwiftUI
+import UIKit
+
+enum JobListFilter: String, CaseIterable, Identifiable {
+    case all
+    case notStarted
+    case inProgress
+    case waiting
+    case review
+    case completed
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all: return "All"
+        case .notStarted: return "Not Started"
+        case .inProgress: return "In Progress"
+        case .waiting: return "Waiting"
+        case .review: return "Review"
+        case .completed: return "Completed"
+        }
+    }
+
+    var status: JobStatus? {
+        switch self {
+        case .all: return nil
+        case .notStarted: return .notStarted
+        case .inProgress: return .inProgress
+        case .waiting: return .waitingForDocuments
+        case .review: return .readyForReview
+        case .completed: return .completed
+        }
+    }
+}
+
+struct JobsView: View {
+    @EnvironmentObject private var store: JobStore
+    @State private var searchText = ""
+    @State private var filter: JobListFilter = .all
+
+    private var filteredJobs: [AccountingJob] {
+        store.sortedJobs.filter { job in
+            let matchesStatus = filter.status == nil || job.status == filter.status
+            let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+            let matchesSearch = query.isEmpty
+                || job.title.localizedCaseInsensitiveContains(query)
+                || job.clientReference.localizedCaseInsensitiveContains(query)
+                || store.typeName(for: job).localizedCaseInsensitiveContains(query)
+            return matchesStatus && matchesSearch
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 14) {
+                    filterBar
+                    if filteredJobs.isEmpty {
+                        EmptyStateView(
+                            icon: "magnifyingglass",
+                            title: "No matching jobs",
+                            message: "Change the search or status filter, or add a new job."
+                        )
+                        .padding(.top, 30)
+                    } else {
+                        ForEach(filteredJobs) { job in
+                            NavigationLink {
+                                JobDetailView(jobID: job.id)
+                            } label: {
+                                JobRow(job: job)
+                            }
+                            .buttonStyle(.plain)
+                            .contextMenu {
+                                Button(role: .destructive) {
+                                    store.delete(job)
+                                } label: {
+                                    Label("Delete Job", systemImage: "trash")
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(16)
+            }
+            .background(Color(uiColor: .systemGroupedBackground).ignoresSafeArea())
+            .navigationTitle("Jobs")
+            .searchable(text: $searchText, prompt: "Search title, client or type")
+        }
+    }
+
+    private var filterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(JobListFilter.allCases) { item in
+                    Button {
+                        filter = item
+                    } label: {
+                        Text(item.title)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(filter == item ? Color.white : Color.primary)
+                            .padding(.horizontal, 13)
+                            .padding(.vertical, 9)
+                            .background(
+                                filter == item ? AppPalette.accent : Color.primary.opacity(0.07),
+                                in: Capsule()
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+}
+
+struct JobRow: View {
+    @EnvironmentObject private var store: JobStore
+    let job: AccountingJob
+
+    private var isOverdue: Bool {
+        job.status != .completed && job.dueDate < Calendar.current.startOfDay(for: Date())
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(job.title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .multilineTextAlignment(.leading)
+                    Text(store.typeName(for: job))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if !job.clientReference.isEmpty {
+                        Text(job.clientReference)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                StatusBadge(status: job.status)
+            }
+
+            Divider().opacity(0.6)
+
+            HStack {
+                Label(DateFormatter.mediumDate.string(from: job.dueDate), systemImage: "calendar")
+                    .foregroundStyle(isOverdue ? AppPalette.red : Color.secondary)
+                Spacer()
+                Text("\(store.settings.currency) \(job.price, specifier: "%.2f")")
+                    .fontWeight(.semibold)
+                Text("•")
+                    .foregroundStyle(.secondary)
+                Text("\(job.targetHours, specifier: "%.1f")h")
+                    .foregroundStyle(.secondary)
+            }
+            .font(.caption)
+        }
+        .glassCard()
+    }
+}

--- a/NextJob/App/Models.swift
+++ b/NextJob/App/Models.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+enum AppTheme: String, Codable, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .system: return "System"
+        case .light: return "Light"
+        case .dark: return "Dark"
+        }
+    }
+}
+
+enum JobStatus: String, Codable, CaseIterable, Identifiable {
+    case notStarted
+    case inProgress
+    case waitingForDocuments
+    case readyForReview
+    case completed
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .notStarted: return "Not Started"
+        case .inProgress: return "In Progress"
+        case .waitingForDocuments: return "Waiting for Documents"
+        case .readyForReview: return "Ready for Review"
+        case .completed: return "Completed"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .notStarted: return "circle.dashed"
+        case .inProgress: return "clock.arrow.circlepath"
+        case .waitingForDocuments: return "doc.badge.ellipsis"
+        case .readyForReview: return "checklist"
+        case .completed: return "checkmark.seal.fill"
+        }
+    }
+}
+
+enum AttachmentKind: String, Codable, CaseIterable, Identifiable {
+    case sourceDocument
+    case completedWork
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .sourceDocument: return "Source Documents"
+        case .completedWork: return "Completed Work"
+        }
+    }
+}
+
+struct JobAttachment: Identifiable, Codable, Hashable {
+    var id: UUID
+    var originalName: String
+    var storedName: String
+    var kind: AttachmentKind
+    var addedAt: Date
+    var byteCount: Int64
+
+    init(
+        id: UUID = UUID(),
+        originalName: String,
+        storedName: String,
+        kind: AttachmentKind,
+        addedAt: Date = Date(),
+        byteCount: Int64 = 0
+    ) {
+        self.id = id
+        self.originalName = originalName
+        self.storedName = storedName
+        self.kind = kind
+        self.addedAt = addedAt
+        self.byteCount = byteCount
+    }
+}
+
+struct JobType: Identifiable, Codable, Hashable {
+    var id: UUID
+    var name: String
+    var defaultPrice: Double
+    var targetHours: Double
+    var isArchived: Bool
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        defaultPrice: Double = 0,
+        targetHours: Double = 1,
+        isArchived: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.defaultPrice = defaultPrice
+        self.targetHours = targetHours
+        self.isArchived = isArchived
+    }
+}
+
+struct AccountingJob: Identifiable, Codable, Hashable {
+    var id: UUID
+    var title: String
+    var clientReference: String
+    var jobTypeID: UUID?
+    var customTypeName: String
+    var status: JobStatus
+    var assignedDate: Date
+    var dueDate: Date
+    var completionDate: Date?
+    var price: Double
+    var targetHours: Double
+    var actualHours: Double
+    var requirements: String
+    var notes: String
+    var attachments: [JobAttachment]
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        clientReference: String = "",
+        jobTypeID: UUID? = nil,
+        customTypeName: String = "",
+        status: JobStatus = .notStarted,
+        assignedDate: Date = Date(),
+        dueDate: Date = Calendar.current.date(byAdding: .day, value: 7, to: Date()) ?? Date(),
+        completionDate: Date? = nil,
+        price: Double = 0,
+        targetHours: Double = 1,
+        actualHours: Double = 0,
+        requirements: String = "",
+        notes: String = "",
+        attachments: [JobAttachment] = [],
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.clientReference = clientReference
+        self.jobTypeID = jobTypeID
+        self.customTypeName = customTypeName
+        self.status = status
+        self.assignedDate = assignedDate
+        self.dueDate = dueDate
+        self.completionDate = completionDate
+        self.price = price
+        self.targetHours = targetHours
+        self.actualHours = actualHours
+        self.requirements = requirements
+        self.notes = notes
+        self.attachments = attachments
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+struct AppSettings: Codable, Hashable {
+    var companyName: String = "KB Accountants"
+    var companyEmail: String = ""
+    var senderName: String = "Zeeshan Barvi"
+    var senderEmail: String = ""
+    var currency: String = "QAR"
+    var theme: AppTheme = .system
+}
+
+struct NextJobSnapshot: Codable {
+    var jobs: [AccountingJob]
+    var jobTypes: [JobType]
+    var settings: AppSettings
+}
+
+struct JobDraft {
+    var id: UUID?
+    var title: String = ""
+    var clientReference: String = ""
+    var jobTypeID: UUID?
+    var customTypeName: String = ""
+    var status: JobStatus = .notStarted
+    var assignedDate: Date = Date()
+    var dueDate: Date = Calendar.current.date(byAdding: .day, value: 7, to: Date()) ?? Date()
+    var completionDateEnabled: Bool = false
+    var completionDate: Date = Date()
+    var price: Double = 0
+    var targetHours: Double = 1
+    var actualHours: Double = 0
+    var requirements: String = ""
+    var notes: String = ""
+    var attachments: [JobAttachment] = []
+    var createdAt: Date = Date()
+
+    init() {}
+
+    init(job: AccountingJob) {
+        id = job.id
+        title = job.title
+        clientReference = job.clientReference
+        jobTypeID = job.jobTypeID
+        customTypeName = job.customTypeName
+        status = job.status
+        assignedDate = job.assignedDate
+        dueDate = job.dueDate
+        completionDateEnabled = job.completionDate != nil
+        completionDate = job.completionDate ?? Date()
+        price = job.price
+        targetHours = job.targetHours
+        actualHours = job.actualHours
+        requirements = job.requirements
+        notes = job.notes
+        attachments = job.attachments
+        createdAt = job.createdAt
+    }
+
+    func makeJob() -> AccountingJob {
+        AccountingJob(
+            id: id ?? UUID(),
+            title: title.trimmingCharacters(in: .whitespacesAndNewlines),
+            clientReference: clientReference.trimmingCharacters(in: .whitespacesAndNewlines),
+            jobTypeID: jobTypeID,
+            customTypeName: customTypeName.trimmingCharacters(in: .whitespacesAndNewlines),
+            status: status,
+            assignedDate: assignedDate,
+            dueDate: dueDate,
+            completionDate: completionDateEnabled ? completionDate : nil,
+            price: max(0, price),
+            targetHours: max(0, targetHours),
+            actualHours: max(0, actualHours),
+            requirements: requirements.trimmingCharacters(in: .whitespacesAndNewlines),
+            notes: notes.trimmingCharacters(in: .whitespacesAndNewlines),
+            attachments: attachments,
+            createdAt: createdAt,
+            updatedAt: Date()
+        )
+    }
+}

--- a/NextJob/App/NextJobApp.swift
+++ b/NextJob/App/NextJobApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct NextJobApp: App {
+    @StateObject private var store = JobStore()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(store)
+        }
+    }
+}

--- a/NextJob/App/RootDashboard.swift
+++ b/NextJob/App/RootDashboard.swift
@@ -1,0 +1,225 @@
+import MessageUI
+import SwiftUI
+import UIKit
+
+struct RootView: View {
+    @EnvironmentObject private var store: JobStore
+
+    var body: some View {
+        TabView {
+            DashboardView()
+                .tabItem { Label("Summary", systemImage: "square.grid.2x2.fill") }
+
+            JobsView()
+                .tabItem { Label("Jobs", systemImage: "briefcase.fill") }
+
+            AddJobScreen()
+                .tabItem { Label("Add", systemImage: "plus.circle.fill") }
+
+            JobTypesView()
+                .tabItem { Label("Types", systemImage: "tag.fill") }
+
+            SettingsView()
+                .tabItem { Label("Settings", systemImage: "gearshape.fill") }
+        }
+        .tint(AppPalette.accent)
+        .preferredColorScheme(store.settings.theme.colorScheme)
+    }
+}
+
+struct DashboardView: View {
+    @EnvironmentObject private var store: JobStore
+
+    private var dueSoon: [AccountingJob] {
+        let limit = Calendar.current.date(byAdding: .day, value: 7, to: Date()) ?? Date()
+        return store.sortedJobs.filter {
+            $0.status != .completed && $0.dueDate <= limit
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 20) {
+                    header
+                    statusGrid
+                    valueGrid
+                    dueSoonSection
+                    recentSection
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 28)
+            }
+            .background(background)
+            .navigationTitle("Next Job")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 14) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [AppPalette.accent, AppPalette.purple],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                Image(systemName: "briefcase.fill")
+                    .font(.system(size: 27, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+            .frame(width: 62, height: 62)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(store.settings.companyName)
+                    .font(.headline)
+                Text("Part-time accounting job tracker")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text("\(store.jobs.count) jobs recorded")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(AppPalette.accent)
+            }
+            Spacer()
+        }
+        .glassCard()
+    }
+
+    private var statusGrid: some View {
+        VStack(spacing: 12) {
+            SectionHeader("Work Summary", subtitle: "Live status of all recorded jobs")
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                MetricCard(
+                    title: "Not Started",
+                    value: "\(store.count(for: .notStarted))",
+                    subtitle: "Waiting to begin",
+                    icon: JobStatus.notStarted.icon,
+                    tint: AppPalette.status(.notStarted)
+                )
+                MetricCard(
+                    title: "In Progress",
+                    value: "\(store.count(for: .inProgress))",
+                    subtitle: "Currently being worked",
+                    icon: JobStatus.inProgress.icon,
+                    tint: AppPalette.status(.inProgress)
+                )
+                MetricCard(
+                    title: "Waiting",
+                    value: "\(store.count(for: .waitingForDocuments))",
+                    subtitle: "Documents requested",
+                    icon: JobStatus.waitingForDocuments.icon,
+                    tint: AppPalette.status(.waitingForDocuments)
+                )
+                MetricCard(
+                    title: "Completed",
+                    value: "\(store.count(for: .completed))",
+                    subtitle: "Ready or already emailed",
+                    icon: JobStatus.completed.icon,
+                    tint: AppPalette.status(.completed)
+                )
+            }
+        }
+    }
+
+    private var valueGrid: some View {
+        VStack(spacing: 12) {
+            SectionHeader("Price & Time", subtitle: "Completed work and remaining workload")
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                MetricCard(
+                    title: "Completed Value",
+                    value: money(store.completedValue),
+                    subtitle: "Price of completed jobs",
+                    icon: "checkmark.circle.fill",
+                    tint: AppPalette.green
+                )
+                MetricCard(
+                    title: "Outstanding Value",
+                    value: money(store.outstandingValue),
+                    subtitle: "Price still in progress",
+                    icon: "hourglass",
+                    tint: AppPalette.orange
+                )
+                MetricCard(
+                    title: "Target Time",
+                    value: hours(store.totalTargetHours),
+                    subtitle: "Planned across all jobs",
+                    icon: "target",
+                    tint: AppPalette.purple
+                )
+                MetricCard(
+                    title: "Time Recorded",
+                    value: hours(store.totalActualHours),
+                    subtitle: "Actual work entered",
+                    icon: "timer",
+                    tint: AppPalette.cyan
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var dueSoonSection: some View {
+        VStack(spacing: 12) {
+            SectionHeader("Due Soon", subtitle: "Open jobs due within seven days")
+            if dueSoon.isEmpty {
+                EmptyStateView(
+                    icon: "calendar.badge.checkmark",
+                    title: "Nothing urgent",
+                    message: "Open jobs due within seven days will appear here."
+                )
+            } else {
+                ForEach(dueSoon.prefix(4)) { job in
+                    NavigationLink {
+                        JobDetailView(jobID: job.id)
+                    } label: {
+                        JobRow(job: job)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var recentSection: some View {
+        VStack(spacing: 12) {
+            SectionHeader("Recent Jobs")
+            if store.sortedJobs.isEmpty {
+                EmptyStateView(
+                    icon: "briefcase",
+                    title: "No jobs yet",
+                    message: "Use the Add tab to record your first KB Accountants job."
+                )
+            } else {
+                ForEach(store.sortedJobs.prefix(5)) { job in
+                    NavigationLink {
+                        JobDetailView(jobID: job.id)
+                    } label: {
+                        JobRow(job: job)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var background: some View {
+        LinearGradient(
+            colors: [AppPalette.accent.opacity(0.09), Color.clear, AppPalette.purple.opacity(0.06)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+        .ignoresSafeArea()
+    }
+
+    private func money(_ amount: Double) -> String {
+        "\(store.settings.currency) " + String(format: "%.0f", amount)
+    }
+
+    private func hours(_ amount: Double) -> String {
+        String(format: "%.1fh", amount)
+    }
+}

--- a/NextJob/App/Services.swift
+++ b/NextJob/App/Services.swift
@@ -1,0 +1,306 @@
+import Foundation
+import MessageUI
+import QuickLook
+import SwiftUI
+import UniformTypeIdentifiers
+import UIKit
+
+struct MailAttachment {
+    let data: Data
+    let mimeType: String
+    let fileName: String
+}
+
+struct MailDraft: Identifiable {
+    let id = UUID()
+    let recipients: [String]
+    let subject: String
+    let body: String
+    let attachments: [MailAttachment]
+}
+
+struct SharePayload: Identifiable {
+    let id = UUID()
+    let items: [Any]
+}
+
+struct PreviewPayload: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
+enum DocumentPickerError: Error {
+    case cancelled
+}
+
+struct DocumentPicker: UIViewControllerRepresentable {
+    let allowsMultipleSelection: Bool
+    let completion: (Result<[URL], Error>) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(completion: completion)
+    }
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.item], asCopy: true)
+        picker.allowsMultipleSelection = allowsMultipleSelection
+        picker.shouldShowFileExtensions = true
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let completion: (Result<[URL], Error>) -> Void
+
+        init(completion: @escaping (Result<[URL], Error>) -> Void) {
+            self.completion = completion
+        }
+
+        func documentPicker(
+            _ controller: UIDocumentPickerViewController,
+            didPickDocumentsAt urls: [URL]
+        ) {
+            completion(.success(urls))
+        }
+
+        func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+            completion(.failure(DocumentPickerError.cancelled))
+        }
+    }
+}
+
+struct MailComposer: UIViewControllerRepresentable {
+    let draft: MailDraft
+    let completion: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(completion: completion)
+    }
+
+    func makeUIViewController(context: Context) -> MFMailComposeViewController {
+        let composer = MFMailComposeViewController()
+        composer.mailComposeDelegate = context.coordinator
+        composer.setToRecipients(draft.recipients.filter { !$0.isEmpty })
+        composer.setSubject(draft.subject)
+        composer.setMessageBody(draft.body, isHTML: false)
+        for attachment in draft.attachments {
+            composer.addAttachmentData(
+                attachment.data,
+                mimeType: attachment.mimeType,
+                fileName: attachment.fileName
+            )
+        }
+        return composer
+    }
+
+    func updateUIViewController(_ uiViewController: MFMailComposeViewController, context: Context) {}
+
+    final class Coordinator: NSObject, MFMailComposeViewControllerDelegate {
+        let completion: () -> Void
+
+        init(completion: @escaping () -> Void) {
+            self.completion = completion
+        }
+
+        func mailComposeController(
+            _ controller: MFMailComposeViewController,
+            didFinishWith result: MFMailComposeResult,
+            error: Error?
+        ) {
+            controller.dismiss(animated: true)
+            completion()
+        }
+    }
+}
+
+struct ActivityView: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+
+struct QuickLookPreview: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(url: url)
+    }
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: QLPreviewController, context: Context) {}
+
+    final class Coordinator: NSObject, QLPreviewControllerDataSource {
+        let url: URL
+
+        init(url: URL) {
+            self.url = url
+        }
+
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
+
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+            url as NSURL
+        }
+    }
+}
+
+struct ZipEntry {
+    let name: String
+    let data: Data
+}
+
+enum StoredZipWriter {
+    static func write(entries: [ZipEntry], to destination: URL) throws {
+        guard entries.count <= Int(UInt16.max) else { throw ZipError.tooManyFiles }
+
+        var output = Data()
+        var centralDirectory = Data()
+        var offsets: [UInt32] = []
+        let stamp = dosTimestamp(Date())
+
+        for entry in entries {
+            let normalizedName = entry.name.replacingOccurrences(of: "\\", with: "/")
+            let nameData = Data(normalizedName.utf8)
+            guard nameData.count <= Int(UInt16.max),
+                  entry.data.count <= Int(UInt32.max),
+                  output.count <= Int(UInt32.max) else {
+                throw ZipError.fileTooLarge
+            }
+
+            let crc = CRC32.checksum(entry.data)
+            offsets.append(UInt32(output.count))
+
+            output.appendUInt32(0x04034B50)
+            output.appendUInt16(20)
+            output.appendUInt16(0x0800)
+            output.appendUInt16(0)
+            output.appendUInt16(stamp.time)
+            output.appendUInt16(stamp.date)
+            output.appendUInt32(crc)
+            output.appendUInt32(UInt32(entry.data.count))
+            output.appendUInt32(UInt32(entry.data.count))
+            output.appendUInt16(UInt16(nameData.count))
+            output.appendUInt16(0)
+            output.append(nameData)
+            output.append(entry.data)
+        }
+
+        for (index, entry) in entries.enumerated() {
+            let normalizedName = entry.name.replacingOccurrences(of: "\\", with: "/")
+            let nameData = Data(normalizedName.utf8)
+            let crc = CRC32.checksum(entry.data)
+
+            centralDirectory.appendUInt32(0x02014B50)
+            centralDirectory.appendUInt16(20)
+            centralDirectory.appendUInt16(20)
+            centralDirectory.appendUInt16(0x0800)
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt16(stamp.time)
+            centralDirectory.appendUInt16(stamp.date)
+            centralDirectory.appendUInt32(crc)
+            centralDirectory.appendUInt32(UInt32(entry.data.count))
+            centralDirectory.appendUInt32(UInt32(entry.data.count))
+            centralDirectory.appendUInt16(UInt16(nameData.count))
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt32(0)
+            centralDirectory.appendUInt32(offsets[index])
+            centralDirectory.append(nameData)
+        }
+
+        guard output.count <= Int(UInt32.max), centralDirectory.count <= Int(UInt32.max) else {
+            throw ZipError.fileTooLarge
+        }
+
+        let centralOffset = UInt32(output.count)
+        output.append(centralDirectory)
+        output.appendUInt32(0x06054B50)
+        output.appendUInt16(0)
+        output.appendUInt16(0)
+        output.appendUInt16(UInt16(entries.count))
+        output.appendUInt16(UInt16(entries.count))
+        output.appendUInt32(UInt32(centralDirectory.count))
+        output.appendUInt32(centralOffset)
+        output.appendUInt16(0)
+
+        try output.write(to: destination, options: .atomic)
+    }
+
+    private static func dosTimestamp(_ date: Date) -> (time: UInt16, date: UInt16) {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: date
+        )
+        let year = max(1980, min(2107, components.year ?? 1980))
+        let month = max(1, min(12, components.month ?? 1))
+        let day = max(1, min(31, components.day ?? 1))
+        let hour = max(0, min(23, components.hour ?? 0))
+        let minute = max(0, min(59, components.minute ?? 0))
+        let second = max(0, min(59, components.second ?? 0))
+
+        let time = UInt16((hour << 11) | (minute << 5) | (second / 2))
+        let dosDate = UInt16(((year - 1980) << 9) | (month << 5) | day)
+        return (time, dosDate)
+    }
+}
+
+enum ZipError: LocalizedError {
+    case tooManyFiles
+    case fileTooLarge
+
+    var errorDescription: String? {
+        switch self {
+        case .tooManyFiles: return "This job contains too many files for one ZIP package."
+        case .fileTooLarge: return "One or more files are too large for the ZIP package."
+        }
+    }
+}
+
+enum CRC32 {
+    private static let table: [UInt32] = (0..<256).map { index in
+        var value = UInt32(index)
+        for _ in 0..<8 {
+            value = (value & 1) == 1 ? (0xEDB88320 ^ (value >> 1)) : (value >> 1)
+        }
+        return value
+    }
+
+    static func checksum(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFFFFFF
+        for byte in data {
+            let index = Int((crc ^ UInt32(byte)) & 0xFF)
+            crc = table[index] ^ (crc >> 8)
+        }
+        return crc ^ 0xFFFFFFFF
+    }
+}
+
+private extension Data {
+    mutating func appendUInt16(_ value: UInt16) {
+        var littleEndianValue = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndianValue) { buffer in
+            append(contentsOf: buffer)
+        }
+    }
+
+    mutating func appendUInt32(_ value: UInt32) {
+        var littleEndianValue = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndianValue) { buffer in
+            append(contentsOf: buffer)
+        }
+    }
+}

--- a/NextJob/App/Store.swift
+++ b/NextJob/App/Store.swift
@@ -1,0 +1,326 @@
+import Combine
+import Foundation
+
+@MainActor
+final class JobStore: ObservableObject {
+    @Published private(set) var jobs: [AccountingJob] = []
+    @Published private(set) var jobTypes: [JobType] = []
+    @Published private(set) var settings = AppSettings()
+
+    private let fileManager = FileManager.default
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init() {
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        load()
+        seedJobTypesIfNeeded()
+    }
+
+    var sortedJobs: [AccountingJob] {
+        jobs.sorted { lhs, rhs in
+            if lhs.status == .completed, rhs.status != .completed { return false }
+            if lhs.status != .completed, rhs.status == .completed { return true }
+            return lhs.dueDate < rhs.dueDate
+        }
+    }
+
+    var completedValue: Double {
+        jobs.filter { $0.status == .completed }.reduce(0) { $0 + $1.price }
+    }
+
+    var outstandingValue: Double {
+        jobs.filter { $0.status != .completed }.reduce(0) { $0 + $1.price }
+    }
+
+    var totalTargetHours: Double {
+        jobs.reduce(0) { $0 + $1.targetHours }
+    }
+
+    var totalActualHours: Double {
+        jobs.reduce(0) { $0 + $1.actualHours }
+    }
+
+    func count(for status: JobStatus) -> Int {
+        jobs.filter { $0.status == status }.count
+    }
+
+    func job(id: UUID) -> AccountingJob? {
+        jobs.first { $0.id == id }
+    }
+
+    func type(id: UUID?) -> JobType? {
+        guard let id else { return nil }
+        return jobTypes.first { $0.id == id }
+    }
+
+    func typeName(for job: AccountingJob) -> String {
+        if let type = type(id: job.jobTypeID) { return type.name }
+        if !job.customTypeName.isEmpty { return job.customTypeName }
+        return "Unspecified"
+    }
+
+    func upsert(_ job: AccountingJob) {
+        if let index = jobs.firstIndex(where: { $0.id == job.id }) {
+            jobs[index] = job
+        } else {
+            jobs.append(job)
+        }
+        save()
+    }
+
+    func delete(_ job: AccountingJob) {
+        jobs.removeAll { $0.id == job.id }
+        try? fileManager.removeItem(at: jobFolderURL(jobID: job.id, create: false))
+        save()
+    }
+
+    func setStatus(_ status: JobStatus, for jobID: UUID) {
+        guard let index = jobs.firstIndex(where: { $0.id == jobID }) else { return }
+        jobs[index].status = status
+        jobs[index].updatedAt = Date()
+        if status == .completed, jobs[index].completionDate == nil {
+            jobs[index].completionDate = Date()
+        } else if status != .completed {
+            jobs[index].completionDate = nil
+        }
+        save()
+    }
+
+    func updateSettings(_ newSettings: AppSettings) {
+        settings = newSettings
+        save()
+    }
+
+    func addJobType(_ type: JobType) {
+        jobTypes.append(type)
+        jobTypes.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        save()
+    }
+
+    func updateJobType(_ type: JobType) {
+        guard let index = jobTypes.firstIndex(where: { $0.id == type.id }) else { return }
+        jobTypes[index] = type
+        jobTypes.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        save()
+    }
+
+    func deleteJobType(_ type: JobType) {
+        jobTypes.removeAll { $0.id == type.id }
+        for index in jobs.indices where jobs[index].jobTypeID == type.id {
+            jobs[index].jobTypeID = nil
+            if jobs[index].customTypeName.isEmpty {
+                jobs[index].customTypeName = type.name
+            }
+        }
+        save()
+    }
+
+    func importFiles(_ urls: [URL], to jobID: UUID, kind: AttachmentKind) throws {
+        guard let jobIndex = jobs.firstIndex(where: { $0.id == jobID }) else {
+            throw StoreError.jobNotFound
+        }
+
+        let folder = jobFolderURL(jobID: jobID, create: true)
+        var newAttachments: [JobAttachment] = []
+
+        for sourceURL in urls {
+            let accessed = sourceURL.startAccessingSecurityScopedResource()
+            defer { if accessed { sourceURL.stopAccessingSecurityScopedResource() } }
+
+            let originalName = sourceURL.lastPathComponent.isEmpty ? "Document" : sourceURL.lastPathComponent
+            let safeName = uniqueStoredName(for: originalName, in: folder)
+            let destination = folder.appendingPathComponent(safeName)
+            try fileManager.copyItem(at: sourceURL, to: destination)
+            let values = try? destination.resourceValues(forKeys: [.fileSizeKey])
+            let byteCount = Int64(values?.fileSize ?? 0)
+            newAttachments.append(
+                JobAttachment(
+                    originalName: originalName,
+                    storedName: safeName,
+                    kind: kind,
+                    byteCount: byteCount
+                )
+            )
+        }
+
+        jobs[jobIndex].attachments.append(contentsOf: newAttachments)
+        jobs[jobIndex].updatedAt = Date()
+        save()
+    }
+
+    func removeAttachment(_ attachment: JobAttachment, from jobID: UUID) {
+        guard let jobIndex = jobs.firstIndex(where: { $0.id == jobID }) else { return }
+        let url = fileURL(for: attachment, jobID: jobID)
+        try? fileManager.removeItem(at: url)
+        jobs[jobIndex].attachments.removeAll { $0.id == attachment.id }
+        jobs[jobIndex].updatedAt = Date()
+        save()
+    }
+
+    func fileURL(for attachment: JobAttachment, jobID: UUID) -> URL {
+        jobFolderURL(jobID: jobID, create: false).appendingPathComponent(attachment.storedName)
+    }
+
+    func makeJobPackage(jobID: UUID) throws -> URL {
+        guard let job = job(id: jobID) else { throw StoreError.jobNotFound }
+        let dateText = DateFormatter.packageDate.string(from: Date())
+        let baseName = sanitizedFileName(job.title.isEmpty ? "Job" : job.title)
+        let destination = fileManager.temporaryDirectory
+            .appendingPathComponent("\(baseName)-\(dateText).zip")
+
+        try? fileManager.removeItem(at: destination)
+
+        var entries: [ZipEntry] = [
+            ZipEntry(name: "Job Summary.txt", data: Data(summaryText(for: job).utf8))
+        ]
+
+        for attachment in job.attachments {
+            let source = fileURL(for: attachment, jobID: job.id)
+            guard fileManager.fileExists(atPath: source.path) else { continue }
+            let data = try Data(contentsOf: source)
+            let folder = attachment.kind == .sourceDocument ? "Source Documents" : "Completed Work"
+            entries.append(ZipEntry(name: "\(folder)/\(attachment.originalName)", data: data))
+        }
+
+        try StoredZipWriter.write(entries: entries, to: destination)
+        return destination
+    }
+
+    func summaryText(for job: AccountingJob) -> String {
+        let completed = job.completionDate.map { DateFormatter.mediumDate.string(from: $0) } ?? "Not completed"
+        return """
+        NEXT JOB - JOB SUMMARY
+
+        Job: \(job.title)
+        Client / Reference: \(job.clientReference.isEmpty ? "Not provided" : job.clientReference)
+        Type: \(typeName(for: job))
+        Status: \(job.status.title)
+        Assigned: \(DateFormatter.mediumDate.string(from: job.assignedDate))
+        Due: \(DateFormatter.mediumDate.string(from: job.dueDate))
+        Completed: \(completed)
+        Price: \(settings.currency) \(String(format: "%.2f", job.price))
+        Target Time: \(String(format: "%.1f", job.targetHours)) hours
+        Actual Time: \(String(format: "%.1f", job.actualHours)) hours
+
+        DOCUMENTS / REQUIREMENTS
+        \(job.requirements.isEmpty ? "None recorded" : job.requirements)
+
+        WORK NOTES
+        \(job.notes.isEmpty ? "None recorded" : job.notes)
+
+        Source documents: \(job.attachments.filter { $0.kind == .sourceDocument }.count)
+        Completed work files: \(job.attachments.filter { $0.kind == .completedWork }.count)
+        """
+    }
+
+    private func seedJobTypesIfNeeded() {
+        guard jobTypes.isEmpty else { return }
+        jobTypes = [
+            JobType(name: "Bank Reconciliation", targetHours: 2),
+            JobType(name: "Bookkeeping", targetHours: 4),
+            JobType(name: "Company Accounts", targetHours: 8),
+            JobType(name: "Management Accounts", targetHours: 6),
+            JobType(name: "Payroll", targetHours: 2),
+            JobType(name: "Tax / VAT Return", targetHours: 4),
+            JobType(name: "Year-End Accounts", targetHours: 10),
+            JobType(name: "Other", targetHours: 1)
+        ]
+        save()
+    }
+
+    private func load() {
+        let url = dataFileURL
+        guard let data = try? Data(contentsOf: url),
+              let snapshot = try? decoder.decode(NextJobSnapshot.self, from: data) else {
+            return
+        }
+        jobs = snapshot.jobs
+        jobTypes = snapshot.jobTypes
+        settings = snapshot.settings
+    }
+
+    private func save() {
+        do {
+            let folder = appSupportFolder
+            try fileManager.createDirectory(at: folder, withIntermediateDirectories: true)
+            let snapshot = NextJobSnapshot(jobs: jobs, jobTypes: jobTypes, settings: settings)
+            let data = try encoder.encode(snapshot)
+            try data.write(to: dataFileURL, options: .atomic)
+        } catch {
+            assertionFailure("Next Job save failed: \(error)")
+        }
+    }
+
+    private var appSupportFolder: URL {
+        let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return base.appendingPathComponent("NextJob", isDirectory: true)
+    }
+
+    private var dataFileURL: URL {
+        appSupportFolder.appendingPathComponent("next-job-data.json")
+    }
+
+    private func jobFolderURL(jobID: UUID, create: Bool) -> URL {
+        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let folder = documents
+            .appendingPathComponent("Next Job Files", isDirectory: true)
+            .appendingPathComponent(jobID.uuidString, isDirectory: true)
+        if create {
+            try? fileManager.createDirectory(at: folder, withIntermediateDirectories: true)
+        }
+        return folder
+    }
+
+    private func uniqueStoredName(for originalName: String, in folder: URL) -> String {
+        let clean = sanitizedFileName(originalName)
+        let extensionText = (clean as NSString).pathExtension
+        let stem = (clean as NSString).deletingPathExtension
+        var candidate = clean
+        var counter = 2
+        while fileManager.fileExists(atPath: folder.appendingPathComponent(candidate).path) {
+            candidate = extensionText.isEmpty ? "\(stem)-\(counter)" : "\(stem)-\(counter).\(extensionText)"
+            counter += 1
+        }
+        return candidate
+    }
+
+    private func sanitizedFileName(_ value: String) -> String {
+        let invalid = CharacterSet(charactersIn: "/\\:?%*|\"<>")
+        let parts = value.components(separatedBy: invalid)
+        let joined = parts.filter { !$0.isEmpty }.joined(separator: "-")
+        return joined.isEmpty ? "File" : joined
+    }
+}
+
+enum StoreError: LocalizedError {
+    case jobNotFound
+
+    var errorDescription: String? {
+        switch self {
+        case .jobNotFound: return "The selected job could not be found."
+        }
+    }
+}
+
+extension DateFormatter {
+    static let mediumDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    static let packageDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+}

--- a/NextJob/App/TypesSettings.swift
+++ b/NextJob/App/TypesSettings.swift
@@ -1,0 +1,201 @@
+import MessageUI
+import SwiftUI
+import UIKit
+
+struct JobTypesView: View {
+    @EnvironmentObject private var store: JobStore
+    @State private var selectedType: JobType?
+    @State private var addingType = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(store.jobTypes) { type in
+                        Button {
+                            selectedType = type
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(type.name)
+                                        .foregroundStyle(.primary)
+                                        .fontWeight(.semibold)
+                                    Text("Target \(type.targetHours, specifier: "%.1f")h • \(store.settings.currency) \(type.defaultPrice, specifier: "%.2f")")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                    }
+                    .onDelete { offsets in
+                        for index in offsets {
+                            store.deleteJobType(store.jobTypes[index])
+                        }
+                    }
+                } header: {
+                    Text("Default price and target time")
+                } footer: {
+                    Text("Selecting a type on a new job automatically fills its default price and target hours. You can still change them for each job.")
+                }
+            }
+            .navigationTitle("Job Types")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        addingType = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(item: $selectedType) { type in
+                NavigationStack {
+                    JobTypeEditor(type: type)
+                }
+            }
+            .sheet(isPresented: $addingType) {
+                NavigationStack {
+                    JobTypeEditor(type: nil)
+                }
+            }
+        }
+    }
+}
+
+struct JobTypeEditor: View {
+    @EnvironmentObject private var store: JobStore
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String
+    @State private var price: Double
+    @State private var hours: Double
+
+    let existingType: JobType?
+
+    init(type: JobType?) {
+        existingType = type
+        _name = State(initialValue: type?.name ?? "")
+        _price = State(initialValue: type?.defaultPrice ?? 0)
+        _hours = State(initialValue: type?.targetHours ?? 1)
+    }
+
+    var body: some View {
+        Form {
+            Section("Job Type") {
+                TextField("Name", text: $name)
+                HStack {
+                    Text("Default price")
+                    Spacer()
+                    Text(store.settings.currency)
+                        .foregroundStyle(.secondary)
+                    TextField("0", value: $price, format: .number.precision(.fractionLength(0...2)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxWidth: 110)
+                }
+                HStack {
+                    Text("Target hours")
+                    Spacer()
+                    TextField("1", value: $hours, format: .number.precision(.fractionLength(0...1)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxWidth: 110)
+                }
+            }
+        }
+        .navigationTitle(existingType == nil ? "Add Type" : "Edit Type")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Save") {
+                    save()
+                }
+                .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+
+    private func save() {
+        let cleanName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanName.isEmpty else { return }
+        if var existingType {
+            existingType.name = cleanName
+            existingType.defaultPrice = max(0, price)
+            existingType.targetHours = max(0, hours)
+            store.updateJobType(existingType)
+        } else {
+            store.addJobType(JobType(name: cleanName, defaultPrice: max(0, price), targetHours: max(0, hours)))
+        }
+        dismiss()
+    }
+}
+
+struct SettingsView: View {
+    @EnvironmentObject private var store: JobStore
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("KB Accountants") {
+                    TextField("Company name", text: settingsBinding(\.companyName))
+                    TextField("Company email", text: settingsBinding(\.companyEmail))
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.emailAddress)
+                    Text("This email is used for document requests and job-completion emails.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Your Details") {
+                    TextField("Your name", text: settingsBinding(\.senderName))
+                    TextField("Your email", text: settingsBinding(\.senderEmail))
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.emailAddress)
+                }
+
+                Section("App") {
+                    TextField("Currency", text: settingsBinding(\.currency))
+                        .textInputAutocapitalization(.characters)
+                    Picker("Appearance", selection: settingsBinding(\.theme)) {
+                        ForEach(AppTheme.allCases) { theme in
+                            Text(theme.title).tag(theme)
+                        }
+                    }
+                }
+
+                Section("Storage") {
+                    LabeledContent("Jobs", value: "\(store.jobs.count)")
+                    LabeledContent("Job Types", value: "\(store.jobTypes.count)")
+                    Text("Job data is saved locally. Attached documents are copied into the Next Job Files folder in the app's Documents storage.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("About") {
+                    LabeledContent("App", value: "Next Job")
+                    LabeledContent("Version", value: "1.0.0")
+                    LabeledContent("Minimum iOS", value: "16.0")
+                    LabeledContent("Author", value: "Next Solution – Zeeshan Barvi")
+                }
+            }
+            .navigationTitle("Settings")
+        }
+    }
+
+    private func settingsBinding<Value>(_ keyPath: WritableKeyPath<AppSettings, Value>) -> Binding<Value> {
+        Binding(
+            get: { store.settings[keyPath: keyPath] },
+            set: { newValue in
+                var copy = store.settings
+                copy[keyPath: keyPath] = newValue
+                store.updateSettings(copy)
+            }
+        )
+    }
+}

--- a/NextJob/App/UIComponents.swift
+++ b/NextJob/App/UIComponents.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+extension AppTheme {
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+}
+
+enum AppPalette {
+    static let accent = Color(red: 0.16, green: 0.45, blue: 0.98)
+    static let cyan = Color(red: 0.10, green: 0.72, blue: 0.82)
+    static let purple = Color(red: 0.50, green: 0.32, blue: 0.95)
+    static let green = Color(red: 0.14, green: 0.70, blue: 0.42)
+    static let orange = Color(red: 0.96, green: 0.55, blue: 0.16)
+    static let red = Color(red: 0.93, green: 0.28, blue: 0.32)
+
+    static func status(_ status: JobStatus) -> Color {
+        switch status {
+        case .notStarted: return .secondary
+        case .inProgress: return accent
+        case .waitingForDocuments: return orange
+        case .readyForReview: return purple
+        case .completed: return green
+        }
+    }
+}
+
+struct GlassCardModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding(16)
+            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.07), lineWidth: 1)
+            )
+    }
+}
+
+extension View {
+    func glassCard() -> some View {
+        modifier(GlassCardModifier())
+    }
+}
+
+struct StatusBadge: View {
+    let status: JobStatus
+
+    var body: some View {
+        Label(status.title, systemImage: status.icon)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(AppPalette.status(status))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(AppPalette.status(status).opacity(0.12), in: Capsule())
+    }
+}
+
+struct MetricCard: View {
+    let title: String
+    let value: String
+    let subtitle: String
+    let icon: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: icon)
+                    .font(.headline)
+                    .foregroundStyle(tint)
+                    .frame(width: 34, height: 34)
+                    .background(tint.opacity(0.13), in: RoundedRectangle(cornerRadius: 11, style: .continuous))
+                Spacer()
+            }
+            Text(value)
+                .font(.title2.bold())
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, minHeight: 145, alignment: .topLeading)
+        .glassCard()
+    }
+}
+
+struct SectionHeader: View {
+    let title: String
+    let subtitle: String?
+
+    init(_ title: String, subtitle: String? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.title3.bold())
+            if let subtitle {
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct EmptyStateView: View {
+    let icon: String
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Image(systemName: icon)
+                .font(.system(size: 42, weight: .semibold))
+                .foregroundStyle(AppPalette.accent)
+            Text(title)
+                .font(.title3.bold())
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(30)
+        .frame(maxWidth: .infinity)
+        .glassCard()
+    }
+}
+
+struct PrimaryActionButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.headline)
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(AppPalette.accent.opacity(configuration.isPressed ? 0.75 : 1), in: RoundedRectangle(cornerRadius: 15, style: .continuous))
+            .scaleEffect(configuration.isPressed ? 0.985 : 1)
+    }
+}

--- a/NextJob/README.md
+++ b/NextJob/README.md
@@ -1,0 +1,23 @@
+# Next Job
+
+Next Job is an iOS 16+ accounting work tracker designed for part-time jobs received from KB Accountants.
+
+## Version 1.0.0 features
+
+- Dashboard for Not Started, In Progress, Waiting for Documents, Ready for Review and Completed jobs.
+- Assigned date, due date and completion date tracking.
+- Job price, target hours and actual hours.
+- Editable job types with default price and target time.
+- Client/reference, required-document checklist and work notes.
+- Source-document uploads and separate completed-work uploads.
+- Local file storage under the app's `Next Job Files` Documents folder.
+- Document request email drafts.
+- Standards-compatible ZIP package containing a job summary and all related files.
+- Completion email draft with the ZIP attached.
+- Share Sheet fallback when Apple Mail is not configured.
+- Light, dark and system appearance.
+- Local JSON persistence with no personal data included in the source or build.
+
+## Build
+
+The GitHub Actions workflow `.github/workflows/build-next-job.yml` generates the Xcode project with XcodeGen, builds an unsigned iPhone application and packages `NextJob-1.0.0.tipa` for TrollStore.

--- a/NextJob/project.yml
+++ b/NextJob/project.yml
@@ -1,0 +1,43 @@
+name: NextJob
+options:
+  bundleIdPrefix: com.nextsolution
+  deploymentTarget:
+    iOS: "16.0"
+  createIntermediateGroups: true
+settings:
+  base:
+    SWIFT_VERSION: "5.7"
+    IPHONEOS_DEPLOYMENT_TARGET: "16.0"
+    TARGETED_DEVICE_FAMILY: "1"
+    SUPPORTS_MACCATALYST: "NO"
+    CODE_SIGN_STYLE: Automatic
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+targets:
+  NextJob:
+    type: application
+    platform: iOS
+    sources:
+      - path: App
+    info:
+      path: App/Info.plist
+      properties:
+        CFBundleDisplayName: Next Job
+        CFBundleName: Next Job
+        CFBundleShortVersionString: "1.0.0"
+        CFBundleVersion: "1"
+        LSRequiresIPhoneOS: true
+        LSSupportsOpeningDocumentsInPlace: true
+        UIFileSharingEnabled: true
+        UIApplicationSupportsIndirectInputEvents: true
+        UILaunchScreen: {}
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.nextsolution.nextjob
+        PRODUCT_NAME: Next Job
+        GENERATE_INFOPLIST_FILE: "NO"
+    scheme:
+      shared: true
+      gatherCoverageData: false


### PR DESCRIPTION
## What changed
- Added the new iOS 16+ **Next Job** app in `NextJob/`.
- Added job status tracking, assigned/due/completion dates, prices, target and actual hours.
- Added editable job types with default price and target time.
- Added source-document and completed-work file storage and preview.
- Added job ZIP generation, document-request email drafts, and completion emails with ZIP attachments.
- Added light, dark, and system themes.
- Added a GitHub Actions workflow to build an unsigned TrollStore TIPA.

## Safety
- `main` remains unchanged.
- No user jobs, personal transactions, API keys, or private files are included in the source or build.
- The KB Accountants recipient email is entered by the user in Settings.

## Validation
- GitHub Actions run `30033026268` completed successfully.
- Xcode project generation, unsigned iPhone build, TrollStore packaging, and artifact upload all passed.
- Artifact: `NextJob-TrollStore`
- TIPA: `NextJob-1.0.0.tipa`
- TIPA SHA-256: `a7e1c2642533ee81891da64a5cd9b66563fab9fc094463d98ad30eef53f023f4`
- Verified bundle ID: `com.nextsolution.nextjob`
- Verified minimum iOS: `16.0`