### PR TITLE
Remove permanent PDF loading screen

### DIFF
--- a/NextPDF/apply_bullet_speed_patch.py
+++ b/NextPDF/apply_bullet_speed_patch.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from pathlib import Path
-import re
 import sys
 
 ROOT = Path(__file__).resolve().parent
@@ -76,61 +75,143 @@ def patch_model() -> None:
     }
 '''
 
-    text = replace_once(text, old_method, new_method, "PDFEditorModel background install API")
+    text = replace_once(text, old_method, new_method, "PDFEditorModel install API")
     MODEL.write_text(text, encoding="utf-8")
 
 
 def patch_workspace() -> None:
     text = WORKSPACE.read_text(encoding="utf-8")
 
-    old_call = '''                let localURL = try await RobustPDFFileImporter.makeVerifiedLocalCopy(of: selectedURL)
+    old_state = '''    @State private var shareItem: RobustShareItem?
+    @State private var exportKind: PDFExportKind = .editable
+'''
+    new_state = '''    @State private var shareItem: RobustShareItem?
+    @State private var exportKind: PDFExportKind = .editable
+    @State private var importRequestID = UUID()
+'''
+    text = replace_once(text, old_state, new_state, "import request state")
+
+    old_overlay = '''    private var loadingOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.3)
+                .ignoresSafeArea()
+
+            VStack(spacing: 14) {
+                ProgressView()
+                    .controlSize(.large)
+                Text(importStatus)
+                    .font(.headline)
+                Text("The file is being copied safely into Next PDF.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(24)
+            .frame(maxWidth: 310)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18))
+            .shadow(radius: 18)
+        }
+    }
+'''
+
+    new_overlay = '''    private var loadingOverlay: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                ProgressView()
+                    .controlSize(.regular)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(importStatus)
+                        .font(.headline)
+                    Text("You can cancel immediately if this Files provider is not responding.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 4)
+            }
+
+            Button(role: .cancel) {
+                cancelCurrentImport()
+            } label: {
+                Label("Cancel Loading", systemImage: "xmark.circle.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(16)
+        .frame(maxWidth: 360)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .shadow(radius: 12)
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+'''
+    text = replace_once(text, old_overlay, new_overlay, "non-blocking loading banner")
+
+    old_import = '''    private func importPDF(from selectedURL: URL) {
+        guard !isImporting else { return }
+        isImporting = true
+        importStatus = "Reading selected file…"
+
+        Task {
+            defer { isImporting = false }
+
+            do {
+                let localURL = try await RobustPDFFileImporter.makeVerifiedLocalCopy(of: selectedURL)
                 importStatus = "Opening PDF…"
                 await Task.yield()
                 model.open(url: localURL)
-'''
-
-    new_call = '''                let localURL = try await RobustPDFFileImporter.prepareForImmediateOpen(selectedURL)
-                importStatus = "Opening PDF in background…"
-                let loaded = try await BulletPDFBackgroundLoader.load(from: localURL, timeout: 15)
-                model.install(document: loaded.document, sourceURL: localURL)
-'''
-
-    text = replace_once(text, old_call, new_call, "workspace background PDF load")
-
-    pattern = re.compile(
-        r'''private enum RobustPDFFileImporter \{.*?\n\}\n\nprivate enum RobustPDFImportError:''',
-        re.DOTALL,
-    )
-
-    replacement = '''private enum RobustPDFFileImporter {
-    static func prepareForImmediateOpen(_ sourceURL: URL) async throws -> URL {
-        try await Task.detached(priority: .userInitiated) {
-            let accessed = sourceURL.startAccessingSecurityScopedResource()
-            defer {
-                if accessed { sourceURL.stopAccessingSecurityScopedResource() }
+                sidebarVisible = true
+            } catch {
+                model.present(error: error)
             }
-
-            let values = try? sourceURL.resourceValues(forKeys: [.isDirectoryKey, .fileSizeKey])
-            if values?.isDirectory == true {
-                throw RobustPDFImportError.folderSelected
-            }
-            if let size = values?.fileSize, size <= 0 {
-                throw RobustPDFImportError.emptyFile
-            }
-
-            let handle = try FileHandle(forReadingFrom: sourceURL)
-            defer { try? handle.close() }
-            let header = try handle.read(upToCount: 1024) ?? Data()
-            guard header.range(of: Data("%PDF-".utf8)) != nil else {
-                throw RobustPDFImportError.notPDF
-            }
-
-            return sourceURL
-        }.value
+        }
     }
-}
+'''
 
