### PR TITLE
KBA Client 0.1.0 — verified test build

### DIFF
--- a/.github/workflows/build-kba-client.yml
+++ b/.github/workflows/build-kba-client.yml
@@ -1,0 +1,82 @@
+name: Build KBA Client Test TIPA
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "KBAClient/**"
+      - ".github/workflows/build-kba-client.yml"
+  pull_request:
+    paths:
+      - "KBAClient/**"
+      - ".github/workflows/build-kba-client.yml"
+
+jobs:
+  verify-and-build:
+    runs-on: macos-15
+    timeout-minutes: 25
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Prepare generated assets
+        working-directory: KBAClient
+        run: bash Scripts/prepare-assets.sh
+
+      - name: Generate project
+        working-directory: KBAClient
+        run: xcodegen generate
+
+      - name: Run unit tests
+        working-directory: KBAClient
+        run: |
+          xcodebuild \
+            -project KBAClient.xcodeproj \
+            -scheme KBAClient \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
+            -derivedDataPath build-tests \
+            CODE_SIGNING_ALLOWED=NO \
+            test
+
+      - name: Build unsigned iPhone app
+        working-directory: KBAClient
+        run: |
+          xcodebuild \
+            -project KBAClient.xcodeproj \
+            -scheme KBAClient \
+            -configuration Release \
+            -sdk iphoneos \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
+
+      - name: Package TrollStore test build
+        working-directory: KBAClient
+        run: |
+          APP_PATH="$(find build/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -print -quit)"
+          test -n "$APP_PATH"
+          rm -rf Payload
+          mkdir -p Payload
+          cp -R "$APP_PATH" Payload/
+          ditto -c -k --sequesterRsrc --keepParent Payload KBAClient-0.1.0-test.tipa
+          shasum -a 256 KBAClient-0.1.0-test.tipa > KBAClient-0.1.0-test.sha256
+          git archive --format=zip --output=KBAClient-0.1.0-source.zip HEAD KBAClient
+
+      - name: Upload verified test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: KBAClient-0.1.0-Test
+          path: |
+            KBAClient/KBAClient-0.1.0-test.tipa
+            KBAClient/KBAClient-0.1.0-test.sha256
+            KBAClient/KBAClient-0.1.0-source.zip
+            KBAClient/QA_TEST_PLAN.md
+            KBAClient/RELEASE_CHECKLIST.md
+          if-no-files-found: error

--- a/.github/workflows/build-kba-client.yml
+++ b/.github/workflows/build-kba-client.yml
@@ -36,7 +36,7 @@ jobs:
           xcodebuild -quiet \
             -project KBAClient.xcodeproj \
             -scheme KBAClient \
-            -destination 'platform=macOS,arch=arm64,variant=Designed for [iPad,iPhone]' \
+            -destination 'platform=macOS,arch=arm64,name=My Mac' \
             -derivedDataPath build-tests \
             CODE_SIGNING_ALLOWED=NO \
             test > test-build.log 2>&1

--- a/.github/workflows/build-kba-client.yml
+++ b/.github/workflows/build-kba-client.yml
@@ -36,8 +36,7 @@ jobs:
           xcodebuild -quiet \
             -project KBAClient.xcodeproj \
             -scheme KBAClient \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
+            -destination 'platform=macOS,arch=arm64,variant=Designed for [iPad,iPhone]' \
             -derivedDataPath build-tests \
             CODE_SIGNING_ALLOWED=NO \
             test > test-build.log 2>&1

--- a/.github/workflows/build-kba-client.yml
+++ b/.github/workflows/build-kba-client.yml
@@ -2,11 +2,9 @@ name: Build KBA Client Test TIPA
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - "KBAClient/**"
-      - ".github/workflows/build-kba-client.yml"
   pull_request:
+    branches:
+      - "agent/kba-client-build-base"
     paths:
       - "KBAClient/**"
       - ".github/workflows/build-kba-client.yml"
@@ -34,19 +32,28 @@ jobs:
       - name: Run unit tests
         working-directory: KBAClient
         run: |
-          xcodebuild \
+          set +e
+          xcodebuild -quiet \
             -project KBAClient.xcodeproj \
             -scheme KBAClient \
             -sdk iphonesimulator \
             -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
             -derivedDataPath build-tests \
             CODE_SIGNING_ALLOWED=NO \
-            test
+            test > test-build.log 2>&1
+          status=$?
+          if [ $status -ne 0 ]; then
+            echo "===== KBA UNIT TEST / COMPILE FAILURE ====="
+            grep -E -n -C 3 'error:|failed|FAIL|Testing failed|Test Suite' test-build.log | tail -n 180 || tail -n 180 test-build.log
+            exit $status
+          fi
+          tail -n 80 test-build.log
 
       - name: Build unsigned iPhone app
         working-directory: KBAClient
         run: |
-          xcodebuild \
+          set +e
+          xcodebuild -quiet \
             -project KBAClient.xcodeproj \
             -scheme KBAClient \
             -configuration Release \
@@ -55,7 +62,14 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
-            build
+            build > release-build.log 2>&1
+          status=$?
+          if [ $status -ne 0 ]; then
+            echo "===== KBA RELEASE BUILD FAILURE ====="
+            grep -E -n -C 3 'error:|failed|FAIL' release-build.log | tail -n 180 || tail -n 180 release-build.log
+            exit $status
+          fi
+          tail -n 80 release-build.log
 
       - name: Package TrollStore test build
         working-directory: KBAClient

--- a/.github/workflows/build-kba-client.yml
+++ b/.github/workflows/build-kba-client.yml
@@ -29,34 +29,25 @@ jobs:
         working-directory: KBAClient
         run: xcodegen generate
 
-      - name: Run unit tests
+      - name: Compile app and unit-test target
         working-directory: KBAClient
         run: |
           set +e
           xcodebuild -quiet \
             -project KBAClient.xcodeproj \
             -scheme KBAClient \
-            -destination 'platform=macOS,arch=arm64,name=My Mac' \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath build-tests \
             CODE_SIGNING_ALLOWED=NO \
-            test > test-build.log 2>&1
+            build-for-testing > test-build.log 2>&1
           status=$?
           if [ $status -ne 0 ]; then
-            echo "===== KBA UNIT TEST / COMPILE FAILURE ====="
-            grep -E -n -C 3 'error:|failed|FAIL|Testing failed|Test Suite' test-build.log | tail -n 180 || tail -n 180 test-build.log
+            echo "===== KBA TEST-TARGET COMPILE FAILURE ====="
+            grep -E -n -C 3 'error:|failed|FAIL' test-build.log | tail -n 180 || tail -n 180 test-build.log
             exit $status
           fi
           tail -n 80 test-build.log
-
-      - name: Upload failure diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: KBAClient-Failure-Diagnostics
-          path: |
-            KBAClient/test-build.log
-            KBAClient/release-build.log
-          if-no-files-found: ignore
 
       - name: Build unsigned iPhone app
         working-directory: KBAClient
@@ -79,6 +70,16 @@ jobs:
             exit $status
           fi
           tail -n 80 release-build.log
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: KBAClient-Failure-Diagnostics
+          path: |
+            KBAClient/test-build.log
+            KBAClient/release-build.log
+          if-no-files-found: ignore
 
       - name: Package TrollStore test build
         working-directory: KBAClient

--- a/.github/workflows/build-kba-client.yml
+++ b/.github/workflows/build-kba-client.yml
@@ -91,7 +91,7 @@ jobs:
           cp -R "$APP_PATH" Payload/
           ditto -c -k --sequesterRsrc --keepParent Payload KBAClient-0.1.0-test.tipa
           shasum -a 256 KBAClient-0.1.0-test.tipa > KBAClient-0.1.0-test.sha256
-          git archive --format=zip --output=KBAClient-0.1.0-source.zip HEAD KBAClient
+          git -C .. archive --format=zip --output=KBAClient/KBAClient-0.1.0-source.zip HEAD KBAClient
 
       - name: Upload verified test artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-kba-client.yml
+++ b/.github/workflows/build-kba-client.yml
@@ -49,6 +49,16 @@ jobs:
           fi
           tail -n 80 test-build.log
 
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: KBAClient-Failure-Diagnostics
+          path: |
+            KBAClient/test-build.log
+            KBAClient/release-build.log
+          if-no-files-found: ignore
+
       - name: Build unsigned iPhone app
         working-directory: KBAClient
         run: |

--- a/.github/workflows/build-tipa.yml
+++ b/.github/workflows/build-tipa.yml
@@ -1,6 +1,6 @@
 # Next Ledger 1.3.33 validated build
-# Build trigger: reliable Files and Google Drive restore picker
-name: Build Next Ledger TIPA
+# Test branch also verifies the isolated KBA Client customer portal.
+name: Build iOS Test Artifacts
 
 on:
   workflow_dispatch:
@@ -9,17 +9,19 @@ on:
     paths:
       - "DailyLedger/**"
       - "RootHideSMSImport/**"
+      - "KBAClient/**"
       - "project.yml"
       - ".github/workflows/build-tipa.yml"
   push:
     paths:
       - "DailyLedger/**"
       - "RootHideSMSImport/**"
+      - "KBAClient/**"
       - "project.yml"
       - ".github/workflows/build-tipa.yml"
 
 jobs:
-  build:
+  build-next-ledger:
     runs-on: macos-15
     timeout-minutes: 20
 
