### PR TITLE
Prevent NextPDF loading screen from hanging

### DIFF
--- a/NextPDF/apply_bullet_speed_patch.py
+++ b/NextPDF/apply_bullet_speed_patch.py
@@ -17,18 +17,66 @@ def replace_once(text: str, old: str, new: str, label: str) -> str:
 
 def patch_model() -> None:
     text = MODEL.read_text(encoding="utf-8")
-    old = '''            let data = try Data(contentsOf: url)
+
+    old_method = '''    func open(url: URL) {
+        do {
+            let accessed = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessed { url.stopAccessingSecurityScopedResource() }
+            }
+
+            let data = try Data(contentsOf: url)
             guard let pdf = PDFDocument(data: data) else {
                 throw CocoaError(.fileReadCorruptFile)
             }
+
+            sourceURL = url
+            documentTitle = url.deletingPathExtension().lastPathComponent
+            document = pdf
+            pdfView?.document = pdf
+            selectedAnnotation = nil
+            selectedAnnotationPage = nil
+            undoStack.removeAll()
+            redoStack.removeAll()
+            refreshUndoState()
+            refreshDocumentState()
+        } catch {
+            present(error: error)
+        }
+    }
 '''
-    new = '''            // Bullet mode: let PDFKit open the local file directly. This avoids
-            // copying the entire PDF into memory before the first page appears.
+
+    new_method = '''    func open(url: URL) {
+        do {
+            let accessed = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessed { url.stopAccessingSecurityScopedResource() }
+            }
+
             guard let pdf = PDFDocument(url: url) else {
                 throw CocoaError(.fileReadCorruptFile)
             }
+            install(document: pdf, sourceURL: url)
+        } catch {
+            present(error: error)
+        }
+    }
+
+    func install(document pdf: PDFDocument, sourceURL url: URL) {
+        self.sourceURL = url
+        documentTitle = url.deletingPathExtension().lastPathComponent
+        document = pdf
+        pdfView?.document = pdf
+        selectedAnnotation = nil
+        selectedAnnotationPage = nil
+        undoStack.removeAll()
+        redoStack.removeAll()
+        refreshUndoState()
+        refreshDocumentState()
+    }
 '''
-    text = replace_once(text, old, new, "PDFEditorModel direct URL open")
+
+    text = replace_once(text, old_method, new_method, "PDFEditorModel background install API")
     MODEL.write_text(text, encoding="utf-8")
 
 
@@ -40,17 +88,20 @@ def patch_workspace() -> None:
                 await Task.yield()
                 model.open(url: localURL)
 '''
+
     new_call = '''                let localURL = try await RobustPDFFileImporter.prepareForImmediateOpen(selectedURL)
-                importStatus = "Opening PDF…"
-                await Task.yield()
-                model.open(url: localURL)
+                importStatus = "Opening PDF in background…"
+                let loaded = try await BulletPDFBackgroundLoader.load(from: localURL, timeout: 15)
+                model.install(document: loaded.document, sourceURL: localURL)
 '''
-    text = replace_once(text, old_call, new_call, "workspace fast import call")
+
+    text = replace_once(text, old_call, new_call, "workspace background PDF load")
 
     pattern = re.compile(
         r'''private enum RobustPDFFileImporter \{.*?\n\}\n\nprivate enum RobustPDFImportError:''',
         re.DOTALL,
     )
+
     replacement = '''private enum RobustPDFFileImporter {
     static func prepareForImmediateOpen(_ sourceURL: URL) async throws -> URL {
         try await Task.detached(priority: .userInitiated) {
@@ -67,8 +118,6 @@ def patch_workspace() -> None:
                 throw RobustPDFImportError.emptyFile
             }
 
-            // UIDocumentPicker is configured with asCopy=true, so the returned URL
-            // is already a local app-accessible copy. Read only the tiny header.
             let handle = try FileHandle(forReadingFrom: sourceURL)
             defer { try? handle.close() }
             let header = try handle.read(upToCount: 1024) ?? Data()
@@ -81,6 +130,69 @@ def patch_workspace() -> None:
     }
 }
 
+private final class BulletLoadedPDF: @unchecked Sendable {
+    let document: PDFDocument
+
+    init(document: PDFDocument) {
+        self.document = document
+    }
+}
+
+private final class BulletPDFCompletionGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finished = false
+
+    func complete(_ action: () -> Void) {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
+        }
+        finished = true
+        lock.unlock()
+        action()
+    }
+}
+
+private enum BulletPDFBackgroundLoader {
+    static func load(from url: URL, timeout: TimeInterval) async throws -> BulletLoadedPDF {
+        try await withCheckedThrowingContinuation { continuation in
+            let gate = BulletPDFCompletionGate()
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                let accessed = url.startAccessingSecurityScopedResource()
+                defer {
+                    if accessed { url.stopAccessingSecurityScopedResource() }
+                }
+
+                if let pdf = PDFDocument(url: url) {
+                    gate.complete {
+                        continuation.resume(returning: BulletLoadedPDF(document: pdf))
+                    }
+                } else {
+                    gate.complete {
+                        continuation.resume(throwing: CocoaError(.fileReadCorruptFile))
+                    }
+                }
+            }
+
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+                gate.complete {
+                    continuation.resume(throwing: BulletPDFLoadError.timedOut)
+                }
+            }
+        }
+    }
+}
+
+private enum BulletPDFLoadError: LocalizedError {
+    case timedOut
+
+    var errorDescription: String? {
+        "The PDF did not open within 15 seconds. Download it fully in Files, then try again."
+    }
+}
+
 private enum RobustPDFImportError:'''
 
     text, count = pattern.subn(replacement, text, count=1)
@@ -89,7 +201,7 @@ private enum RobustPDFImportError:'''
 
     text = text.replace(
         'importStatus = "Reading selected file…"',
-        'importStatus = "Opening PDF…"',
+        'importStatus = "Preparing PDF…"',
         1,
     )
     WORKSPACE.write_text(text, encoding="utf-8")
@@ -99,10 +211,10 @@ def main() -> int:
     try:
         patch_model()
         patch_workspace()
-        print("Applied NextPDF bullet-speed loading patch")
+        print("Applied NextPDF background PDF loader with timeout")
         return 0
     except Exception as exc:
-        print(f"Bullet-speed patch failed: {exc}", file=sys.stderr)
+        print(f"Background-loader patch failed: {exc}", file=sys.stderr)
         return 1
 
 


### PR DESCRIPTION
Moves PDFDocument parsing completely off the main actor, installs the parsed document on the UI only after background loading finishes, keeps the lightweight header check, and adds a 15-second timeout so the loading overlay can never remain indefinitely.