-private final class BulletLoadedPDF: @unchecked Sendable {
+    new_import = '''    private func importPDF(from selectedURL: URL) {
+        guard !isImporting else { return }
+
+        let requestID = UUID()
+        importRequestID = requestID
+        isImporting = true
+        importStatus = "Opening PDF…"
+
+        Task {
+            do {
+                // No header read, no duplicate copy and no synchronous file validation.
+                // The document picker already supplies an app-accessible local copy.
+                let loaded = try await NoStuckPDFLoader.load(from: selectedURL, timeout: 6)
+                guard importRequestID == requestID else { return }
+
+                // Hide the loading UI before PDFKit receives the document. Even if
+                // first-page rendering is expensive, the user is never trapped behind it.
+                isImporting = false
+                await Task.yield()
+                guard importRequestID == requestID else { return }
+
+                model.install(document: loaded.document, sourceURL: selectedURL)
+                sidebarVisible = true
+            } catch {
+                guard importRequestID == requestID else { return }
+                isImporting = false
+                model.present(error: error)
+            }
+        }
+    }
+
+    private func cancelCurrentImport() {
+        importRequestID = UUID()
+        isImporting = false
+        importStatus = "Opening PDF…"
+    }
+'''
+    text = replace_once(text, old_import, new_import, "cancel-safe PDF import")
+
+    loader_code = '''
+
+private final class NoStuckLoadedPDF: @unchecked Sendable {
     let document: PDFDocument
 
     init(document: PDFDocument) {
@@ -138,27 +219,29 @@ private final class BulletLoadedPDF: @unchecked Sendable {
     }
 }
 
-private final class BulletPDFCompletionGate: @unchecked Sendable {
+private final class NoStuckCompletionGate: @unchecked Sendable {
     private let lock = NSLock()
-    private var finished = false
+    private var completed = false
 
-    func complete(_ action: () -> Void) {
+    func finish(_ action: () -> Void) {
         lock.lock()
-        guard !finished else {
+        guard !completed else {
             lock.unlock()
             return
         }
-        finished = true
+        completed = true
         lock.unlock()
         action()
     }
 }
 
-private enum BulletPDFBackgroundLoader {
-    static func load(from url: URL, timeout: TimeInterval) async throws -> BulletLoadedPDF {
+private enum NoStuckPDFLoader {
+    static func load(from url: URL, timeout: TimeInterval) async throws -> NoStuckLoadedPDF {
         try await withCheckedThrowingContinuation { continuation in
-            let gate = BulletPDFCompletionGate()
+            let gate = NoStuckCompletionGate()
 
+            // This is intentionally unstructured. The timeout is allowed to return
+            // immediately without waiting for a blocked third-party Files provider.
             DispatchQueue.global(qos: .userInitiated).async {
                 let accessed = url.startAccessingSecurityScopedResource()
                 defer {
@@ -166,44 +249,45 @@ private enum BulletPDFBackgroundLoader {
                 }
 
                 if let pdf = PDFDocument(url: url) {
-                    gate.complete {
-                        continuation.resume(returning: BulletLoadedPDF(document: pdf))
+                    gate.finish {
+                        continuation.resume(returning: NoStuckLoadedPDF(document: pdf))
                     }
                 } else {
-                    gate.complete {
-                        continuation.resume(throwing: CocoaError(.fileReadCorruptFile))
+                    gate.finish {
+                        continuation.resume(throwing: NoStuckPDFLoadError.cannotOpen)
                     }
                 }
             }
 
             DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
-                gate.complete {
-                    continuation.resume(throwing: BulletPDFLoadError.timedOut)
+                gate.finish {
+                    continuation.resume(throwing: NoStuckPDFLoadError.timedOut)
                 }
             }
         }
     }
 }
 
-private enum BulletPDFLoadError: LocalizedError {
+private enum NoStuckPDFLoadError: LocalizedError {
     case timedOut
+    case cannotOpen
 
     var errorDescription: String? {
-        "The PDF did not open within 15 seconds. Download it fully in Files, then try again."
+        switch self {
+        case .timedOut:
+            return "This Files provider did not supply the PDF within 6 seconds. Open the PDF once in Files so it downloads locally, then select it again."
+        case .cannotOpen:
+            return "The selected file could not be opened as a PDF. It may be damaged or password-protected."
+        }
     }
 }
+'''
 
-private enum RobustPDFImportError:'''
+    marker = '''private enum RobustPDFImportError: LocalizedError {'''
+    if marker not in text:
+        raise RuntimeError("loader insertion marker not found")
+    text = text.replace(marker, loader_code + "\n\n" + marker, 1)
 
-    text, count = pattern.subn(replacement, text, count=1)
-    if count != 1:
-        raise RuntimeError(f"workspace importer replacement: expected one match, found {count}")
-
-    text = text.replace(
-        'importStatus = "Reading selected file…"',
-        'importStatus = "Preparing PDF…"',
-        1,
-    )
     WORKSPACE.write_text(text, encoding="utf-8")
 
 
@@ -211,10 +295,10 @@ def main() -> int:
     try:
         patch_model()
         patch_workspace()
-        print("Applied NextPDF background PDF loader with timeout")
+        print("Applied NextPDF non-blocking cancel-safe loader")
         return 0
     except Exception as exc:
-        print(f"Background-loader patch failed: {exc}", file=sys.stderr)
+        print(f"No-stuck loader patch failed: {exc}", file=sys.stderr)
         return 1
 
 


### PR DESCRIPTION
Removes the unprotected Files-provider header read, uses an unstructured timeout that never waits for a blocked PDF operation, adds a visible Cancel Loading button, hides the loader before installing the PDF into PDFKit, and ignores all late results after cancellation or timeout.