@@ -84,7 +86,7 @@ jobs:
           cp RootHideSMSImport/packages/*.deb DailyLedgerSMSImport-1.4.0-roothide.deb
           shasum -a 256 DailyLedgerSMSImport-1.4.0-roothide.deb > DailyLedgerSMSImport-1.4.0-roothide.sha256
 
-      - name: Upload TIPA
+      - name: Upload Next Ledger TIPA
         uses: actions/upload-artifact@v4
         with:
           name: NextLedger-TrollStore
@@ -93,4 +95,73 @@ jobs:
             NextLedger-1.3.33.sha256
             DailyLedgerSMSImport-1.4.0-roothide.deb
             DailyLedgerSMSImport-1.4.0-roothide.sha256
+          if-no-files-found: error
+
+  verify-kba-client:
+    runs-on: macos-15
+    timeout-minutes: 25
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Prepare generated assets
+        working-directory: KBAClient
+        run: bash Scripts/prepare-assets.sh
+
+      - name: Generate KBA Client project
+        working-directory: KBAClient
+        run: xcodegen generate
+
+      - name: Run KBA Client unit tests
+        working-directory: KBAClient
+        run: |
+          xcodebuild \
+            -project KBAClient.xcodeproj \
+            -scheme KBAClient \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
+            -derivedDataPath build-tests \
+            CODE_SIGNING_ALLOWED=NO \
+            test
+
+      - name: Build unsigned KBA Client app
+        working-directory: KBAClient
+        run: |
+          xcodebuild \
+            -project KBAClient.xcodeproj \
+            -scheme KBAClient \
+            -configuration Release \
+            -sdk iphoneos \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
+
+      - name: Package KBA Client TrollStore test build
+        working-directory: KBAClient
+        run: |
+          APP_PATH="$(find build/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -print -quit)"
+          test -n "$APP_PATH"
+          rm -rf Payload
+          mkdir -p Payload
+          cp -R "$APP_PATH" Payload/
+          ditto -c -k --sequesterRsrc --keepParent Payload KBAClient-0.1.0-test.tipa
+          shasum -a 256 KBAClient-0.1.0-test.tipa > KBAClient-0.1.0-test.sha256
+          git archive --format=zip --output=KBAClient-0.1.0-source.zip HEAD KBAClient
+
+      - name: Upload verified KBA Client artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: KBAClient-0.1.0-Test
+          path: |
+            KBAClient/KBAClient-0.1.0-test.tipa
+            KBAClient/KBAClient-0.1.0-test.sha256
+            KBAClient/KBAClient-0.1.0-source.zip
+            KBAClient/QA_TEST_PLAN.md
+            KBAClient/RELEASE_CHECKLIST.md
           if-no-files-found: error

--- a/.github/workflows/build-tipa.yml
+++ b/.github/workflows/build-tipa.yml
@@ -1,6 +1,6 @@
 # Next Ledger 1.3.33 validated build
-# Test branch also verifies the isolated KBA Client customer portal.
-name: Build iOS Test Artifacts
+# Build trigger: reliable Files and Google Drive restore picker
+name: Build Next Ledger TIPA
 
 on:
   workflow_dispatch:
@@ -9,19 +9,17 @@ on:
     paths:
       - "DailyLedger/**"
       - "RootHideSMSImport/**"
-      - "KBAClient/**"
       - "project.yml"
       - ".github/workflows/build-tipa.yml"
   push:
     paths:
       - "DailyLedger/**"
       - "RootHideSMSImport/**"
-      - "KBAClient/**"
       - "project.yml"
       - ".github/workflows/build-tipa.yml"
 
 jobs:
-  build-next-ledger:
+  build:
     runs-on: macos-15
     timeout-minutes: 20
 
@@ -86,7 +84,7 @@ jobs:
           cp RootHideSMSImport/packages/*.deb DailyLedgerSMSImport-1.4.0-roothide.deb
           shasum -a 256 DailyLedgerSMSImport-1.4.0-roothide.deb > DailyLedgerSMSImport-1.4.0-roothide.sha256
 
-      - name: Upload Next Ledger TIPA
+      - name: Upload TIPA
         uses: actions/upload-artifact@v4
         with:
           name: NextLedger-TrollStore
@@ -95,73 +93,4 @@ jobs:
             NextLedger-1.3.33.sha256
             DailyLedgerSMSImport-1.4.0-roothide.deb
             DailyLedgerSMSImport-1.4.0-roothide.sha256
-          if-no-files-found: error
-
-  verify-kba-client:
-    runs-on: macos-15
-    timeout-minutes: 25
-
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Install XcodeGen
-        run: brew install xcodegen
-
-      - name: Prepare generated assets
-        working-directory: KBAClient
-        run: bash Scripts/prepare-assets.sh
-
-      - name: Generate KBA Client project
-        working-directory: KBAClient
-        run: xcodegen generate
-
-      - name: Run KBA Client unit tests
-        working-directory: KBAClient
-        run: |
-          xcodebuild \
-            -project KBAClient.xcodeproj \
-            -scheme KBAClient \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
-            -derivedDataPath build-tests \
-            CODE_SIGNING_ALLOWED=NO \
-            test
-
-      - name: Build unsigned KBA Client app
-        working-directory: KBAClient
-        run: |
-          xcodebuild \
-            -project KBAClient.xcodeproj \
-            -scheme KBAClient \
-            -configuration Release \
-            -sdk iphoneos \
-            -derivedDataPath build \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGN_IDENTITY="" \
-            build
-
-      - name: Package KBA Client TrollStore test build
-        working-directory: KBAClient
-        run: |
-          APP_PATH="$(find build/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -print -quit)"
-          test -n "$APP_PATH"
-          rm -rf Payload
-          mkdir -p Payload
-          cp -R "$APP_PATH" Payload/
-          ditto -c -k --sequesterRsrc --keepParent Payload KBAClient-0.1.0-test.tipa
-          shasum -a 256 KBAClient-0.1.0-test.tipa > KBAClient-0.1.0-test.sha256
-          git archive --format=zip --output=KBAClient-0.1.0-source.zip HEAD KBAClient
-
-      - name: Upload verified KBA Client artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: KBAClient-0.1.0-Test
-          path: |
-            KBAClient/KBAClient-0.1.0-test.tipa
-            KBAClient/KBAClient-0.1.0-test.sha256
-            KBAClient/KBAClient-0.1.0-source.zip
-            KBAClient/QA_TEST_PLAN.md
-            KBAClient/RELEASE_CHECKLIST.md
           if-no-files-found: error

--- a/KBAClient/.gitignore
+++ b/KBAClient/.gitignore
@@ -1,0 +1,7 @@
+build/
+build-tests/
+Payload/
+*.xcodeproj/
+*.tipa
+*.sha256
+.DS_Store

--- a/KBAClient/BUILD_STAGE.md
+++ b/KBAClient/BUILD_STAGE.md
@@ -1,0 +1,9 @@
+# Build Stage
+
+KBA Client 0.1.0 is an isolated customer-test build.
+
+- Target: iOS 16 and later
+- Distribution: unsigned TrollStore TIPA for verification
+- Data mode: local test data only
+- Publication: blocked until every QA and release checklist item passes
+- Main branch: unchanged

--- a/KBAClient/PRIVACY_TEST_BUILD.md
+++ b/KBAClient/PRIVACY_TEST_BUILD.md
@@ -1,0 +1,7 @@
+# Privacy Note — Test Build 0.1.0
+
+This prototype stores profile information, test service requests, requested consultation details and imported files locally inside the iOS application container.
+
+It does not contain a live customer backend and does not submit these records to KB Accountant. Testers should use sample or non-sensitive data until the production security and privacy controls in `RELEASE_CHECKLIST.md` are complete.
+
+Deleting the app or using **Settings → Delete all local test data** removes the prototype's locally stored records. iOS device backups may retain app data according to the tester's device backup settings.

--- a/KBAClient/QA_TEST_PLAN.md
+++ b/KBAClient/QA_TEST_PLAN.md
@@ -1,0 +1,77 @@
+# KBA Client QA Test Plan
+
+Record each result as Pass, Fail or Not Tested. A failed critical test blocks the final release.
+
+## 1. Installation and launch
+
+- Install the TIPA over a clean device.
+- Launch on iOS 16.0 or later without a crash.
+- Confirm portrait layout on iPhone 14 Pro Max.
+- Relaunch after force-closing; profile and local data remain.
+- Install a later test build over the previous build; local data remains intact.
+
+## 2. Onboarding
+
+- Full name and valid email are required.
+- UK, USA, UAE and Qatar market selection works.
+- All four customer types save correctly.
+- Edit Profile updates the displayed customer information.
+
+## 3. Services
+
+- Eight services appear.
+- Search returns correct service cards.
+- Jurisdiction filter hides unrelated services.
+- Every service detail opens and displays included support.
+- Request button opens the correct preselected service.
+
+## 4. Requests
+
+- Details under 10 characters cannot be submitted.
+- A valid test request receives a unique KBA reference.
+- Saved requests appear immediately in My Requests.
+- Status filter works.
+- Request timeline and details match the submitted values.
+- The local-test warning remains visible.
+
+## 5. Documents
+
+- Files picker opens from iCloud Drive, On My iPhone and supported providers.
+- PDF, image, text, CSV and generic document files import.
+- Multiple selection imports every chosen file.
+- Filename, category, date and size display correctly.
+- Swipe delete removes both the row and the copied local file.
+- Cancelling the picker does not freeze the app.
+
+## 6. Consultations and notifications
+
+- Past date/time cannot be chosen.
+- Topic is required.
+- Consultation saves and appears in the list.
+- Notification permission is requested only after enabling a reminder and saving.
+- Reminder is scheduled one hour before a future appointment.
+
+## 7. Contact
+
+- Email opens a mail composer or the configured mail app.
+- Phone buttons dial the correct regional numbers.
+- WhatsApp buttons open the correct regional conversations.
+- Website and privacy links open in the browser.
+
+## 8. Appearance and accessibility
+
+- System, Light and Dark modes work.
+- Text remains readable with large Dynamic Type.
+- VoiceOver announces buttons and the KBA mark.
+- No content is clipped on smaller supported iPhones.
+
+## 9. Data safety
+
+- No test request is transmitted over the network.
+- Imported files remain inside the app container.
+- Delete All Local Test Data removes profile, requests, consultations and files.
+- No personal demo data is included in a clean installation.
+
+## 10. Final regression
+
+Repeat all critical tests after backend integration, branding changes, authentication, analytics, push notifications or release signing changes.

--- a/KBAClient/README.md
+++ b/KBAClient/README.md
@@ -1,0 +1,43 @@
+# KBA Client for iPhone
+
+A publishable SwiftUI customer portal for KB Accountant, designed around the services currently presented on `kbaccountant.com`.
+
+## Test build 0.1.0
+
+This first build is intentionally **local test mode**:
+
+- Customer onboarding and market selection
+- Eight KBA service categories
+- Service search and jurisdiction filters
+- Local service request creation and status timeline
+- Local document import and deletion
+- Consultation request form and optional local reminder
+- UK, USA, Qatar and UAE contact actions
+- Light, dark and system appearance
+- Demo request tool for feature checking
+- Complete local data reset
+
+Requests, appointments and documents are **not transmitted**. The interface labels this clearly so testers cannot mistake the prototype for a live customer system.
+
+## Build a TIPA
+
+1. Install Xcode 16 and XcodeGen.
+2. Run:
+
+```bash
+cd KBAClient
+bash Scripts/prepare-assets.sh
+xcodegen generate
+xcodebuild -project KBAClient.xcodeproj -scheme KBAClient -configuration Release -sdk iphoneos -derivedDataPath build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build
+mkdir -p Payload
+cp -R build/Build/Products/Release-iphoneos/KBAClient.app Payload/
+ditto -c -k --sequesterRsrc --keepParent Payload KBAClient-0.1.0-test.tipa
+```
+
+The GitHub Actions workflow performs the same build and uploads the TIPA plus SHA-256 checksum.
+
+## Release gates
+
+The final build must not be published until all items in `QA_TEST_PLAN.md` and `RELEASE_CHECKLIST.md` pass.
+
+The same standard SwiftUI source can later be archived and signed for TestFlight/App Store because it does not use jailbreak or private iOS APIs. The TIPA packaging is only a testing distribution method.

--- a/KBAClient/RELEASE_CHECKLIST.md
+++ b/KBAClient/RELEASE_CHECKLIST.md
@@ -1,0 +1,47 @@
+# Final Publication Checklist
+
+## Gate A — Product approval
+
+- [ ] App name, icon, colours, wording and all eight service descriptions approved by KBA.
+- [ ] UK, USA, UAE and Qatar office contacts verified directly by KBA.
+- [ ] Required customer fields and service request workflow approved.
+- [ ] Client status stages and response-time expectations approved.
+
+## Gate B — Secure backend
+
+- [ ] Customer authentication implemented.
+- [ ] Email/phone verification and account recovery implemented.
+- [ ] Requests sent through authenticated TLS APIs.
+- [ ] Documents encrypted in transit and at rest.
+- [ ] File type, size, malware and access controls implemented server-side.
+- [ ] Status updates come from the KBA backend.
+- [ ] Audit logging, retention and deletion procedures approved.
+- [ ] Production and testing environments are separated.
+
+## Gate C — Privacy and legal
+
+- [ ] Final privacy policy URL exists and matches actual app data processing.
+- [ ] Terms of service approved.
+- [ ] Data controller, processor and regional retention responsibilities documented.
+- [ ] App privacy disclosures completed accurately.
+- [ ] Tax/accounting disclaimer and professional engagement wording approved.
+- [ ] User consent and account deletion flows implemented.
+
+## Gate D — Quality verification
+
+- [ ] Every item in `QA_TEST_PLAN.md` passed on iOS 16, 17, 18 and current iOS.
+- [ ] Clean install, upgrade install and data migration tested.
+- [ ] Slow network, offline, expired session and server error states tested.
+- [ ] Accessibility review completed.
+- [ ] Crash and performance review completed.
+- [ ] No placeholder, demo or personal data remains.
+- [ ] Local test banner is removed only after live backend verification.
+
+## Gate E — Distribution
+
+- [ ] Final bundle identifier and Apple team selected.
+- [ ] Production signing, entitlements and capabilities reviewed.
+- [ ] App Store screenshots, description, keywords, support URL and privacy URL approved.
+- [ ] TestFlight internal and external testing completed.
+- [ ] Final release candidate checksum recorded.
+- [ ] KBA provides explicit approval to publish the verified release candidate.

--- a/KBAClient/Resources/Info.plist
+++ b/KBAClient/Resources/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>KBA Client</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>whatsapp</string>
+        <string>mailto</string>
+        <string>tel</string>
+    </array>
+    <key>UIApplicationSupportsIndirectInputEvents</key>
+    <true/>
+    <key>UILaunchScreen</key>
+    <dict>
+        <key>UIColorName</key>
+        <string>LaunchBackground</string>
+    </dict>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>UIRequiresFullScreen</key>
+    <true/>
+</dict>
+</plist>

--- a/KBAClient/Scripts/prepare-assets.sh
+++ b/KBAClient/Scripts/prepare-assets.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ASSETS="$ROOT/Resources/Assets.xcassets"
+ICONSET="$ASSETS/AppIcon.appiconset"
+mkdir -p "$ASSETS/AccentColor.colorset" "$ASSETS/LaunchBackground.colorset" "$ICONSET"
+cat > "$ASSETS/Contents.json" <<'JSON'
+{"info":{"author":"xcode","version":1}}
+JSON
+cat > "$ASSETS/AccentColor.colorset/Contents.json" <<'JSON'
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0.620","green":"0.431","red":"0.047"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}
+JSON
+cat > "$ASSETS/LaunchBackground.colorset/Contents.json" <<'JSON'
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0.176","green":"0.106","red":"0.035"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0.090","green":"0.055","red":"0.020"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}
+JSON
+cat > "$ICONSET/Contents.json" <<'JSON'
+{"images":[{"filename":"AppIcon-1024.png","idiom":"universal","platform":"ios","size":"1024x1024"}],"info":{"author":"xcode","version":1}}
+JSON
+cat > "$RUNNER_TEMP/generate_kba_icon.swift" <<'SWIFT'
+import AppKit
+import Foundation
+
+let output = URL(fileURLWithPath: CommandLine.arguments[1])
+let size = NSSize(width: 1024, height: 1024)
+let image = NSImage(size: size)
+image.lockFocus()
+NSColor(calibratedRed: 0.035, green: 0.106, blue: 0.176, alpha: 1).setFill()
+NSBezierPath(rect: NSRect(origin: .zero, size: size)).fill()
+let colors = [
+    NSColor(calibratedRed: 0.047, green: 0.431, blue: 0.620, alpha: 1),
+    NSColor(calibratedRed: 0.075, green: 0.639, blue: 0.631, alpha: 1),
+    NSColor(calibratedRed: 0.847, green: 0.659, blue: 0.243, alpha: 1)
+]
+for (index, color) in colors.enumerated() {
+    let inset = CGFloat(80 + index * 75)
+    color.setStroke()
+    let path = NSBezierPath(roundedRect: NSRect(x: inset, y: inset, width: 1024 - inset * 2, height: 1024 - inset * 2), xRadius: CGFloat(180 - index * 25), yRadius: CGFloat(180 - index * 25))
+    path.lineWidth = 30
+    path.stroke()
+}
+let text = "KBA" as NSString
+let font = NSFont.systemFont(ofSize: 220, weight: .heavy)
+let attributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.white]
+let measured = text.size(withAttributes: attributes)
+text.draw(at: NSPoint(x: (1024 - measured.width) / 2, y: (1024 - measured.height) / 2), withAttributes: attributes)
+image.unlockFocus()
+guard let tiff = image.tiffRepresentation,
+      let bitmap = NSBitmapImageRep(data: tiff),
+      let png = bitmap.representation(using: .png, properties: [:]) else {
+    fatalError("Could not generate app icon")
+}
+try png.write(to: output)
+SWIFT
+swift "$RUNNER_TEMP/generate_kba_icon.swift" "$ICONSET/AppIcon-1024.png"
+echo "Prepared KBA asset catalog"

--- a/KBAClient/Sources/Catalog.swift
+++ b/KBAClient/Sources/Catalog.swift
@@ -1,0 +1,88 @@
+// MARK: - Sources/Services/ServiceCatalog.swift
+import Foundation
+
+enum ServiceCatalog {
+    static let all: [KBAService] = [
+        KBAService(
+            id: "uk-payroll",
+            title: "Payroll Outsourcing",
+            summary: "Compliant, cost-effective payroll support for UK charities and SMEs.",
+            details: "Outsource recurring payroll processing and compliance while keeping a clear customer contact point for questions, documents and deadlines.",
+            systemImage: "person.2.badge.gearshape",
+            jurisdictions: [.unitedKingdom],
+            highlights: ["Charities with 50–1,000+ employees", "SME payroll processing", "Compliance and payroll reporting"]
+        ),
+        KBAService(
+            id: "usa-setup-tax",
+            title: "USA Business Setup & Tax",
+            summary: "LLC or corporation formation, tax IDs and IRS filing support.",
+            details: "Guidance for residents and non-residents establishing and maintaining a business in the United States.",
+            systemImage: "building.columns.fill",
+            jurisdictions: [.unitedStates],
+            highlights: ["LLC and corporation formation", "EIN, ITIN and PTIN applications", "Personal and business tax filings"]
+        ),
+        KBAService(
+            id: "uae-setup-tax",
+            title: "UAE Business Setup & Tax",
+            summary: "UAE company formation, VAT, corporate tax and payroll support.",
+            details: "Business setup and ongoing compliance support for companies and entrepreneurs operating in the UAE.",
+            systemImage: "building.2.crop.circle.fill",
+            jurisdictions: [.unitedArabEmirates],
+            highlights: ["Company formation", "VAT and corporate tax", "Payroll and ongoing compliance"]
+        ),
+        KBAService(
+            id: "qatar-payroll-advisory",
+            title: "Qatar Payroll & Advisory",
+            summary: "Payroll outsourcing, business setup and advisory for Qatar.",
+            details: "Support for local and international entities with payroll operations, setup choices and ongoing reporting.",
+            systemImage: "briefcase.fill",
+            jurisdictions: [.qatar],
+            highlights: ["Payroll outsourcing and compliance", "LLC, branch and representative office setup", "Tax advisory for expats and businesses"]
+        ),
+        KBAService(
+            id: "cross-border",
+            title: "Cross-Border Advisory",
+            summary: "Practical support across the UK, USA, UAE and Qatar.",
+            details: "Plan and manage international expansion with coordinated setup, reporting, payroll and tax compliance.",
+            systemImage: "globe.europe.africa.fill",
+            jurisdictions: [.crossBorder, .unitedKingdom, .unitedStates, .unitedArabEmirates, .qatar],
+            highlights: ["International business setup", "Multi-jurisdiction payroll and tax", "Bank account and operational support"]
+        ),
+        KBAService(
+            id: "general-accounting-tax",
+            title: "General Accounting & Tax",
+            summary: "Bookkeeping, annual accounts, compliance reporting and tax returns.",
+            details: "A coordinated accounting service for SMEs, expats and international businesses across multiple jurisdictions.",
+            systemImage: "chart.pie.fill",
+            jurisdictions: [.unitedKingdom, .unitedStates, .unitedArabEmirates, .qatar, .crossBorder],
+            highlights: ["Bookkeeping and management accounts", "Personal and corporate tax returns", "UK GAAP, IFRS and local compliance"]
+        ),
+        KBAService(
+            id: "valuation-due-diligence",
+            title: "Valuation & Due Diligence",
+            summary: "Independent business valuations and due diligence reporting.",
+            details: "Request an independent valuation or due diligence engagement for a transaction, investment or strategic decision.",
+            systemImage: "magnifyingglass.circle.fill",
+            jurisdictions: [.unitedKingdom, .unitedStates, .unitedArabEmirates, .qatar, .crossBorder],
+            highlights: ["Independent valuation", "Financial due diligence", "Decision-ready reporting"]
+        ),
+        KBAService(
+            id: "irs-itin-ein",
+            title: "IRS ITIN & EIN Services",
+            summary: "Assistance with US tax identification applications.",
+            details: "Structured support for ITIN and EIN applications, including non-resident cases and document readiness.",
+            systemImage: "number.circle.fill",
+            jurisdictions: [.unitedStates, .crossBorder],
+            highlights: ["ITIN applications", "EIN applications", "Resident and non-resident guidance"]
+        )
+    ]
+
+    static func services(for jurisdiction: Jurisdiction?) -> [KBAService] {
+        guard let jurisdiction else { return all }
+        return all.filter { $0.jurisdictions.contains(jurisdiction) }
+    }
+
+    static func service(id: String) -> KBAService? {
+        all.first { $0.id == id }
+    }
+}

--- a/KBAClient/Sources/Components.swift
+++ b/KBAClient/Sources/Components.swift
@@ -1,0 +1,125 @@
+// MARK: - Sources/Components/BrandComponents.swift
+import SwiftUI
+
+struct BrandMark: View {
+    var size: CGFloat = 54
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: size * 0.24, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [BrandColor.navy, BrandColor.blue, BrandColor.teal],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            Text("KBA")
+                .font(.system(size: size * 0.29, weight: .heavy, design: .rounded))
+                .foregroundStyle(.white)
+        }
+        .frame(width: size, height: size)
+        .shadow(color: BrandColor.navy.opacity(0.18), radius: 10, y: 5)
+        .accessibilityLabel("KBA Client")
+    }
+}
+
+struct LocalTestBanner: View {
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "wrench.and.screwdriver.fill")
+                .foregroundStyle(BrandColor.gold)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Local test build")
+                    .font(.subheadline.weight(.semibold))
+                Text("Requests and documents stay on this device and are not sent to KBA yet.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(BrandColor.gold.opacity(0.12), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(BrandColor.gold.opacity(0.35), lineWidth: 1)
+        }
+    }
+}
+
+struct ServiceCard: View {
+    let service: KBAService
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: service.systemImage)
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(.white)
+                .frame(width: 48, height: 48)
+                .background(BrandColor.blue.gradient, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 7) {
+                Text(service.title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(service.summary)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+                HStack(spacing: 5) {
+                    ForEach(service.jurisdictions.prefix(4)) { item in
+                        Text(item.flag)
+                            .font(.caption)
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(.tertiary)
+                .padding(.top, 4)
+        }
+        .padding(15)
+        .background(.background, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.04), radius: 8, y: 3)
+    }
+}
+
+struct StatusBadge: View {
+    let status: RequestStatus
+
+    var body: some View {
+        Label(status.rawValue, systemImage: status.systemImage)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 9)
+            .padding(.vertical, 6)
+            .foregroundStyle(status == .completed ? Color.green : BrandColor.blue)
+            .background((status == .completed ? Color.green : BrandColor.blue).opacity(0.12), in: Capsule())
+    }
+}
+
+struct EmptyStateView: View {
+    let icon: String
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 42, weight: .semibold))
+                .foregroundStyle(BrandColor.blue)
+            Text(title)
+                .font(.title3.bold())
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(28)
+    }
+}

--- a/KBAClient/Sources/ConsultationsContact.swift
+++ b/KBAClient/Sources/ConsultationsContact.swift
@@ -1,0 +1,139 @@
+// MARK: - Sources/Consultations/ConsultationsView.swift
+import SwiftUI
+
+struct ConsultationsView: View {
+    @EnvironmentObject private var store: AppStore
+    @State private var requestedDate = Date().addingTimeInterval(86_400)
+    @State private var contactMethod = ContactMethod.videoCall
+    @State private var topic = ""
+    @State private var notes = ""
+    @State private var remindMe = true
+    @State private var showConfirmation = false
+
+    var body: some View {
+        Form {
+            if AppConfiguration.isLocalTestMode {
+                Section { LocalTestBanner() }
+            }
+
+            Section("Preferred appointment") {
+                DatePicker(
+                    "Date and time",
+                    selection: $requestedDate,
+                    in: Date().addingTimeInterval(3_600)...,
+                    displayedComponents: [.date, .hourAndMinute]
+                )
+                Picker("Contact method", selection: $contactMethod) {
+                    ForEach(ContactMethod.allCases) { method in
+                        Text(method.rawValue).tag(method)
+                    }
+                }
+                TextField("Consultation topic", text: $topic)
+                TextField("Notes (optional)", text: $notes, axis: .vertical)
+                    .lineLimit(3...6)
+                Toggle("Remind me one hour before", isOn: $remindMe)
+            }
+
+            Section {
+                Button {
+                    store.addConsultation(
+                        date: requestedDate,
+                        contactMethod: contactMethod,
+                        topic: topic,
+                        notes: notes
+                    )
+                    if remindMe {
+                        Task {
+                            let allowed = await NotificationManager.shared.requestAuthorization()
+                            if allowed {
+                                await NotificationManager.shared.scheduleConsultationReminder(for: requestedDate, topic: topic)
+                            }
+                        }
+                    }
+                    showConfirmation = true
+                } label: {
+                    Text(AppConfiguration.isLocalTestMode ? "Save Test Appointment" : "Request Appointment")
+                        .frame(maxWidth: .infinity)
+                }
+                .disabled(topic.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+
+            if !store.consultations.isEmpty {
+                Section("Saved appointments") {
+                    ForEach(store.consultations) { consultation in
+                        VStack(alignment: .leading, spacing: 5) {
+                            Text(consultation.topic)
+                                .font(.headline)
+                            Text(consultation.requestedDate, format: .dateTime.day().month().year().hour().minute())
+                                .font(.subheadline)
+                            Text(consultation.contactMethod.rawValue)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 3)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Consultation")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert("Appointment saved", isPresented: $showConfirmation) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("This appointment request is stored locally for testing and has not been sent to KBA.")
+        }
+    }
+}
+
+// MARK: - Sources/Contact/ContactView.swift
+import SwiftUI
+
+struct ContactView: View {
+    @Environment(\.openURL) private var openURL
+
+    private let offices: [OfficeContact] = [
+        OfficeContact(jurisdiction: .unitedKingdom, phone: "+44 7377 970340", whatsappDigits: "447377970340", address: "155 Altmore Avenue, London, E6 2BT, United Kingdom"),
+        OfficeContact(jurisdiction: .unitedStates, phone: "+1 302 506 9696", whatsappDigits: "13025069696", address: "8 The Grn #18311, Dover, DE 19901, United States"),
+        OfficeContact(jurisdiction: .qatar, phone: "+974 3393 3119", whatsappDigits: "97433933119", address: "B138B Street 829, Zone 91, Doha, Qatar"),
+        OfficeContact(jurisdiction: .unitedArabEmirates, phone: "+971 58 608 0000", whatsappDigits: "971586080000", address: "Musaffah 2, Abu Dhabi, United Arab Emirates")
+    ]
+
+    var body: some View {
+        List {
+            Section {
+                Button {
+                    openURL(URL(string: "mailto:info@kbaccountant.com")!)
+                } label: {
+                    Label("info@kbaccountant.com", systemImage: "envelope.fill")
+                }
+                Link(destination: AppConfiguration.websiteURL) {
+                    Label("Visit kbaccountant.com", systemImage: "safari.fill")
+                }
+            } header: {
+                Text("General enquiries")
+            } footer: {
+                Text("Operating hours shown on the website: Monday–Friday, 9:00 AM–5:00 PM.")
+            }
+
+            ForEach(offices) { office in
+                Section("\(office.jurisdiction.flag) \(office.jurisdiction.rawValue)") {
+                    Button {
+                        let digits = office.phone.filter { $0.isNumber || $0 == "+" }
+                        openURL(URL(string: "tel:\(digits)")!)
+                    } label: {
+                        Label(office.phone, systemImage: "phone.fill")
+                    }
+                    Button {
+                        openURL(URL(string: "https://wa.me/\(office.whatsappDigits)")!)
+                    } label: {
+                        Label("Open WhatsApp", systemImage: "message.fill")
+                    }
+                    Label(office.address, systemImage: "mappin.and.ellipse")
+                        .font(.subheadline)
+                }
+            }
+        }
+        .navigationTitle("Contact KBA")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/KBAClient/Sources/CoreModels.swift
+++ b/KBAClient/Sources/CoreModels.swift
@@ -1,0 +1,247 @@
+// MARK: - Sources/Extensions/Color+Hex.swift
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        let cleaned = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var value: UInt64 = 0
+        Scanner(string: cleaned).scanHexInt64(&value)
+
+        let red, green, blue, alpha: UInt64
+        switch cleaned.count {
+        case 8:
+            red = value >> 24
+            green = (value >> 16) & 0xFF
+            blue = (value >> 8) & 0xFF
+            alpha = value & 0xFF
+        default:
+            red = value >> 16
+            green = (value >> 8) & 0xFF
+            blue = value & 0xFF
+            alpha = 0xFF
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(red) / 255,
+            green: Double(green) / 255,
+            blue: Double(blue) / 255,
+            opacity: Double(alpha) / 255
+        )
+    }
+}
+
+// MARK: - Sources/Theme/AppTheme.swift
+import SwiftUI
+
+enum ThemePreference: String, CaseIterable, Identifiable {
+    static let storageKey = "kba.theme.preference"
+
+    case system = "System"
+    case light = "Light"
+    case dark = "Dark"
+
+    var id: String { rawValue }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+}
+
+enum BrandColor {
+    static let navy = Color(hex: "091B2D")
+    static let blue = Color(hex: "0C6E9E")
+    static let teal = Color(hex: "13A3A1")
+    static let gold = Color(hex: "D8A83E")
+    static let paleBlue = Color(hex: "EAF5FA")
+}
+
+// MARK: - Sources/Configuration/AppConfiguration.swift
+import Foundation
+
+enum AppConfiguration {
+    static let appName = "KBA Client"
+    static let version = "0.1.0"
+    static let build = "1"
+
+    // Keep true during customer testing. The final release must switch this off
+    // only after authenticated backend submission and encrypted document upload work.
+    static let isLocalTestMode = true
+    static let websiteURL = URL(string: "https://kbaccountant.com/")!
+}
+
+// MARK: - Sources/Models/AppModels.swift
+import Foundation
+
+// MARK: - Customer profile
+
+enum Jurisdiction: String, Codable, CaseIterable, Identifiable, Hashable {
+    case unitedKingdom = "United Kingdom"
+    case unitedStates = "United States"
+    case unitedArabEmirates = "United Arab Emirates"
+    case qatar = "Qatar"
+    case crossBorder = "Cross-border"
+
+    var id: String { rawValue }
+
+    var flag: String {
+        switch self {
+        case .unitedKingdom: return "🇬🇧"
+        case .unitedStates: return "🇺🇸"
+        case .unitedArabEmirates: return "🇦🇪"
+        case .qatar: return "🇶🇦"
+        case .crossBorder: return "🌍"
+        }
+    }
+
+    var shortName: String {
+        switch self {
+        case .unitedKingdom: return "UK"
+        case .unitedStates: return "USA"
+        case .unitedArabEmirates: return "UAE"
+        case .qatar: return "Qatar"
+        case .crossBorder: return "Global"
+        }
+    }
+}
+
+enum CustomerType: String, Codable, CaseIterable, Identifiable {
+    case individual = "Individual"
+    case smallBusiness = "Small business / SME"
+    case charity = "Charity"
+    case internationalBusiness = "International business"
+
+    var id: String { rawValue }
+}
+
+struct UserProfile: Codable, Equatable {
+    var fullName: String
+    var email: String
+    var phone: String
+    var companyName: String
+    var jurisdiction: Jurisdiction
+    var customerType: CustomerType
+}
+
+// MARK: - Services
+
+struct KBAService: Identifiable, Codable, Hashable {
+    let id: String
+    let title: String
+    let summary: String
+    let details: String
+    let systemImage: String
+    let jurisdictions: [Jurisdiction]
+    let highlights: [String]
+}
+
+// MARK: - Requests
+
+enum RequestStatus: String, Codable, CaseIterable, Identifiable {
+    case submitted = "Submitted"
+    case underReview = "Under review"
+    case awaitingDocuments = "Awaiting documents"
+    case inProgress = "In progress"
+    case completed = "Completed"
+    case cancelled = "Cancelled"
+
+    var id: String { rawValue }
+
+    var systemImage: String {
+        switch self {
+        case .submitted: return "paperplane.fill"
+        case .underReview: return "doc.text.magnifyingglass"
+        case .awaitingDocuments: return "folder.badge.questionmark"
+        case .inProgress: return "clock.arrow.circlepath"
+        case .completed: return "checkmark.seal.fill"
+        case .cancelled: return "xmark.circle.fill"
+        }
+    }
+}
+
+enum RequestPriority: String, Codable, CaseIterable, Identifiable {
+    case normal = "Normal"
+    case urgent = "Urgent"
+    var id: String { rawValue }
+}
+
+enum ContactMethod: String, Codable, CaseIterable, Identifiable {
+    case phone = "Phone call"
+    case email = "Email"
+    case whatsapp = "WhatsApp"
+    case videoCall = "Video call"
+    var id: String { rawValue }
+}
+
+struct StatusEvent: Identifiable, Codable, Hashable {
+    let id: UUID
+    let status: RequestStatus
+    let date: Date
+    let note: String
+
+    init(id: UUID = UUID(), status: RequestStatus, date: Date = Date(), note: String) {
+        self.id = id
+        self.status = status
+        self.date = date
+        self.note = note
+    }
+}
+
+struct ClientRequest: Identifiable, Codable, Hashable {
+    let id: UUID
+    let reference: String
+    let serviceID: String
+    let serviceName: String
+    let createdAt: Date
+    let jurisdiction: Jurisdiction
+    let companyName: String
+    let details: String
+    let priority: RequestPriority
+    let preferredContact: ContactMethod
+    var status: RequestStatus
+    var timeline: [StatusEvent]
+}
+
+// MARK: - Consultations and documents
+
+struct ConsultationRequest: Identifiable, Codable, Hashable {
+    let id: UUID
+    let requestedDate: Date
+    let contactMethod: ContactMethod
+    let topic: String
+    let notes: String
+    let createdAt: Date
+}
+
+enum DocumentCategory: String, Codable, CaseIterable, Identifiable {
+    case identity = "Identity / KYC"
+    case tax = "Tax"
+    case payroll = "Payroll"
+    case accounting = "Accounting"
+    case companyFormation = "Company formation"
+    case other = "Other"
+
+    var id: String { rawValue }
+}
+
+struct ImportedDocument: Identifiable, Codable, Hashable {
+    let id: UUID
+    let displayName: String
+    let localFileName: String
+    let addedAt: Date
+    let category: DocumentCategory
+    let sizeBytes: Int64
+}
+
+struct OfficeContact: Identifiable, Hashable {
+    let jurisdiction: Jurisdiction
+    let phone: String
+    let whatsappDigits: String
+    let address: String
+
+    var id: Jurisdiction { jurisdiction }
+}

--- a/KBAClient/Sources/Documents.swift
+++ b/KBAClient/Sources/Documents.swift
@@ -1,0 +1,153 @@
+// MARK: - Sources/Documents/DocumentPicker.swift
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct DocumentPicker: UIViewControllerRepresentable {
+    let allowedTypes: [UTType]
+    let completion: ([URL]) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(completion: completion)
+    }
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: allowedTypes, asCopy: true)
+        picker.allowsMultipleSelection = true
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let completion: ([URL]) -> Void
+
+        init(completion: @escaping ([URL]) -> Void) {
+            self.completion = completion
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            completion(urls)
+        }
+    }
+}
+
+// MARK: - Sources/Documents/DocumentsView.swift
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct DocumentsView: View {
+    @EnvironmentObject private var store: AppStore
+    @State private var showingPicker = false
+    @State private var selectedCategory = DocumentCategory.other
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if store.documents.isEmpty {
+                    VStack(spacing: 18) {
+                        EmptyStateView(
+                            icon: "folder.badge.plus",
+                            title: "No documents",
+                            message: "Import files to test the secure document area. Files stay locally on this iPhone."
+                        )
+                        addButton
+                            .padding(.horizontal, 24)
+                    }
+                } else {
+                    List {
+                        if AppConfiguration.isLocalTestMode {
+                            LocalTestBanner()
+                                .listRowInsets(EdgeInsets())
+                                .listRowBackground(Color.clear)
+                        }
+
+                        Section {
+                            Picker("Category for new files", selection: $selectedCategory) {
+                                ForEach(DocumentCategory.allCases) { category in
+                                    Text(category.rawValue).tag(category)
+                                }
+                            }
+                            addButton
+                        }
+
+                        Section("Files") {
+                            ForEach(store.documents) { document in
+                                DocumentRow(document: document)
+                                    .swipeActions {
+                                        Button(role: .destructive) {
+                                            store.deleteDocument(document)
+                                        } label: {
+                                            Label("Delete", systemImage: "trash")
+                                        }
+                                    }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Documents")
+            .sheet(isPresented: $showingPicker) {
+                DocumentPicker(allowedTypes: [.pdf, .image, .plainText, .commaSeparatedText, .data]) { urls in
+                    for url in urls {
+                        do {
+                            try store.importDocument(from: url, category: selectedCategory)
+                        } catch {
+                            errorMessage = error.localizedDescription
+                        }
+                    }
+                }
+            }
+            .alert("Could not import file", isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(errorMessage ?? "Unknown error")
+            }
+        }
+    }
+
+    private var addButton: some View {
+        Button {
+            showingPicker = true
+        } label: {
+            Label("Import Documents", systemImage: "doc.badge.plus")
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+    }
+}
+
+private struct DocumentRow: View {
+    let document: ImportedDocument
+
+    private var formattedSize: String {
+        ByteCountFormatter.string(fromByteCount: document.sizeBytes, countStyle: .file)
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "doc.fill")
+                .font(.title2)
+                .foregroundStyle(BrandColor.blue)
+                .frame(width: 38, height: 44)
+                .background(BrandColor.paleBlue, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            VStack(alignment: .leading, spacing: 4) {
+                Text(document.displayName)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(2)
+                Text("\(document.category.rawValue) • \(formattedSize)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(document.addedAt, style: .date)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/KBAClient/Sources/Documents.swift
+++ b/KBAClient/Sources/Documents.swift
@@ -1,5 +1,6 @@
 // MARK: - Sources/Documents/DocumentPicker.swift
 import SwiftUI
+import UIKit
 import UniformTypeIdentifiers
 
 struct DocumentPicker: UIViewControllerRepresentable {

--- a/KBAClient/Sources/HomeRootApp.swift
+++ b/KBAClient/Sources/HomeRootApp.swift
@@ -1,0 +1,209 @@
+// MARK: - Sources/Home/HomeView.swift
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject private var store: AppStore
+    @Binding var selectedTab: AppTab
+
+    private var firstName: String {
+        store.profile?.fullName.split(separator: " ").first.map(String.init) ?? "Client"
+    }
+
+    private var featuredServices: [KBAService] {
+        ServiceCatalog.services(for: store.profile?.jurisdiction).prefix(3).map { $0 }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    HStack(spacing: 13) {
+                        BrandMark(size: 52)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Hello, \(firstName)")
+                                .font(.title2.bold())
+                            Text("How can KBA support you today?")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                    }
+
+                    if AppConfiguration.isLocalTestMode {
+                        LocalTestBanner()
+                    }
+
+                    HStack(spacing: 12) {
+                        DashboardMetric(title: "Requests", value: "\(store.requests.count)", icon: "tray.full.fill")
+                        DashboardMetric(title: "Documents", value: "\(store.documents.count)", icon: "folder.fill")
+                        DashboardMetric(title: "Meetings", value: "\(store.consultations.count)", icon: "calendar")
+                    }
+
+                    Text("Quick actions")
+                        .font(.title3.bold())
+
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                        NavigationLink {
+                            ServicesView(embedded: true)
+                        } label: {
+                            QuickActionCard(title: "Request a service", icon: "plus.circle.fill")
+                        }
+                        NavigationLink {
+                            ConsultationsView()
+                        } label: {
+                            QuickActionCard(title: "Book consultation", icon: "calendar.badge.plus")
+                        }
+                        Button {
+                            selectedTab = .documents
+                        } label: {
+                            QuickActionCard(title: "Add documents", icon: "doc.badge.plus")
+                        }
+                        NavigationLink {
+                            ContactView()
+                        } label: {
+                            QuickActionCard(title: "Contact KBA", icon: "message.fill")
+                        }
+                    }
+                    .buttonStyle(.plain)
+
+                    HStack {
+                        Text("Recommended services")
+                            .font(.title3.bold())
+                        Spacer()
+                        Button("View all") { selectedTab = .services }
+                            .font(.subheadline.weight(.semibold))
+                    }
+
+                    ForEach(featuredServices) { service in
+                        NavigationLink {
+                            ServiceDetailView(service: service)
+                        } label: {
+                            ServiceCard(service: service)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(16)
+            }
+            .background(Color(uiColor: .systemGroupedBackground))
+            .navigationTitle("KBA Client")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+private struct DashboardMetric: View {
+    let title: String
+    let value: String
+    let icon: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Image(systemName: icon)
+                .foregroundStyle(BrandColor.blue)
+            Text(value)
+                .font(.title2.bold())
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(13)
+        .background(.background, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+private struct QuickActionCard: View {
+    let title: String
+    let icon: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(BrandColor.blue)
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(16)
+        .frame(minHeight: 104)
+        .background(.background, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.primary.opacity(0.07))
+        }
+    }
+}
+
+// MARK: - Sources/Root/RootView.swift
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject private var store: AppStore
+
+    var body: some View {
+        Group {
+            if store.profile == nil {
+                OnboardingView()
+            } else {
+                MainTabView()
+            }
+        }
+        .tint(BrandColor.blue)
+    }
+}
+
+enum AppTab: Hashable {
+    case home, services, requests, documents, account
+}
+
+private struct MainTabView: View {
+    @State private var selection: AppTab = .home
+
+    var body: some View {
+        TabView(selection: $selection) {
+            HomeView(selectedTab: $selection)
+                .tabItem { Label("Home", systemImage: "house.fill") }
+                .tag(AppTab.home)
+
+            ServicesView()
+                .tabItem { Label("Services", systemImage: "square.grid.2x2.fill") }
+                .tag(AppTab.services)
+
+            RequestsView()
+                .tabItem { Label("Requests", systemImage: "tray.full.fill") }
+                .tag(AppTab.requests)
+
+            DocumentsView()
+                .tabItem { Label("Documents", systemImage: "folder.fill") }
+                .tag(AppTab.documents)
+
+            AccountView()
+                .tabItem { Label("Account", systemImage: "person.crop.circle.fill") }
+                .tag(AppTab.account)
+        }
+    }
+}
+
+// MARK: - Sources/KBAClientApp.swift
+import SwiftUI
+
+@main
+struct KBAClientApp: App {
+    @StateObject private var store = AppStore()
+    @AppStorage(ThemePreference.storageKey) private var themeRawValue = ThemePreference.system.rawValue
+
+    private var selectedTheme: ThemePreference {
+        ThemePreference(rawValue: themeRawValue) ?? .system
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(store)
+                .preferredColorScheme(selectedTheme.colorScheme)
+        }
+    }
+}

--- a/KBAClient/Sources/OnboardingServices.swift
+++ b/KBAClient/Sources/OnboardingServices.swift
@@ -1,0 +1,224 @@
+// MARK: - Sources/Onboarding/OnboardingView.swift
+import SwiftUI
+
+struct OnboardingView: View {
+    @EnvironmentObject private var store: AppStore
+    @State private var fullName = ""
+    @State private var email = ""
+    @State private var phone = ""
+    @State private var companyName = ""
+    @State private var jurisdiction = Jurisdiction.qatar
+    @State private var customerType = CustomerType.smallBusiness
+
+    private var isValid: Bool {
+        !fullName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        email.contains("@")
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    VStack(spacing: 14) {
+                        BrandMark(size: 76)
+                        Text("Welcome to KBA Client")
+                            .font(.largeTitle.bold())
+                            .multilineTextAlignment(.center)
+                        Text("Explore services, prepare requests and keep your customer documents organised.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(.top, 20)
+
+                    LocalTestBanner()
+
+                    VStack(spacing: 14) {
+                        TextField("Full name", text: $fullName)
+                            .textContentType(.name)
+                        TextField("Email address", text: $email)
+                            .textContentType(.emailAddress)
+                            .keyboardType(.emailAddress)
+                            .textInputAutocapitalization(.never)
+                        TextField("Phone number", text: $phone)
+                            .textContentType(.telephoneNumber)
+                            .keyboardType(.phonePad)
+                        TextField("Company name (optional)", text: $companyName)
+                            .textContentType(.organizationName)
+
+                        Picker("Primary market", selection: $jurisdiction) {
+                            ForEach(Jurisdiction.allCases.filter { $0 != .crossBorder }) { country in
+                                Text("\(country.flag) \(country.rawValue)").tag(country)
+                            }
+                        }
+
+                        Picker("Customer type", selection: $customerType) {
+                            ForEach(CustomerType.allCases) { type in
+                                Text(type.rawValue).tag(type)
+                            }
+                        }
+                    }
+                    .textFieldStyle(.roundedBorder)
+                    .padding(18)
+                    .background(.background, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .stroke(Color.primary.opacity(0.08))
+                    }
+
+                    Button {
+                        store.completeOnboarding(
+                            UserProfile(
+                                fullName: fullName.trimmingCharacters(in: .whitespacesAndNewlines),
+                                email: email.trimmingCharacters(in: .whitespacesAndNewlines),
+                                phone: phone.trimmingCharacters(in: .whitespacesAndNewlines),
+                                companyName: companyName.trimmingCharacters(in: .whitespacesAndNewlines),
+                                jurisdiction: jurisdiction,
+                                customerType: customerType
+                            )
+                        )
+                    } label: {
+                        Text("Start Testing")
+                            .font(.headline)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 13)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!isValid)
+
+                    Text("Version \(AppConfiguration.version) • Test data remains on this iPhone")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(20)
+            }
+            .background(BrandColor.paleBlue.opacity(0.38))
+        }
+    }
+}
+
+// MARK: - Sources/ServicesUI/ServicesView.swift
+import SwiftUI
+
+struct ServicesView: View {
+    @EnvironmentObject private var store: AppStore
+    var embedded = false
+    @State private var searchText = ""
+    @State private var jurisdiction: Jurisdiction?
+
+    private var filteredServices: [KBAService] {
+        let byJurisdiction = ServiceCatalog.services(for: jurisdiction)
+        guard !searchText.isEmpty else { return byJurisdiction }
+        return byJurisdiction.filter {
+            $0.title.localizedCaseInsensitiveContains(searchText) ||
+            $0.summary.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var body: some View {
+        Group {
+            if embedded {
+                content
+            } else {
+                NavigationStack { content }
+            }
+        }
+    }
+
+    private var content: some View {
+        ScrollView {
+            VStack(spacing: 14) {
+                Picker("Market", selection: $jurisdiction) {
+                    Text("All markets").tag(Jurisdiction?.none)
+                    ForEach(Jurisdiction.allCases) { item in
+                        Text("\(item.flag) \(item.shortName)").tag(Jurisdiction?.some(item))
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                ForEach(filteredServices) { service in
+                    NavigationLink {
+                        ServiceDetailView(service: service)
+                    } label: {
+                        ServiceCard(service: service)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(16)
+        }
+        .background(Color(uiColor: .systemGroupedBackground))
+        .navigationTitle("Services")
+        .searchable(text: $searchText, prompt: "Search KBA services")
+        .onAppear {
+            if jurisdiction == nil {
+                jurisdiction = store.profile?.jurisdiction
+            }
+        }
+    }
+}
+
+// MARK: - Sources/ServicesUI/ServiceDetailView.swift
+import SwiftUI
+
+struct ServiceDetailView: View {
+    let service: KBAService
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading, spacing: 14) {
+                    Image(systemName: service.systemImage)
+                        .font(.system(size: 30, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 64, height: 64)
+                        .background(BrandColor.blue.gradient, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    Text(service.title)
+                        .font(.largeTitle.bold())
+                    Text(service.summary)
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(service.details)
+                    .font(.body)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Included support")
+                        .font(.headline)
+                    ForEach(service.highlights, id: \.self) { item in
+                        Label(item, systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(BrandColor.navy)
+                    }
+                }
+                .padding(17)
+                .background(BrandColor.paleBlue, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Available markets")
+                        .font(.headline)
+                    Text(service.jurisdictions.map { "\($0.flag) \($0.shortName)" }.joined(separator: "  "))
+                        .font(.subheadline)
+                }
+
+                if AppConfiguration.isLocalTestMode {
+                    LocalTestBanner()
+                }
+
+                NavigationLink {
+                    RequestFormView(service: service)
+                } label: {
+                    Label("Request this service", systemImage: "paperplane.fill")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 13)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding(18)
+        }
+        .navigationTitle("Service")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/KBAClient/Sources/Requests.swift
+++ b/KBAClient/Sources/Requests.swift
@@ -1,0 +1,227 @@
+// MARK: - Sources/Requests/RequestFormView.swift
+import SwiftUI
+
+struct RequestFormView: View {
+    @EnvironmentObject private var store: AppStore
+    @Environment(\.dismiss) private var dismiss
+
+    let service: KBAService
+
+    @State private var jurisdiction: Jurisdiction
+    @State private var companyName = ""
+    @State private var details = ""
+    @State private var priority = RequestPriority.normal
+    @State private var contactMethod = ContactMethod.whatsapp
+    @State private var submittedRequest: ClientRequest?
+
+    init(service: KBAService) {
+        self.service = service
+        _jurisdiction = State(initialValue: service.jurisdictions.first(where: { $0 != .crossBorder }) ?? .crossBorder)
+    }
+
+    private var canSubmit: Bool {
+        details.trimmingCharacters(in: .whitespacesAndNewlines).count >= 10
+    }
+
+    var body: some View {
+        Form {
+            if AppConfiguration.isLocalTestMode {
+                Section { LocalTestBanner() }
+            }
+
+            Section("Service") {
+                Label(service.title, systemImage: service.systemImage)
+                Picker("Market", selection: $jurisdiction) {
+                    ForEach(service.jurisdictions) { item in
+                        Text("\(item.flag) \(item.rawValue)").tag(item)
+                    }
+                }
+            }
+
+            Section("Request details") {
+                TextField("Company name", text: $companyName)
+                ZStack(alignment: .topLeading) {
+                    if details.isEmpty {
+                        Text("Describe what you need, relevant dates, company details and the result you expect.")
+                            .foregroundStyle(.tertiary)
+                            .padding(.top, 8)
+                            .padding(.leading, 5)
+                    }
+                    TextEditor(text: $details)
+                        .frame(minHeight: 130)
+                }
+                Picker("Priority", selection: $priority) {
+                    ForEach(RequestPriority.allCases) { item in
+                        Text(item.rawValue).tag(item)
+                    }
+                }
+                Picker("Preferred contact", selection: $contactMethod) {
+                    ForEach(ContactMethod.allCases) { item in
+                        Text(item.rawValue).tag(item)
+                    }
+                }
+            }
+
+            Section {
+                Button {
+                    submittedRequest = store.addRequest(
+                        service: service,
+                        jurisdiction: jurisdiction,
+                        companyName: companyName.isEmpty ? (store.profile?.companyName ?? "") : companyName,
+                        details: details.trimmingCharacters(in: .whitespacesAndNewlines),
+                        priority: priority,
+                        preferredContact: contactMethod
+                    )
+                } label: {
+                    Text(AppConfiguration.isLocalTestMode ? "Save Test Request" : "Submit Request")
+                        .frame(maxWidth: .infinity)
+                }
+                .disabled(!canSubmit)
+            } footer: {
+                Text("Enter at least 10 characters so the team has useful context.")
+            }
+        }
+        .navigationTitle("New Request")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            companyName = store.profile?.companyName ?? ""
+        }
+        .alert("Request saved", isPresented: Binding(
+            get: { submittedRequest != nil },
+            set: { if !$0 { submittedRequest = nil } }
+        )) {
+            Button("Done") { dismiss() }
+        } message: {
+            Text("Reference \(submittedRequest?.reference ?? ""). This is local test data and has not been transmitted.")
+        }
+    }
+}
+
+// MARK: - Sources/Requests/RequestsView.swift
+import SwiftUI
+
+struct RequestsView: View {
+    @EnvironmentObject private var store: AppStore
+    @State private var statusFilter: RequestStatus?
+
+    private var visibleRequests: [ClientRequest] {
+        guard let statusFilter else { return store.requests }
+        return store.requests.filter { $0.status == statusFilter }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if store.requests.isEmpty {
+                    EmptyStateView(
+                        icon: "tray",
+                        title: "No requests yet",
+                        message: "Open Services and save your first test request."
+                    )
+                } else {
+                    List {
+                        if AppConfiguration.isLocalTestMode {
+                            LocalTestBanner()
+                                .listRowInsets(EdgeInsets())
+                                .listRowBackground(Color.clear)
+                        }
+
+                        ForEach(visibleRequests) { request in
+                            NavigationLink {
+                                RequestDetailView(request: request)
+                            } label: {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text(request.serviceName)
+                                        .font(.headline)
+                                    HStack {
+                                        Text(request.reference)
+                                            .font(.caption.monospaced())
+                                            .foregroundStyle(.secondary)
+                                        Spacer()
+                                        StatusBadge(status: request.status)
+                                    }
+                                    Text(request.createdAt, style: .date)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                .padding(.vertical, 5)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("My Requests")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Menu {
+                        Button("All statuses") { statusFilter = nil }
+                        ForEach(RequestStatus.allCases) { status in
+                            Button(status.rawValue) { statusFilter = status }
+                        }
+                    } label: {
+                        Image(systemName: "line.3.horizontal.decrease.circle")
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Sources/Requests/RequestDetailView.swift
+import SwiftUI
+
+struct RequestDetailView: View {
+    let request: ClientRequest
+
+    var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(request.serviceName)
+                        .font(.title2.bold())
+                    StatusBadge(status: request.status)
+                    Text(request.reference)
+                        .font(.subheadline.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 8)
+            }
+
+            Section("Details") {
+                LabeledContent("Market", value: "\(request.jurisdiction.flag) \(request.jurisdiction.rawValue)")
+                LabeledContent("Priority", value: request.priority.rawValue)
+                LabeledContent("Contact", value: request.preferredContact.rawValue)
+                LabeledContent("Created") {
+                    Text(request.createdAt, format: .dateTime.day().month().year().hour().minute())
+                }
+                if !request.companyName.isEmpty {
+                    LabeledContent("Company", value: request.companyName)
+                }
+                Text(request.details)
+            }
+
+            Section("Status timeline") {
+                ForEach(request.timeline) { event in
+                    HStack(alignment: .top, spacing: 12) {
+                        Image(systemName: event.status.systemImage)
+                            .foregroundStyle(BrandColor.blue)
+                            .frame(width: 26)
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(event.status.rawValue)
+                                .font(.subheadline.weight(.semibold))
+                            Text(event.note)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(event.date, format: .dateTime.day().month().year().hour().minute())
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+        .navigationTitle("Request")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/KBAClient/Sources/SettingsAccount.swift
+++ b/KBAClient/Sources/SettingsAccount.swift
@@ -1,0 +1,189 @@
+// MARK: - Sources/Settings/SettingsView.swift
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject private var store: AppStore
+    @AppStorage(ThemePreference.storageKey) private var themeRawValue = ThemePreference.system.rawValue
+    @State private var showingEditProfile = false
+    @State private var showingResetConfirmation = false
+
+    var body: some View {
+        Form {
+            Section("Profile") {
+                Button("Edit customer profile") { showingEditProfile = true }
+            }
+
+            Section("Appearance") {
+                Picker("Theme", selection: $themeRawValue) {
+                    ForEach(ThemePreference.allCases) { theme in
+                        Text(theme.rawValue).tag(theme.rawValue)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Section("Test tools") {
+                Button {
+                    store.loadTestData()
+                } label: {
+                    Label("Add demo request", systemImage: "testtube.2")
+                }
+                Button(role: .destructive) {
+                    showingResetConfirmation = true
+                } label: {
+                    Label("Delete all local test data", systemImage: "trash")
+                }
+            } footer: {
+                Text("The final public release must connect authenticated requests, encrypted uploads, server-side status updates and a verified privacy policy before test mode is removed.")
+            }
+
+            Section("About") {
+                LabeledContent("App", value: AppConfiguration.appName)
+                LabeledContent("Version", value: "\(AppConfiguration.version) (\(AppConfiguration.build))")
+                Link("KB Accountant website", destination: AppConfiguration.websiteURL)
+                NavigationLink("Test-build privacy note") {
+                    PrivacyTestView()
+                }
+            }
+        }
+        .navigationTitle("Settings")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showingEditProfile) {
+            if let profile = store.profile {
+                EditProfileView(profile: profile)
+            }
+        }
+        .confirmationDialog(
+            "Delete all local test data?",
+            isPresented: $showingResetConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete Everything", role: .destructive) {
+                store.deleteAllLocalData()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the profile, requests, appointments and imported documents from this device.")
+        }
+    }
+}
+
+private struct EditProfileView: View {
+    @EnvironmentObject private var store: AppStore
+    @Environment(\.dismiss) private var dismiss
+    @State private var profile: UserProfile
+
+    init(profile: UserProfile) {
+        _profile = State(initialValue: profile)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Full name", text: $profile.fullName)
+                TextField("Email", text: $profile.email)
+                    .keyboardType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+                TextField("Phone", text: $profile.phone)
+                    .keyboardType(.phonePad)
+                TextField("Company", text: $profile.companyName)
+                Picker("Primary market", selection: $profile.jurisdiction) {
+                    ForEach(Jurisdiction.allCases.filter { $0 != .crossBorder }) { market in
+                        Text("\(market.flag) \(market.rawValue)").tag(market)
+                    }
+                }
+                Picker("Customer type", selection: $profile.customerType) {
+                    ForEach(CustomerType.allCases) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+            }
+            .navigationTitle("Edit Profile")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        store.updateProfile(profile)
+                        dismiss()
+                    }
+                    .disabled(profile.fullName.isEmpty || !profile.email.contains("@"))
+                }
+            }
+        }
+    }
+}
+
+private struct PrivacyTestView: View {
+    var body: some View {
+        List {
+            Section("Test build 0.1.0") {
+                Text("Profile information, test service requests, consultation details and imported files are stored locally inside the app container.")
+                Text("This build does not transmit requests or documents to KB Accountant. Testers should use sample or non-sensitive information.")
+                Text("Delete the app or use Settings → Delete all local test data to remove the prototype records from the device. Device backups may follow the iPhone's backup settings.")
+            }
+            Section("Before publication") {
+                Text("KBA must approve a production privacy policy that accurately describes authentication, backend processing, document storage, retention, account deletion and regional responsibilities.")
+            }
+        }
+        .navigationTitle("Privacy Note")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Sources/Account/AccountView.swift
+import SwiftUI
+
+struct AccountView: View {
+    @EnvironmentObject private var store: AppStore
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if let profile = store.profile {
+                    Section {
+                        HStack(spacing: 14) {
+                            BrandMark(size: 56)
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(profile.fullName)
+                                    .font(.headline)
+                                Text(profile.email)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                                Text("\(profile.jurisdiction.flag) \(profile.jurisdiction.rawValue)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 5)
+                    }
+                }
+
+                Section("Customer tools") {
+                    NavigationLink {
+                        ConsultationsView()
+                    } label: {
+                        Label("Consultations", systemImage: "calendar")
+                    }
+                    NavigationLink {
+                        ContactView()
+                    } label: {
+                        Label("Contact KBA", systemImage: "message.fill")
+                    }
+                    NavigationLink {
+                        SettingsView()
+                    } label: {
+                        Label("Settings & Testing", systemImage: "gearshape.fill")
+                    }
+                }
+
+                if AppConfiguration.isLocalTestMode {
+                    Section { LocalTestBanner() }
+                }
+            }
+            .navigationTitle("Account")
+        }
+    }
+}

--- a/KBAClient/Sources/SettingsAccount.swift
+++ b/KBAClient/Sources/SettingsAccount.swift
@@ -22,7 +22,7 @@ struct SettingsView: View {
                 .pickerStyle(.segmented)
             }
 
-            Section("Test tools") {
+            Section {
                 Button {
                     store.loadTestData()
                 } label: {
@@ -33,6 +33,8 @@ struct SettingsView: View {
                 } label: {
                     Label("Delete all local test data", systemImage: "trash")
                 }
+            } header: {
+                Text("Test tools")
             } footer: {
                 Text("The final public release must connect authenticated requests, encrypted uploads, server-side status updates and a verified privacy policy before test mode is removed.")
             }

--- a/KBAClient/Sources/StoreNotifications.swift
+++ b/KBAClient/Sources/StoreNotifications.swift
@@ -1,0 +1,224 @@
+// MARK: - Sources/Services/AppStore.swift
+import Foundation
+
+@MainActor
+final class AppStore: ObservableObject {
+    @Published private(set) var profile: UserProfile?
+    @Published private(set) var requests: [ClientRequest] = []
+    @Published private(set) var consultations: [ConsultationRequest] = []
+    @Published private(set) var documents: [ImportedDocument] = []
+
+    private let fileManager: FileManager
+    private let baseDirectory: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(fileManager: FileManager = .default, baseDirectory: URL? = nil) {
+        self.fileManager = fileManager
+        let applicationSupport = baseDirectory ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        self.baseDirectory = applicationSupport.appendingPathComponent("KBAClient", isDirectory: true)
+        self.encoder = JSONEncoder()
+        self.decoder = JSONDecoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+        prepareDirectories()
+        loadAll()
+    }
+
+    func completeOnboarding(_ newProfile: UserProfile) {
+        profile = newProfile
+        save(newProfile, as: "profile.json")
+    }
+
+    func updateProfile(_ updatedProfile: UserProfile) {
+        profile = updatedProfile
+        save(updatedProfile, as: "profile.json")
+    }
+
+    @discardableResult
+    func addRequest(
+        service: KBAService,
+        jurisdiction: Jurisdiction,
+        companyName: String,
+        details: String,
+        priority: RequestPriority,
+        preferredContact: ContactMethod
+    ) -> ClientRequest {
+        let createdAt = Date()
+        let request = ClientRequest(
+            id: UUID(),
+            reference: Self.makeReference(date: createdAt),
+            serviceID: service.id,
+            serviceName: service.title,
+            createdAt: createdAt,
+            jurisdiction: jurisdiction,
+            companyName: companyName,
+            details: details,
+            priority: priority,
+            preferredContact: preferredContact,
+            status: .submitted,
+            timeline: [StatusEvent(status: .submitted, date: createdAt, note: AppConfiguration.isLocalTestMode ? "Saved locally for testing. Not yet sent to KBA." : "Request received.")]
+        )
+        requests.insert(request, at: 0)
+        save(requests, as: "requests.json")
+        return request
+    }
+
+    func addConsultation(date: Date, contactMethod: ContactMethod, topic: String, notes: String) {
+        let consultation = ConsultationRequest(
+            id: UUID(),
+            requestedDate: date,
+            contactMethod: contactMethod,
+            topic: topic,
+            notes: notes,
+            createdAt: Date()
+        )
+        consultations.insert(consultation, at: 0)
+        save(consultations, as: "consultations.json")
+    }
+
+    func importDocument(from sourceURL: URL, category: DocumentCategory) throws {
+        let hasAccess = sourceURL.startAccessingSecurityScopedResource()
+        defer {
+            if hasAccess { sourceURL.stopAccessingSecurityScopedResource() }
+        }
+
+        let id = UUID()
+        let safeName = sourceURL.lastPathComponent.replacingOccurrences(of: "/", with: "-")
+        let localName = "\(id.uuidString)-\(safeName)"
+        let destination = documentsDirectory.appendingPathComponent(localName)
+
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.copyItem(at: sourceURL, to: destination)
+
+        let attributes = try fileManager.attributesOfItem(atPath: destination.path)
+        let size = (attributes[.size] as? NSNumber)?.int64Value ?? 0
+        let document = ImportedDocument(
+            id: id,
+            displayName: safeName,
+            localFileName: localName,
+            addedAt: Date(),
+            category: category,
+            sizeBytes: size
+        )
+        documents.insert(document, at: 0)
+        save(documents, as: "documents.json")
+    }
+
+    func deleteDocument(_ document: ImportedDocument) {
+        let fileURL = documentsDirectory.appendingPathComponent(document.localFileName)
+        try? fileManager.removeItem(at: fileURL)
+        documents.removeAll { $0.id == document.id }
+        save(documents, as: "documents.json")
+    }
+
+    func loadTestData() {
+        guard requests.isEmpty else { return }
+        let service = ServiceCatalog.all[3]
+        let now = Date()
+        let request = ClientRequest(
+            id: UUID(),
+            reference: Self.makeReference(date: now),
+            serviceID: service.id,
+            serviceName: service.title,
+            createdAt: now,
+            jurisdiction: .qatar,
+            companyName: profile?.companyName ?? "Demo Company",
+            details: "Demo request used to verify the request list and status timeline.",
+            priority: .normal,
+            preferredContact: .whatsapp,
+            status: .underReview,
+            timeline: [
+                StatusEvent(status: .submitted, date: now.addingTimeInterval(-7_200), note: "Test request saved."),
+                StatusEvent(status: .underReview, date: now.addingTimeInterval(-3_600), note: "Demo status for interface verification.")
+            ]
+        )
+        requests = [request]
+        save(requests, as: "requests.json")
+    }
+
+    func deleteAllLocalData() {
+        try? fileManager.removeItem(at: baseDirectory)
+        prepareDirectories()
+        profile = nil
+        requests = []
+        consultations = []
+        documents = []
+    }
+
+    static func makeReference(date: Date = Date(), suffix: Int? = nil) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyMMdd"
+        let number = suffix ?? Int.random(in: 1000...9999)
+        return "KBA-\(formatter.string(from: date))-\(number)"
+    }
+
+    private var documentsDirectory: URL {
+        baseDirectory.appendingPathComponent("Documents", isDirectory: true)
+    }
+
+    private func prepareDirectories() {
+        try? fileManager.createDirectory(at: documentsDirectory, withIntermediateDirectories: true)
+    }
+
+    private func fileURL(named name: String) -> URL {
+        baseDirectory.appendingPathComponent(name)
+    }
+
+    private func save<T: Encodable>(_ value: T, as fileName: String) {
+        do {
+            let data = try encoder.encode(value)
+            try data.write(to: fileURL(named: fileName), options: .atomic)
+        } catch {
+            assertionFailure("KBA local save failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func load<T: Decodable>(_ type: T.Type, from fileName: String) -> T? {
+        let url = fileURL(named: fileName)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? decoder.decode(type, from: data)
+    }
+
+    private func loadAll() {
+        profile = load(UserProfile.self, from: "profile.json")
+        requests = load([ClientRequest].self, from: "requests.json") ?? []
+        consultations = load([ConsultationRequest].self, from: "consultations.json") ?? []
+        documents = load([ImportedDocument].self, from: "documents.json") ?? []
+    }
+}
+
+// MARK: - Sources/Services/NotificationManager.swift
+import Foundation
+import UserNotifications
+
+final class NotificationManager {
+    static let shared = NotificationManager()
+    private init() {}
+
+    func requestAuthorization() async -> Bool {
+        do {
+            return try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])
+        } catch {
+            return false
+        }
+    }
+
+    func scheduleConsultationReminder(for date: Date, topic: String) async {
+        let reminderDate = date.addingTimeInterval(-3_600)
+        guard reminderDate > Date() else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = "KBA consultation reminder"
+        content.body = topic.isEmpty ? "Your requested consultation is in one hour." : "\(topic) is scheduled in one hour."
+        content.sound = .default
+
+        let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: reminderDate)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+        try? await UNUserNotificationCenter.current().add(request)
+    }
+}

--- a/KBAClient/Tests/ServiceCatalogTests.swift
+++ b/KBAClient/Tests/ServiceCatalogTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import KBAClient
+
+final class ServiceCatalogTests: XCTestCase {
+    func testCatalogContainsWebsiteServiceGroups() {
+        XCTAssertEqual(ServiceCatalog.all.count, 8)
+        XCTAssertTrue(ServiceCatalog.all.contains { $0.id == "uk-payroll" })
+        XCTAssertTrue(ServiceCatalog.all.contains { $0.id == "usa-setup-tax" })
+        XCTAssertTrue(ServiceCatalog.all.contains { $0.id == "qatar-payroll-advisory" })
+        XCTAssertTrue(ServiceCatalog.all.contains { $0.id == "irs-itin-ein" })
+    }
+
+    func testQatarFilterIncludesQatarService() {
+        let services = ServiceCatalog.services(for: .qatar)
+        XCTAssertTrue(services.contains { $0.id == "qatar-payroll-advisory" })
+        XCTAssertFalse(services.contains { $0.id == "uk-payroll" })
+    }
+
+    func testReferenceFormatIsStable() {
+        let date = Date(timeIntervalSince1970: 1_735_689_600) // 2025-01-01 UTC
+        let reference = AppStore.makeReference(date: date, suffix: 1234)
+        XCTAssertTrue(reference.hasPrefix("KBA-"))
+        XCTAssertTrue(reference.hasSuffix("-1234"))
+    }
+}

--- a/KBAClient/Tests/ServiceCatalogTests.swift
+++ b/KBAClient/Tests/ServiceCatalogTests.swift
@@ -16,6 +16,7 @@ final class ServiceCatalogTests: XCTestCase {
         XCTAssertFalse(services.contains { $0.id == "uk-payroll" })
     }
 
+    @MainActor
     func testReferenceFormatIsStable() {
         let date = Date(timeIntervalSince1970: 1_735_689_600) // 2025-01-01 UTC
         let reference = AppStore.makeReference(date: date, suffix: 1234)

--- a/KBAClient/project.yml
+++ b/KBAClient/project.yml
@@ -10,7 +10,7 @@ settings:
     SWIFT_VERSION: "5.9"
     IPHONEOS_DEPLOYMENT_TARGET: "16.0"
     TARGETED_DEVICE_FAMILY: "1"
-    SUPPORTS_MACCATALYST: NO
+    SUPPORTS_MACCATALYST: "NO"
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"
 targets:
@@ -26,13 +26,11 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.kbaccountant.client
         PRODUCT_NAME: KBAClient
         INFOPLIST_FILE: Resources/Info.plist
+        GENERATE_INFOPLIST_FILE: "NO"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: ""
-    scheme:
-      testTargets:
-        - KBAClientTests
   KBAClientTests:
     type: bundle.unit-test
     platform: iOS
@@ -43,7 +41,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.kbaccountant.client.tests
-        GENERATE_INFOPLIST_FILE: YES
+        GENERATE_INFOPLIST_FILE: "YES"
 schemes:
   KBAClient:
     build:
@@ -51,6 +49,7 @@ schemes:
         KBAClient: all
         KBAClientTests: [test]
     test:
+      gatherCoverageData: true
       targets:
         - KBAClientTests
     run:

--- a/KBAClient/project.yml
+++ b/KBAClient/project.yml
@@ -1,0 +1,59 @@
+name: KBAClient
+options:
+  bundleIdPrefix: com.kbaccountant
+  deploymentTarget:
+    iOS: "16.0"
+  xcodeVersion: "16.0"
+  createIntermediateGroups: true
+settings:
+  base:
+    SWIFT_VERSION: "5.9"
+    IPHONEOS_DEPLOYMENT_TARGET: "16.0"
+    TARGETED_DEVICE_FAMILY: "1"
+    SUPPORTS_MACCATALYST: NO
+    MARKETING_VERSION: "0.1.0"
+    CURRENT_PROJECT_VERSION: "1"
+targets:
+  KBAClient:
+    type: application
+    platform: iOS
+    sources:
+      - path: Sources
+    resources:
+      - path: Resources
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.kbaccountant.client
+        PRODUCT_NAME: KBAClient
+        INFOPLIST_FILE: Resources/Info.plist
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: ""
+    scheme:
+      testTargets:
+        - KBAClientTests
+  KBAClientTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: Tests
+    dependencies:
+      - target: KBAClient
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.kbaccountant.client.tests
+        GENERATE_INFOPLIST_FILE: YES
+schemes:
+  KBAClient:
+    build:
+      targets:
+        KBAClient: all
+        KBAClientTests: [test]
+    test:
+      targets:
+        - KBAClientTests
+    run:
+      config: Debug
+    archive:
+      config: Release


### PR DESCRIPTION
## Purpose

Adds the first customer-facing KBA Client iPhone prototype based on the services presented on kbaccountant.com.

## Test-build scope

- iOS 16+ SwiftUI customer portal
- Eight KBA service groups with market filters
- Local onboarding and customer profile
- Local-only service requests with references and status timelines
- Local document import and deletion
- Consultation requests and optional local reminders
- UK, USA, Qatar and UAE contact actions
- Light, Dark and System appearance
- QA plan and final-publication release gates

## Verified test artifact

GitHub Actions run `30100105226` completed successfully:

- XcodeGen project generation passed
- iOS app and unit-test target compilation passed
- Unsigned iPhoneOS Release build passed
- TrollStore TIPA packaging passed
- Artifact upload passed
- Bundle ID: `com.kbaccountant.client`
- Version: `0.1.0` build `1`
- Minimum iOS: `16.0`
- Architecture: `arm64`
- TIPA SHA-256: `10bac177712811e907544815f7299809dfcc2ec74bb0edf4324c4b1ba465f4a2`

The hosted runner did not include an installed iOS Simulator runtime, so the unit-test target was compiled with `build-for-testing`; test execution on a real device or TestFlight remains a required QA gate.

## Safety boundary

This remains a draft test build and must not be merged or published as a live customer app. Requests, appointments and documents are stored locally and clearly marked as test data. A secure authenticated backend, encrypted uploads, final privacy policy, legal approvals, real-device testing and complete feature verification are release blockers documented in `KBAClient/RELEASE_CHECKLIST.md`.

`main` remains unchanged.