### PR TITLE
Align PhoneAura 0.4.16 tabs and pin recent tutorial

### DIFF
--- a/.github/scripts/publish-phoneaura-blog.py
+++ b/.github/scripts/publish-phoneaura-blog.py
@@ -1,105 +1,231 @@
-# One-shot publication helper for the PhoneAura 0.4.15 tutorial.
-# This branch commit intentionally triggers the merged publication workflow.
-# Final tutorials-grid and sitemap publication pass.
 from pathlib import Path
+import re
 
 INDEX_PATH = Path("index.html")
+TUTORIALS_PATH = Path("tutorials.html")
+ARTICLE_PATH = Path("phoneaura-tweak-ios16.html")
 SITEMAP_PATH = Path("sitemap.xml")
 
-CARD_START = "<!-- PHONEAURA_TUTORIAL_CARD_START -->"
-CARD_END = "<!-- PHONEAURA_TUTORIAL_CARD_END -->"
+RECENT_CARD_START = "<!-- PHONEAURA_RECENT_CARD_START -->"
+RECENT_CARD_END = "<!-- PHONEAURA_RECENT_CARD_END -->"
+TABS_CSS_START = "/* PHONEAURA_SHARED_TABS_START */"
+TABS_CSS_END = "/* PHONEAURA_SHARED_TABS_END */"
 
-PHONEAURA_CARD = f"""
-      {CARD_START}
-      <div class="content-card blog-post-card" style="overflow: hidden; padding: 0; border: 1px solid rgba(106,17,203,.24);">
-        <a href="phoneaura-tweak-ios16.html" style="display: block; text-decoration: none; color: inherit;">
-          <img src="assets/phoneaura/phoneaura-hero.svg"
-               alt="PhoneAura 0.4.15 iOS 16 Phone app redesign concept"
-               loading="lazy"
-               width="1600"
-               height="900"
-               style="display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; border-bottom: 1px solid rgba(106,17,203,.18);">
-        </a>
-        <div style="padding: 1.35rem;">
-          <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 12px;">
-            <span style="width: 42px; height: 42px; display: grid; place-items: center; border-radius: 14px; color: white; font-size: 18px; font-weight: 900; background: linear-gradient(135deg,#7b2cff,#168dff); box-shadow: 0 10px 24px rgba(74,75,255,.28);">P</span>
-            <div>
-              <h3 style="margin: 0;">PhoneAura 0.4.15</h3>
-              <p style="color: #666; font-size: .9rem; margin: 2px 0 0;">📱 Free iOS 16 Phone App Redesign</p>
-            </div>
-          </div>
-          <p><strong>RootHide and rootless downloads included.</strong> Redesign Favorites, Recents, Contacts and Keypad with fixed saved-number suggestions, smart call filters and long-press Cut, Copy and Paste controls.</p>
-          <div style="display: flex; gap: 10px; margin-top: 1rem; flex-wrap: wrap;">
-            <a href="phoneaura-tweak-ios16.html" class="read-more blog-post-btn">
-              Read Full Guide <i class="fas fa-arrow-right"></i>
-            </a>
-            <a href="sileo://source/https://zeshan0727.github.io/" class="youtube-link" style="background: linear-gradient(135deg,#168dff,#6a11cb);">
-              <i class="fas fa-download"></i> Add Repo
-            </a>
-          </div>
-        </div>
-      </div>
-      {CARD_END}
+PHONEAURA_RECENT_CARD = f"""
+        {RECENT_CARD_START}
+        <article class="card">
+          <div class="icon"><i class="fas fa-phone-volume" aria-hidden="true"></i></div>
+          <h3>PhoneAura 0.4.16 — Stable Phone App Redesign</h3>
+          <p>Emergency stability hotfix with redesigned Favorites, Recents, Contacts and a fixed smart Keypad for RootHide and rootless jailbreaks.</p>
+          <a class="more" href="phoneaura-tweak-ios16.html">Read guide &amp; download <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
+        </article>
+        {RECENT_CARD_END}
 """
+
+SHARED_TABS_CSS = f"""
+    {TABS_CSS_START}
+    .header-links {{
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      overscroll-behavior-x: contain;
+      scrollbar-width: none;
+      -webkit-overflow-scrolling: touch;
+    }}
+    .header-links::-webkit-scrollbar {{ display: none; }}
+    .header-links a {{ flex: 0 0 auto; white-space: nowrap; }}
+    .header-links a[aria-current="page"] {{
+      color: #fff;
+      background: rgba(255,255,255,.14);
+    }}
+    @media (max-width: 650px) {{
+      .site-header-inner {{
+        min-height: 0;
+        align-items: stretch;
+        flex-direction: column;
+        padding: 10px 0;
+      }}
+      .header-links {{ width: 100%; }}
+      .header-links a:not(:last-child) {{ display: block; }}
+    }}
+    {TABS_CSS_END}
+"""
+
+
+def remove_marked_block(text: str, start: str, end: str) -> str:
+    pattern = re.compile(rf"\s*{re.escape(start)}.*?{re.escape(end)}\s*", re.S)
+    return pattern.sub("\n", text)
 
 
 def update_index() -> bool:
     original = INDEX_PATH.read_text(encoding="utf-8")
-    updated = original.replace("https://www.nextsolution.app", "https://nextsolution.cc")
-    updated = updated.replace("Latest Video Tutorials", "Latest Tutorials & Tweak Guides")
-    updated = updated.replace(">60+</span>", ">61+</span>", 1)
-    updated = updated.replace('id="current-year">2025</span>', 'id="current-year">2026</span>')
+    updated = original.replace(
+        '<div class="heading"><h2>Popular tutorials</h2><p>Guides covering the most requested jailbreak and iPhone customization topics.</p></div>',
+        '<div class="heading"><h2>Recent tutorials</h2><p>The newest Next Solution guides, with PhoneAura permanently pinned for quick access.</p></div>',
+    )
 
-    if CARD_START not in updated:
-        tutorial_start = updated.find('<section id="tutorials">')
-        if tutorial_start == -1:
-            raise RuntimeError("Could not find the Tutorials section in index.html")
+    updated = remove_marked_block(updated, RECENT_CARD_START, RECENT_CARD_END)
+    section_start = updated.find('<section class="section" id="tutorials">')
+    if section_start == -1:
+        raise RuntimeError("Could not find the main-page tutorials section")
 
-        grid_marker = '<div class="content-grid">'
-        grid_start = updated.find(grid_marker, tutorial_start)
-        if grid_start == -1:
-            raise RuntimeError("Could not find the Tutorials content grid in index.html")
+    grid_marker = '<div class="grid">'
+    grid_start = updated.find(grid_marker, section_start)
+    if grid_start == -1:
+        raise RuntimeError("Could not find the main-page tutorials grid")
 
-        insertion_point = grid_start + len(grid_marker)
-        updated = updated[:insertion_point] + "\n" + PHONEAURA_CARD + updated[insertion_point:]
+    insertion_point = grid_start + len(grid_marker)
+    updated = updated[:insertion_point] + "\n" + PHONEAURA_RECENT_CARD + updated[insertion_point:]
 
     if updated == original:
         return False
-
     INDEX_PATH.write_text(updated, encoding="utf-8")
+    return True
+
+
+def update_tutorials() -> bool:
+    original = TUTORIALS_PATH.read_text(encoding="utf-8")
+    updated = original.replace("PhoneAura 0.4.15", "PhoneAura 0.4.16")
+    updated = updated.replace(
+        "Includes fixed saved-number suggestions, smart call filters, Number Options, direct DEB downloads and long-press Cut, Copy and Paste controls.",
+        "Includes fixed saved-number suggestions, smart call filters, Number Options, direct DEB downloads and the 0.4.16 emergency stability rollback.",
+    )
+    updated = updated.replace(
+        "PhoneAura 0.4.16 — Complete Phone App Redesign",
+        "PhoneAura 0.4.16 — Stable Phone App Redesign",
+    )
+
+    if updated == original:
+        return False
+    TUTORIALS_PATH.write_text(updated, encoding="utf-8")
+    return True
+
+
+def update_article() -> bool:
+    original = ARTICLE_PATH.read_text(encoding="utf-8")
+    updated = original.replace("0.4.15", "0.4.16")
+
+    old_nav = '''      <nav class="header-links" aria-label="Article navigation">
+        <a href="./#tutorials">Tutorials</a>
+        <a href="videos">Videos</a>
+        <a href="downloads">Downloads</a>
+        <a href="#download">Get PhoneAura</a>
+      </nav>'''
+    new_nav = '''      <nav class="header-links" aria-label="Primary navigation">
+        <a href="./">Home</a>
+        <a href="tutorials.html" aria-current="page">Tutorials</a>
+        <a href="videos.html">Videos</a>
+        <a href="./#faq">FAQ</a>
+      </nav>'''
+    if old_nav in updated:
+        updated = updated.replace(old_nav, new_nav)
+    elif new_nav not in updated:
+        raise RuntimeError("Could not find the PhoneAura article navigation")
+
+    updated = remove_marked_block(updated, TABS_CSS_START, TABS_CSS_END)
+    updated = updated.replace("  </style>", SHARED_TABS_CSS + "  </style>", 1)
+
+    replacements = {
+        "Redesign Favorites, Recents, Contacts and Keypad on iOS 16 with fixed suggestions, smart filters and long-press phone-number editing.":
+            "Redesign Favorites, Recents, Contacts and Keypad on iOS 16 with fixed suggestions, smart filters and the 0.4.16 emergency stability hotfix.",
+        "Modern Favorites, smart Recents, redesigned Contacts, a stable keypad and native long-press number editing for jailbroken iOS 16.":
+            "Modern Favorites, smart Recents, redesigned Contacts and a stable keypad for jailbroken iOS 16.",
+        "Use the native iOS edit menu for Cut, Copy and Paste where appropriate, including Paste to Keypad.":
+            "Version 0.4.16 removes the unsafe global edit-menu hooks from 0.4.15 and restores the stable number-display behavior used in 0.4.14.",
+        "Long-Press Number Editing": "Stable Number Handling",
+        "PhoneAura Keypad with fixed contact suggestion card and long-press edit menu":
+            "PhoneAura Keypad with fixed contact suggestion card and stable number display",
+        "Keypad concept: fixed suggestion space, preserved Number Options, Next Solution shortcut and native phone-number editing.":
+            "Keypad concept: fixed suggestion space, preserved Number Options, Next Solution shortcut and a stable number display.",
+        "            <li>Long press the displayed number to open the editing menu.</li>\n": "",
+        "Read more jailbreak tutorials on <a href=\"./#tutorials\">Next Solution</a>":
+            "Read more jailbreak tutorials on <a href=\"tutorials.html\">Next Solution</a>",
+    }
+    for old, new in replacements.items():
+        updated = updated.replace(old, new)
+
+    stability_section = '''
+      <section class="section" id="number-menu">
+        <div class="section-heading">
+          <span class="kicker">PhoneAura 0.4.16 hotfix</span>
+          <h2>Phone app crash fixed</h2>
+          <p>Version 0.4.15 attached edit-menu interactions by globally modifying UILabel behavior inside the Phone process. On affected devices this caused MobilePhone to crash during launch or while views were updating.</p>
+        </div>
+
+        <div class="glass-card prose-card">
+          <ul>
+            <li>The global long-press phone-number editing hooks have been removed.</li>
+            <li>The tweak now uses the proven 0.4.14 runtime file set.</li>
+            <li>Favorites, Recents, Contacts, Keypad, fixed suggestions, Number Options and the Next Solution shortcut remain available.</li>
+            <li>RootHide and rootless builds were compiled separately as version 0.4.16.</li>
+          </ul>
+          <div class="warning"><strong>Remove 0.4.15 immediately.</strong> Refresh the Next Solution repository and upgrade to 0.4.16 before reopening the Phone app.</div>
+        </div>
+      </section>
+
+'''
+    number_menu_pattern = re.compile(
+        r'\s*<section class="section" id="number-menu">.*?</section>\s*(?=<section class="section" id="compatibility">)',
+        re.S,
+    )
+    if number_menu_pattern.search(updated):
+        updated = number_menu_pattern.sub("\n" + stability_section, updated, count=1)
+    elif "Phone app crash fixed" not in updated:
+        raise RuntimeError("Could not replace the old long-press editing section")
+
+    old_test = '''          <h3>Recommended first test</h3>
+          <ol>
+            <li>Open Keypad and type at least two digits.</li>
+            <li>Confirm the suggestion area stays visible and the keypad does not move.</li>
+            <li>Long press the typed number and test Copy or Paste.</li>
+            <li>Open Contacts or Recents and long press a displayed number.</li>
+            <li>Check Favorites, Recents filters and the upper Next Solution logo.</li>
+          </ol>'''
+    new_test = '''          <h3>Recommended first test</h3>
+          <ol>
+            <li>Confirm Settings → PhoneAura shows version 0.4.16.</li>
+            <li>Respring, fully close the Phone app and reopen it.</li>
+            <li>Open Keypad and type at least two digits.</li>
+            <li>Confirm the suggestion area stays visible and the keypad does not move.</li>
+            <li>Check Favorites, Recents filters, Contacts, Number Options and the upper Next Solution logo.</li>
+          </ol>'''
+    if old_test in updated:
+        updated = updated.replace(old_test, new_test)
+
+    old_faq = '''          <details>
+            <summary>Why is Cut disabled on saved numbers?</summary>
+            <p>Saved contacts and call-history numbers are read-only in this menu. Disabling Cut protects stored data while still allowing Copy and Paste to Keypad.</p>
+          </details>'''
+    new_faq = '''          <details>
+            <summary>Why was long-press number editing removed?</summary>
+            <p>The 0.4.15 implementation modified UILabel behavior globally and caused the Phone app to crash on affected devices. Version 0.4.16 removes that code and restores the stable 0.4.14 runtime.</p>
+          </details>'''
+    if old_faq in updated:
+        updated = updated.replace(old_faq, new_faq)
+
+    if updated == original:
+        return False
+    ARTICLE_PATH.write_text(updated, encoding="utf-8")
     return True
 
 
 def update_sitemap() -> bool:
     original = SITEMAP_PATH.read_text(encoding="utf-8")
-    updated = original.replace("https://www.nextsolution.app", "https://nextsolution.cc")
-
-    phoneaura_url = "https://nextsolution.cc/phoneaura-tweak-ios16.html"
-    if phoneaura_url not in updated:
-        entry = """
-
-  <!-- PhoneAura iOS 16 Tweak Guide -->
-  <url>
-    <loc>https://nextsolution.cc/phoneaura-tweak-ios16.html</loc>
-    <lastmod>2026-07-30</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-"""
-        closing = "</urlset>"
-        if closing not in updated:
-            raise RuntimeError("Could not find closing urlset tag in sitemap.xml")
-        updated = updated.replace(closing, entry + "\n" + closing)
-
+    updated = original.replace(
+        "<lastmod>2026-07-30</lastmod>",
+        "<lastmod>2026-07-30</lastmod>",
+    )
     if updated == original:
         return False
-
     SITEMAP_PATH.write_text(updated, encoding="utf-8")
     return True
 
 
 if __name__ == "__main__":
-    index_changed = update_index()
-    sitemap_changed = update_sitemap()
-    print(f"index.html changed: {index_changed}")
-    print(f"sitemap.xml changed: {sitemap_changed}")
+    results = {
+        "index.html": update_index(),
+        "tutorials.html": update_tutorials(),
+        "phoneaura-tweak-ios16.html": update_article(),
+        "sitemap.xml": update_sitemap(),
+    }
+    for path, changed in results.items():
+        print(f"{path} changed: {changed}")

--- a/.github/workflows/publish-phoneaura-tutorial.yml
+++ b/.github/workflows/publish-phoneaura-tutorial.yml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - ".github/scripts/publish-phoneaura-blog.py"
+      - ".github/workflows/publish-phoneaura-tutorial.yml"
   pull_request:
     branches:
       - main
     paths:
       - ".github/scripts/publish-phoneaura-blog.py"
+      - ".github/workflows/publish-phoneaura-tutorial.yml"
   workflow_dispatch:
 
 permissions:
@@ -30,15 +32,26 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.head_ref || github.ref_name }}
 
-      - name: Add PhoneAura to Tutorials and sitemap
+      - name: Update PhoneAura article and listings
         run: python3 .github/scripts/publish-phoneaura-blog.py
 
-      - name: Validate generated links
+      - name: Validate generated website changes
         run: |
           test -f phoneaura-tweak-ios16.html
+          test -f tutorials.html
           test -f assets/phoneaura/phoneaura-hero.svg
-          grep -q 'phoneaura-tweak-ios16.html' index.html
+          grep -q 'PHONEAURA_RECENT_CARD_START' index.html
+          grep -q '<h2>Recent tutorials</h2>' index.html
+          grep -q 'PhoneAura 0.4.16' tutorials.html
+          grep -q 'PhoneAura 0.4.16' phoneaura-tweak-ios16.html
+          grep -q 'aria-current="page">Tutorials' phoneaura-tweak-ios16.html
+          grep -q 'PhoneAura_0.4.16_RootHide_iOS16.deb' phoneaura-tweak-ios16.html
+          grep -q 'PhoneAura_0.4.16_Rootless_iOS16.deb' phoneaura-tweak-ios16.html
           grep -q 'https://nextsolution.cc/phoneaura-tweak-ios16.html' sitemap.xml
+          if grep -q 'PhoneAura_0.4.15' phoneaura-tweak-ios16.html; then
+            echo 'Old 0.4.15 article reference remains.'
+            exit 1
+          fi
 
       - name: Commit generated website changes
         env:
@@ -46,10 +59,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add index.html sitemap.xml
+          git add index.html tutorials.html phoneaura-tweak-ios16.html sitemap.xml
           if git diff --cached --quiet; then
-            echo "PhoneAura tutorial listing is already current."
+            echo "PhoneAura tutorial and listings are already current."
             exit 0
           fi
-          git commit -m "Publish PhoneAura 0.4.15 tutorial"
+          git commit -m "Publish PhoneAura 0.4.16 tutorial and recent card"
           git push origin HEAD:"$TARGET_BRANCH"

--- a/index.html
+++ b/index.html
@@ -107,8 +107,18 @@
     </section>
 
     <section class="section" id="tutorials">
-      <div class="heading"><h2>Popular tutorials</h2><p>Guides covering the most requested jailbreak and iPhone customization topics.</p></div>
+      <div class="heading"><h2>Recent tutorials</h2><p>The newest Next Solution guides, with PhoneAura permanently pinned for quick access.</p></div>
       <div class="grid">
+
+        <!-- PHONEAURA_RECENT_CARD_START -->
+        <article class="card">
+          <div class="icon"><i class="fas fa-phone-volume" aria-hidden="true"></i></div>
+          <h3>PhoneAura 0.4.16 — Stable Phone App Redesign</h3>
+          <p>Emergency stability hotfix with redesigned Favorites, Recents, Contacts and a fixed smart Keypad for RootHide and rootless jailbreaks.</p>
+          <a class="more" href="phoneaura-tweak-ios16.html">Read guide &amp; download <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
+        </article>
+        <!-- PHONEAURA_RECENT_CARD_END -->
+
         <article class="card"><div class="icon"><i class="fas fa-mobile-alt"></i></div><h3>Complete iOS 16 Jailbreak Guide</h3><p>Follow the palera1n process, device requirements, and common fixes.</p><a class="more" href="how-to-jailbreak.html">Read guide <i class="fas fa-arrow-right"></i></a></article>
         <article class="card"><div class="icon"><i class="fas fa-list-check"></i></div><h3>25+ Free iOS 16 Rootless Tweaks</h3><p>A curated list of free rootless tweaks with repositories and installation details.</p><a class="more" href="ios16-rootless-tweaks.html">View all tweaks <i class="fas fa-arrow-right"></i></a></article>
         <article class="card"><div class="icon"><i class="fas fa-sync-alt"></i></div><h3>Convert Rootful to Rootless</h3><p>Prepare older tweak packages for modern rootless jailbreak environments.</p><a class="more" href="convert-rootful-to-rootless.html">Read conversion guide <i class="fas fa-arrow-right"></i></a></article>

--- a/phoneaura-tweak-ios16.html
+++ b/phoneaura-tweak-ios16.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#07111f">
-  <title>PhoneAura 0.4.15 — Modern iOS 16 Phone App Tweak | Next Solution</title>
-  <meta name="description" content="Download PhoneAura 0.4.15 for RootHide or rootless jailbreaks. Redesign Favorites, Recents, Contacts and Keypad on iOS 16 with fixed suggestions, smart filters and long-press phone-number editing.">
+  <title>PhoneAura 0.4.16 — Modern iOS 16 Phone App Tweak | Next Solution</title>
+  <meta name="description" content="Download PhoneAura 0.4.16 for RootHide or rootless jailbreaks. Redesign Favorites, Recents, Contacts and Keypad on iOS 16 with fixed suggestions, smart filters and the 0.4.16 emergency stability hotfix.">
   <meta name="keywords" content="PhoneAura tweak, iOS 16 Phone app tweak, RootHide tweak, rootless jailbreak tweak, Dopamine tweak, iPhone keypad redesign, Next Solution repo">
   <meta name="author" content="Next Solution">
   <link rel="canonical" href="https://nextsolution.cc/phoneaura-tweak-ios16.html">
@@ -13,14 +13,14 @@
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="Next Solution">
   <meta property="og:url" content="https://nextsolution.cc/phoneaura-tweak-ios16.html">
-  <meta property="og:title" content="PhoneAura 0.4.15 — A Complete iOS 16 Phone App Redesign">
-  <meta property="og:description" content="Modern Favorites, smart Recents, redesigned Contacts, a stable keypad and native long-press number editing for jailbroken iOS 16.">
+  <meta property="og:title" content="PhoneAura 0.4.16 — A Complete iOS 16 Phone App Redesign">
+  <meta property="og:description" content="Modern Favorites, smart Recents, redesigned Contacts and a stable keypad for jailbroken iOS 16.">
   <meta property="og:image" content="https://nextsolution.cc/assets/phoneaura/phoneaura-hero.svg">
-  <meta property="og:image:alt" content="PhoneAura 0.4.15 concept preview by Next Solution">
+  <meta property="og:image:alt" content="PhoneAura 0.4.16 concept preview by Next Solution">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@nextsoluti0n">
-  <meta name="twitter:title" content="PhoneAura 0.4.15 for Jailbroken iOS 16">
+  <meta name="twitter:title" content="PhoneAura 0.4.16 for Jailbroken iOS 16">
   <meta name="twitter:description" content="Download the RootHide or rootless build and redesign the complete iOS Phone app.">
   <meta name="twitter:image" content="https://nextsolution.cc/assets/phoneaura/phoneaura-hero.svg">
 
@@ -32,8 +32,8 @@
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
-    "headline": "PhoneAura 0.4.15 — A Complete iOS 16 Phone App Redesign",
-    "description": "Feature guide, compatibility information and direct downloads for the PhoneAura 0.4.15 RootHide and rootless jailbreak tweak.",
+    "headline": "PhoneAura 0.4.16 — A Complete iOS 16 Phone App Redesign",
+    "description": "Feature guide, compatibility information and direct downloads for the PhoneAura 0.4.16 RootHide and rootless jailbreak tweak.",
     "image": "https://nextsolution.cc/assets/phoneaura/phoneaura-hero.svg",
     "datePublished": "2026-07-30",
     "dateModified": "2026-07-30",
@@ -616,6 +616,32 @@
       .compat-table th,
       .compat-table td { padding: 11px 10px; }
     }
+
+    /* PHONEAURA_SHARED_TABS_START */
+    .header-links {
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      overscroll-behavior-x: contain;
+      scrollbar-width: none;
+      -webkit-overflow-scrolling: touch;
+    }
+    .header-links::-webkit-scrollbar { display: none; }
+    .header-links a { flex: 0 0 auto; white-space: nowrap; }
+    .header-links a[aria-current="page"] {
+      color: #fff;
+      background: rgba(255,255,255,.14);
+    }
+    @media (max-width: 650px) {
+      .site-header-inner {
+        min-height: 0;
+        align-items: stretch;
+        flex-direction: column;
+        padding: 10px 0;
+      }
+      .header-links { width: 100%; }
+      .header-links a:not(:last-child) { display: block; }
+    }
+    /* PHONEAURA_SHARED_TABS_END */
   </style>
 </head>
 <body>
@@ -625,11 +651,11 @@
         <span class="brand-mark" aria-hidden="true"></span>
         <span>Next Solution</span>
       </a>
-      <nav class="header-links" aria-label="Article navigation">
-        <a href="./#tutorials">Tutorials</a>
-        <a href="videos">Videos</a>
-        <a href="downloads">Downloads</a>
-        <a href="#download">Get PhoneAura</a>
+      <nav class="header-links" aria-label="Primary navigation">
+        <a href="./">Home</a>
+        <a href="tutorials.html" aria-current="page">Tutorials</a>
+        <a href="videos.html">Videos</a>
+        <a href="./#faq">FAQ</a>
       </nav>
     </div>
   </header>
@@ -639,7 +665,7 @@
       <section class="hero">
         <div class="hero-copy">
           <span class="eyebrow">Next Solution Original Tweak</span>
-          <h1><span class="gradient-text">PhoneAura 0.4.15</span></h1>
+          <h1><span class="gradient-text">PhoneAura 0.4.16</span></h1>
           <p>PhoneAura replaces the standard iOS 16 Phone app experience with modern Favorites, smarter Recents, redesigned Contacts and a stable, feature-rich Keypad—without moving the keypad while saved-number suggestions update.</p>
 
           <div class="hero-badges" aria-label="Compatibility highlights">
@@ -658,7 +684,7 @@
         </div>
 
         <div class="hero-art">
-          <img src="assets/phoneaura/phoneaura-hero.svg" alt="PhoneAura 0.4.15 redesigned Keypad concept" width="1600" height="900">
+          <img src="assets/phoneaura/phoneaura-hero.svg" alt="PhoneAura 0.4.16 redesigned Keypad concept" width="1600" height="900">
         </div>
       </section>
 
@@ -696,8 +722,8 @@
 
           <article class="feature-card">
             <div class="feature-icon">✂</div>
-            <h3>Long-Press Number Editing</h3>
-            <p>Use the native iOS edit menu for Cut, Copy and Paste where appropriate, including Paste to Keypad.</p>
+            <h3>Stable Number Handling</h3>
+            <p>Version 0.4.16 removes the unsafe global edit-menu hooks from 0.4.15 and restores the stable number-display behavior used in 0.4.14.</p>
           </article>
 
           <article class="feature-card">
@@ -717,8 +743,8 @@
 
         <div class="visual-grid">
           <figure>
-            <img src="assets/phoneaura/phoneaura-keypad-concept.svg" alt="PhoneAura Keypad with fixed contact suggestion card and long-press edit menu" width="1200" height="800" loading="lazy">
-            <figcaption>Keypad concept: fixed suggestion space, preserved Number Options, Next Solution shortcut and native phone-number editing.</figcaption>
+            <img src="assets/phoneaura/phoneaura-keypad-concept.svg" alt="PhoneAura Keypad with fixed contact suggestion card and stable number display" width="1200" height="800" loading="lazy">
+            <figcaption>Keypad concept: fixed suggestion space, preserved Number Options, Next Solution shortcut and a stable number display.</figcaption>
           </figure>
 
           <figure>
@@ -748,57 +774,29 @@
             <li>Long press Delete to clear the complete number.</li>
             <li>Use the lower Number Options menu to create or update a contact.</li>
             <li>Tap the upper Next Solution logo to open the YouTube channel.</li>
-            <li>Long press the displayed number to open the editing menu.</li>
           </ul>
         </div>
       </section>
 
       <section class="section" id="number-menu">
         <div class="section-heading">
-          <span class="kicker">PhoneAura 0.4.15</span>
-          <h2>Native long-press number controls</h2>
-          <p>The editing menu changes safely depending on whether the displayed number is editable or belongs to stored contact/call data.</p>
+          <span class="kicker">PhoneAura 0.4.16 hotfix</span>
+          <h2>Phone app crash fixed</h2>
+          <p>Version 0.4.15 attached edit-menu interactions by globally modifying UILabel behavior inside the Phone process. On affected devices this caused MobilePhone to crash during launch or while views were updating.</p>
         </div>
 
         <div class="glass-card prose-card">
-          <table class="edit-menu-table">
-            <thead>
-              <tr>
-                <th>Number location</th>
-                <th>Cut</th>
-                <th>Copy</th>
-                <th>Paste</th>
-                <th>Safety behavior</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Number currently typed on Keypad</td>
-                <td><span class="yes">Available</span></td>
-                <td><span class="yes">Available</span></td>
-                <td><span class="yes">Available</span></td>
-                <td>Cut clears the editable keypad value only.</td>
-              </tr>
-              <tr>
-                <td>Contacts, Favorites and contact details</td>
-                <td>Disabled</td>
-                <td><span class="yes">Available</span></td>
-                <td><span class="safe">Paste to Keypad</span></td>
-                <td>Saved contact data is not deleted or edited by the menu.</td>
-              </tr>
-              <tr>
-                <td>Recents and call-detail numbers</td>
-                <td>Disabled</td>
-                <td><span class="yes">Available</span></td>
-                <td><span class="safe">Paste to Keypad</span></td>
-                <td>Read-only history remains protected.</td>
-              </tr>
-            </tbody>
-          </table>
+          <ul>
+            <li>The global long-press phone-number editing hooks have been removed.</li>
+            <li>The tweak now uses the proven 0.4.14 runtime file set.</li>
+            <li>Favorites, Recents, Contacts, Keypad, fixed suggestions, Number Options and the Next Solution shortcut remain available.</li>
+            <li>RootHide and rootless builds were compiled separately as version 0.4.16.</li>
+          </ul>
+          <div class="warning"><strong>Remove 0.4.15 immediately.</strong> Refresh the Next Solution repository and upgrade to 0.4.16 before reopening the Phone app.</div>
         </div>
       </section>
 
-      <section class="section" id="compatibility">
+<section class="section" id="compatibility">
         <div class="section-heading">
           <span class="kicker">Compatibility</span>
           <h2>Choose the correct package</h2>
@@ -834,7 +832,7 @@
 
       <section class="section glass-card download-panel" id="download">
         <span class="eyebrow">Free download</span>
-        <h2>Download PhoneAura 0.4.15</h2>
+        <h2>Download PhoneAura 0.4.16</h2>
         <p>Install from the Next Solution repository for easier upgrades, or download the matching DEB directly.</p>
 
         <div class="download-actions">
@@ -846,13 +844,13 @@
           <article class="package-card">
             <h3>RootHide Package</h3>
             <p>For RootHide jailbreak environments. Architecture: iphoneos-arm64e.</p>
-            <a class="button green" href="https://raw.githubusercontent.com/zeshan0727/zeshan0727.github.io/main/debfiles/PhoneAura_0.4.15_RootHide_iOS16.deb">Download RootHide DEB</a>
+            <a class="button green" href="https://raw.githubusercontent.com/zeshan0727/zeshan0727.github.io/main/debfiles/PhoneAura_0.4.16_RootHide_iOS16.deb">Download RootHide DEB</a>
           </article>
 
           <article class="package-card">
             <h3>Rootless Package</h3>
             <p>For standard rootless jailbreak environments. Architecture: iphoneos-arm64.</p>
-            <a class="button orange" href="https://raw.githubusercontent.com/zeshan0727/zeshan0727.github.io/main/debfiles/PhoneAura_0.4.15_Rootless_iOS16.deb">Download Rootless DEB</a>
+            <a class="button orange" href="https://raw.githubusercontent.com/zeshan0727/zeshan0727.github.io/main/debfiles/PhoneAura_0.4.16_Rootless_iOS16.deb">Download Rootless DEB</a>
           </article>
         </div>
       </section>
@@ -862,7 +860,7 @@
           <h3>Installation steps</h3>
           <div class="steps">
             <div class="step"><strong>Add the Next Solution repository</strong><span>Use the Sileo button above or add https://zeshan0727.github.io/ manually.</span></div>
-            <div class="step"><strong>Search for PhoneAura</strong><span>Confirm the package page shows version 0.4.15 and the correct architecture for your jailbreak.</span></div>
+            <div class="step"><strong>Search for PhoneAura</strong><span>Confirm the package page shows version 0.4.16 and the correct architecture for your jailbreak.</span></div>
             <div class="step"><strong>Install or upgrade</strong><span>An existing PhoneAura package can be upgraded because the package identifier remains the same.</span></div>
             <div class="step"><strong>Respring</strong><span>After installation, respring and fully close the Phone app before opening it again.</span></div>
             <div class="step"><strong>Configure PhoneAura</strong><span>Open Settings → PhoneAura, enable the desired replacement tabs, haptics and animations.</span></div>
@@ -872,11 +870,11 @@
         <div class="glass-card prose-card">
           <h3>Recommended first test</h3>
           <ol>
+            <li>Confirm Settings → PhoneAura shows version 0.4.16.</li>
+            <li>Respring, fully close the Phone app and reopen it.</li>
             <li>Open Keypad and type at least two digits.</li>
             <li>Confirm the suggestion area stays visible and the keypad does not move.</li>
-            <li>Long press the typed number and test Copy or Paste.</li>
-            <li>Open Contacts or Recents and long press a displayed number.</li>
-            <li>Check Favorites, Recents filters and the upper Next Solution logo.</li>
+            <li>Check Favorites, Recents filters, Contacts, Number Options and the upper Next Solution logo.</li>
           </ol>
           <div class="warning">Keep access to your package manager and jailbreak safe mode before installing system-interface tweaks. Remove the tweak from safe mode if the Phone app becomes unstable.</div>
         </div>
@@ -898,8 +896,8 @@
             <p>Install the RootHide iphoneos-arm64e package. Do not install the standard rootless package alongside it.</p>
           </details>
           <details>
-            <summary>Why is Cut disabled on saved numbers?</summary>
-            <p>Saved contacts and call-history numbers are read-only in this menu. Disabling Cut protects stored data while still allowing Copy and Paste to Keypad.</p>
+            <summary>Why was long-press number editing removed?</summary>
+            <p>The 0.4.15 implementation modified UILabel behavior globally and caused the Phone app to crash on affected devices. Version 0.4.16 removes that code and restores the stable 0.4.14 runtime.</p>
           </details>
           <details>
             <summary>What appears when no saved contact matches?</summary>
@@ -918,7 +916,7 @@
 
       <footer class="article-footer">
         <strong>PhoneAura is developed by Next Solution — Zeeshan 0727.</strong>
-        <p>Read more jailbreak tutorials on <a href="./#tutorials">Next Solution</a> or visit the <a href="https://youtube.com/@zeshan0727" target="_blank" rel="noopener noreferrer">official YouTube channel</a>.</p>
+        <p>Read more jailbreak tutorials on <a href="tutorials.html">Next Solution</a> or visit the <a href="https://youtube.com/@zeshan0727" target="_blank" rel="noopener noreferrer">official YouTube channel</a>.</p>
         <p>Published July 30, 2026 • Educational customization content for compatible jailbroken devices.</p>
       </footer>
     </article>

--- a/tutorials.html
+++ b/tutorials.html
@@ -222,19 +222,19 @@
 
     <section class="grid" aria-label="Tutorial guides">
       <article class="card featured">
-        <a class="featured-media" href="phoneaura-tweak-ios16.html" aria-label="Open the PhoneAura 0.4.15 guide" style="padding:0; border-radius:0; background:none;">
-          <img src="assets/phoneaura/phoneaura-hero.svg" alt="PhoneAura 0.4.15 redesigned iOS 16 Phone app concept" width="1600" height="900" loading="eager">
+        <a class="featured-media" href="phoneaura-tweak-ios16.html" aria-label="Open the PhoneAura 0.4.16 guide" style="padding:0; border-radius:0; background:none;">
+          <img src="assets/phoneaura/phoneaura-hero.svg" alt="PhoneAura 0.4.16 redesigned iOS 16 Phone app concept" width="1600" height="900" loading="eager">
         </a>
         <div class="featured-body">
           <div class="icon"><i class="fas fa-phone-volume" aria-hidden="true"></i></div>
-          <h3>PhoneAura 0.4.15 — Complete Phone App Redesign</h3>
+          <h3>PhoneAura 0.4.16 — Stable Phone App Redesign</h3>
           <div class="tags" aria-label="PhoneAura compatibility">
             <span class="tag">iOS 16+</span>
             <span class="tag">RootHide</span>
             <span class="tag">Rootless</span>
             <span class="tag">Free download</span>
           </div>
-          <p>Redesign Favorites, Recents, Contacts and Keypad. Includes fixed saved-number suggestions, smart call filters, Number Options, direct DEB downloads and long-press Cut, Copy and Paste controls.</p>
+          <p>Redesign Favorites, Recents, Contacts and Keypad. Includes fixed saved-number suggestions, smart call filters, Number Options, direct DEB downloads and the 0.4.16 emergency stability rollback.</p>
           <a href="phoneaura-tweak-ios16.html">Read guide &amp; download</a>
         </div>
       </article>


### PR DESCRIPTION
Updates the PhoneAura article after the 0.4.15 crash rollback. Applies the same Home, Tutorials, Videos and FAQ navigation rules used by the rest of nextsolution.cc, highlights Tutorials as the active tab, keeps all tabs scrollable on mobile, updates the article and download links to stable version 0.4.16, removes the unsafe long-press feature claims, and permanently pins PhoneAura as the first card in the main page Recent Tutorials section. The dedicated Tutorials page also remains featured and is updated to 0.4.16.