### PR TITLE
PhoneAura 0.5.1 diagnostic recovery console

### DIFF
--- a/.github/workflows/build-phoneaura-050-test.yml
+++ b/.github/workflows/build-phoneaura-050-test.yml
@@ -1,0 +1,153 @@
+name: Build PhoneAura 0.5.0 Test Packages
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "PhoneAuraFeaturePack/**"
+      - ".github/workflows/build-phoneaura-050-test.yml"
+  push:
+    branches:
+      - fix/phoneaura-0416-tabs-and-recent
+    paths:
+      - "PhoneAuraFeaturePack/**"
+      - ".github/workflows/build-phoneaura-050-test.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: brew install dpkg ldid
+
+      - name: Validate source
+        shell: bash
+        run: |
+          set -euo pipefail
+          P="$GITHUB_WORKSPACE/PhoneAuraFeaturePack"
+          for f in Makefile control PhoneAuraNativeFeatures.plist Tweak.m prepare_package.py README.md; do test -f "$P/$f"; done
+          grep -q '^ARCHS = arm64 arm64e$' "$P/Makefile"
+          grep -q 'PAContactsDashboardV46' "$P/Tweak.m"
+          grep -q 'containersMatchingPredicate' "$P/Tweak.m"
+          grep -q 'predicateForContactsInContainerWithIdentifier' "$P/Tweak.m"
+          grep -q 'predicateForContactsInGroupWithIdentifier' "$P/Tweak.m"
+          grep -q 'contactBookSelector' "$P/Tweak.m"
+          grep -q 'com.apple.mobilephone' "$P/PhoneAuraNativeFeatures.plist"
+          python3 -m py_compile "$P/prepare_package.py"
+          plutil -lint "$P/PhoneAuraNativeFeatures.plist"
+
+      - name: Build rootless companion
+        shell: bash
+        run: |
+          set -euo pipefail
+          P="$GITHUB_WORKSPACE/PhoneAuraFeaturePack"
+          git clone --recursive --depth 1 https://github.com/theos/theos.git "$RUNNER_TEMP/theos-rootless"
+          export THEOS="$RUNNER_TEMP/theos-rootless"
+          export THEOS_PACKAGE_SCHEME=rootless
+          rm -rf "$P/packages" "$P/.theos"
+          make -C "$P" clean package FINALPACKAGE=1 2>&1 | tee "$RUNNER_TEMP/rootless-build.log"
+          DEB="$(find "$P/packages" -type f -name '*_iphoneos-arm64.deb' -print -quit)"
+          test -n "$DEB"
+          mkdir -p "$RUNNER_TEMP/companion-rootless"
+          dpkg-deb -x "$DEB" "$RUNNER_TEMP/companion-rootless"
+          test -f "$RUNNER_TEMP/companion-rootless/var/jb/Library/MobileSubstrate/DynamicLibraries/PhoneAuraNativeFeatures.dylib"
+
+      - name: Build RootHide companion
+        shell: bash
+        run: |
+          set -euo pipefail
+          P="$GITHUB_WORKSPACE/PhoneAuraFeaturePack"
+          git init "$RUNNER_TEMP/theos-roothide"
+          git -C "$RUNNER_TEMP/theos-roothide" remote add origin https://github.com/roothide/theos.git
+          git -C "$RUNNER_TEMP/theos-roothide" fetch --depth 1 origin 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+          git -C "$RUNNER_TEMP/theos-roothide" checkout --detach 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+          git -C "$RUNNER_TEMP/theos-roothide" submodule update --init --recursive --depth 1
+          sed -i '' 's/^Architecture: iphoneos-arm64$/Architecture: iphoneos-arm64e/' "$P/control"
+          export THEOS="$RUNNER_TEMP/theos-roothide"
+          export THEOS_PACKAGE_SCHEME=roothide
+          rm -rf "$P/packages" "$P/.theos"
+          make -C "$P" clean package FINALPACKAGE=1 2>&1 | tee "$RUNNER_TEMP/roothide-build.log"
+          DEB="$(find "$P/packages" -type f -name '*_iphoneos-arm64e.deb' -print -quit)"
+          test -n "$DEB"
+          mkdir -p "$RUNNER_TEMP/companion-roothide"
+          dpkg-deb -x "$DEB" "$RUNNER_TEMP/companion-roothide"
+          test -f "$RUNNER_TEMP/companion-roothide/Library/MobileSubstrate/DynamicLibraries/PhoneAuraNativeFeatures.dylib"
+
+      - name: Assemble PhoneAura update packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/phoneaura-050"
+          mkdir -p "$OUT"
+
+          assemble() {
+            kind="$1"; base="$2"; prefix="$3"; companion="$4"; output="$5"
+            layout="$RUNNER_TEMP/layout-$kind"
+            rm -rf "$layout"
+            dpkg-deb -R "$base" "$layout"
+            dynamic="$layout/$prefix/Library/MobileSubstrate/DynamicLibraries"
+            cp "$companion/PhoneAuraNativeFeatures.dylib" "$dynamic/PhoneAuraNativeFeatures.dylib"
+            cp "$GITHUB_WORKSPACE/PhoneAuraFeaturePack/PhoneAuraNativeFeatures.plist" "$dynamic/PhoneAuraNativeFeatures.plist"
+            ldid -S "$dynamic/PhoneAuraNativeFeatures.dylib"
+            python3 "$GITHUB_WORKSPACE/PhoneAuraFeaturePack/prepare_package.py" "$layout" --root-prefix "$prefix"
+            chmod 755 "$layout/DEBIAN/postinst" "$layout/DEBIAN/prerm" || true
+            dpkg-deb -b "$layout" "$OUT/$output"
+          }
+
+          assemble rootless \
+            "$GITHUB_WORKSPACE/debfiles/PhoneAura_0.4.16_Rootless_iOS16.deb" \
+            "var/jb" \
+            "$RUNNER_TEMP/companion-rootless/var/jb/Library/MobileSubstrate/DynamicLibraries" \
+            "PhoneAura_0.5.0_Rootless_iOS16.deb"
+
+          assemble roothide \
+            "$GITHUB_WORKSPACE/debfiles/PhoneAura_0.4.16_RootHide_iOS16.deb" \
+            "" \
+            "$RUNNER_TEMP/companion-roothide/Library/MobileSubstrate/DynamicLibraries" \
+            "PhoneAura_0.5.0_RootHide_iOS16.deb"
+
+      - name: Validate final packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/phoneaura-050"
+          validate() {
+            deb="$1"; arch="$2"; prefix="$3"; x="$(mktemp -d)"
+            test "$(dpkg-deb -f "$deb" Package)" = com.zeshan.phoneaura
+            test "$(dpkg-deb -f "$deb" Version)" = 0.5.0
+            test "$(dpkg-deb -f "$deb" Architecture)" = "$arch"
+            dpkg-deb -x "$deb" "$x"
+            dynamic="$x/$prefix/Library/MobileSubstrate/DynamicLibraries"
+            test -f "$dynamic/PhoneAura.dylib"
+            test -f "$dynamic/PhoneAuraNativeFeatures.dylib"
+            test -f "$dynamic/PhoneAuraNativeFeatures.plist"
+            grep -q com.apple.mobilephone "$dynamic/PhoneAuraNativeFeatures.plist"
+            strings -a "$dynamic/PhoneAuraNativeFeatures.dylib" | grep -q PAContactsDashboardV46
+            strings -a "$dynamic/PhoneAuraNativeFeatures.dylib" | grep -q contactBookSelection
+            strings -a "$dynamic/PhoneAuraNativeFeatures.dylib" | grep -q 'All Contacts'
+            root="$x/$prefix/Library/PreferenceBundles/PhoneAuraPrefs.bundle/Root.plist"
+            info="$x/$prefix/Library/PreferenceBundles/PhoneAuraPrefs.bundle/Info.plist"
+            plutil -lint "$root" "$info"
+            plutil -p "$root" | grep -q 'Contact Book Selector'
+            plutil -p "$info" | grep -q '0.5.0'
+            rm -rf "$x"
+          }
+          validate "$OUT/PhoneAura_0.5.0_Rootless_iOS16.deb" iphoneos-arm64 var/jb
+          validate "$OUT/PhoneAura_0.5.0_RootHide_iOS16.deb" iphoneos-arm64e ""
+          shasum -a 256 "$OUT"/*.deb | tee "$OUT/SHA256SUMS.txt"
+          cp "$RUNNER_TEMP/rootless-build.log" "$OUT/"
+          cp "$RUNNER_TEMP/roothide-build.log" "$OUT/"
+
+      - name: Upload test packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: PhoneAura-0.5.0-test-debs
+          path: ${{ runner.temp }}/phoneaura-050/
+          retention-days: 7

--- a/.github/workflows/build-phoneaura-050-test.yml
+++ b/.github/workflows/build-phoneaura-050-test.yml
@@ -1,153 +1,16 @@
-name: Build PhoneAura 0.5.0 Test Packages
+name: Deprecated PhoneAura 0.5.0 Test Build
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - "PhoneAuraFeaturePack/**"
-      - ".github/workflows/build-phoneaura-050-test.yml"
-  push:
-    branches:
-      - fix/phoneaura-0416-tabs-and-recent
-    paths:
-      - "PhoneAuraFeaturePack/**"
-      - ".github/workflows/build-phoneaura-050-test.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  build:
-    runs-on: macos-15
-    timeout-minutes: 45
+  deprecated:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install build tools
-        run: brew install dpkg ldid
-
-      - name: Validate source
-        shell: bash
+      - name: Deprecated build notice
         run: |
-          set -euo pipefail
-          P="$GITHUB_WORKSPACE/PhoneAuraFeaturePack"
-          for f in Makefile control PhoneAuraNativeFeatures.plist Tweak.m prepare_package.py README.md; do test -f "$P/$f"; done
-          grep -q '^ARCHS = arm64 arm64e$' "$P/Makefile"
-          grep -q 'PAContactsDashboardV46' "$P/Tweak.m"
-          grep -q 'containersMatchingPredicate' "$P/Tweak.m"
-          grep -q 'predicateForContactsInContainerWithIdentifier' "$P/Tweak.m"
-          grep -q 'predicateForContactsInGroupWithIdentifier' "$P/Tweak.m"
-          grep -q 'contactBookSelector' "$P/Tweak.m"
-          grep -q 'com.apple.mobilephone' "$P/PhoneAuraNativeFeatures.plist"
-          python3 -m py_compile "$P/prepare_package.py"
-          plutil -lint "$P/PhoneAuraNativeFeatures.plist"
-
-      - name: Build rootless companion
-        shell: bash
-        run: |
-          set -euo pipefail
-          P="$GITHUB_WORKSPACE/PhoneAuraFeaturePack"
-          git clone --recursive --depth 1 https://github.com/theos/theos.git "$RUNNER_TEMP/theos-rootless"
-          export THEOS="$RUNNER_TEMP/theos-rootless"
-          export THEOS_PACKAGE_SCHEME=rootless
-          rm -rf "$P/packages" "$P/.theos"
-          make -C "$P" clean package FINALPACKAGE=1 2>&1 | tee "$RUNNER_TEMP/rootless-build.log"
-          DEB="$(find "$P/packages" -type f -name '*_iphoneos-arm64.deb' -print -quit)"
-          test -n "$DEB"
-          mkdir -p "$RUNNER_TEMP/companion-rootless"
-          dpkg-deb -x "$DEB" "$RUNNER_TEMP/companion-rootless"
-          test -f "$RUNNER_TEMP/companion-rootless/var/jb/Library/MobileSubstrate/DynamicLibraries/PhoneAuraNativeFeatures.dylib"
-
-      - name: Build RootHide companion
-        shell: bash
-        run: |
-          set -euo pipefail
-          P="$GITHUB_WORKSPACE/PhoneAuraFeaturePack"
-          git init "$RUNNER_TEMP/theos-roothide"
-          git -C "$RUNNER_TEMP/theos-roothide" remote add origin https://github.com/roothide/theos.git
-          git -C "$RUNNER_TEMP/theos-roothide" fetch --depth 1 origin 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
-          git -C "$RUNNER_TEMP/theos-roothide" checkout --detach 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
-          git -C "$RUNNER_TEMP/theos-roothide" submodule update --init --recursive --depth 1
-          sed -i '' 's/^Architecture: iphoneos-arm64$/Architecture: iphoneos-arm64e/' "$P/control"
-          export THEOS="$RUNNER_TEMP/theos-roothide"
-          export THEOS_PACKAGE_SCHEME=roothide
-          rm -rf "$P/packages" "$P/.theos"
-          make -C "$P" clean package FINALPACKAGE=1 2>&1 | tee "$RUNNER_TEMP/roothide-build.log"
-          DEB="$(find "$P/packages" -type f -name '*_iphoneos-arm64e.deb' -print -quit)"
-          test -n "$DEB"
-          mkdir -p "$RUNNER_TEMP/companion-roothide"
-          dpkg-deb -x "$DEB" "$RUNNER_TEMP/companion-roothide"
-          test -f "$RUNNER_TEMP/companion-roothide/Library/MobileSubstrate/DynamicLibraries/PhoneAuraNativeFeatures.dylib"
-
-      - name: Assemble PhoneAura update packages
-        shell: bash
-        run: |
-          set -euo pipefail
-          OUT="$RUNNER_TEMP/phoneaura-050"
-          mkdir -p "$OUT"
-
-          assemble() {
-            kind="$1"; base="$2"; prefix="$3"; companion="$4"; output="$5"
-            layout="$RUNNER_TEMP/layout-$kind"
-            rm -rf "$layout"
-            dpkg-deb -R "$base" "$layout"
-            dynamic="$layout/$prefix/Library/MobileSubstrate/DynamicLibraries"
-            cp "$companion/PhoneAuraNativeFeatures.dylib" "$dynamic/PhoneAuraNativeFeatures.dylib"
-            cp "$GITHUB_WORKSPACE/PhoneAuraFeaturePack/PhoneAuraNativeFeatures.plist" "$dynamic/PhoneAuraNativeFeatures.plist"
-            ldid -S "$dynamic/PhoneAuraNativeFeatures.dylib"
-            python3 "$GITHUB_WORKSPACE/PhoneAuraFeaturePack/prepare_package.py" "$layout" --root-prefix "$prefix"
-            chmod 755 "$layout/DEBIAN/postinst" "$layout/DEBIAN/prerm" || true
-            dpkg-deb -b "$layout" "$OUT/$output"
-          }
-
-          assemble rootless \
-            "$GITHUB_WORKSPACE/debfiles/PhoneAura_0.4.16_Rootless_iOS16.deb" \
-            "var/jb" \
-            "$RUNNER_TEMP/companion-rootless/var/jb/Library/MobileSubstrate/DynamicLibraries" \
-            "PhoneAura_0.5.0_Rootless_iOS16.deb"
-
-          assemble roothide \
-            "$GITHUB_WORKSPACE/debfiles/PhoneAura_0.4.16_RootHide_iOS16.deb" \
-            "" \
-            "$RUNNER_TEMP/companion-roothide/Library/MobileSubstrate/DynamicLibraries" \
-            "PhoneAura_0.5.0_RootHide_iOS16.deb"
-
-      - name: Validate final packages
-        shell: bash
-        run: |
-          set -euo pipefail
-          OUT="$RUNNER_TEMP/phoneaura-050"
-          validate() {
-            deb="$1"; arch="$2"; prefix="$3"; x="$(mktemp -d)"
-            test "$(dpkg-deb -f "$deb" Package)" = com.zeshan.phoneaura
-            test "$(dpkg-deb -f "$deb" Version)" = 0.5.0
-            test "$(dpkg-deb -f "$deb" Architecture)" = "$arch"
-            dpkg-deb -x "$deb" "$x"
-            dynamic="$x/$prefix/Library/MobileSubstrate/DynamicLibraries"
-            test -f "$dynamic/PhoneAura.dylib"
-            test -f "$dynamic/PhoneAuraNativeFeatures.dylib"
-            test -f "$dynamic/PhoneAuraNativeFeatures.plist"
-            grep -q com.apple.mobilephone "$dynamic/PhoneAuraNativeFeatures.plist"
-            strings -a "$dynamic/PhoneAuraNativeFeatures.dylib" | grep -q PAContactsDashboardV46
-            strings -a "$dynamic/PhoneAuraNativeFeatures.dylib" | grep -q contactBookSelection
-            strings -a "$dynamic/PhoneAuraNativeFeatures.dylib" | grep -q 'All Contacts'
-            root="$x/$prefix/Library/PreferenceBundles/PhoneAuraPrefs.bundle/Root.plist"
-            info="$x/$prefix/Library/PreferenceBundles/PhoneAuraPrefs.bundle/Info.plist"
-            plutil -lint "$root" "$info"
-            plutil -p "$root" | grep -q 'Contact Book Selector'
-            plutil -p "$info" | grep -q '0.5.0'
-            rm -rf "$x"
-          }
-          validate "$OUT/PhoneAura_0.5.0_Rootless_iOS16.deb" iphoneos-arm64 var/jb
-          validate "$OUT/PhoneAura_0.5.0_RootHide_iOS16.deb" iphoneos-arm64e ""
-          shasum -a 256 "$OUT"/*.deb | tee "$OUT/SHA256SUMS.txt"
-          cp "$RUNNER_TEMP/rootless-build.log" "$OUT/"
-          cp "$RUNNER_TEMP/roothide-build.log" "$OUT/"
-
-      - name: Upload test packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: PhoneAura-0.5.0-test-debs
-          path: ${{ runner.temp }}/phoneaura-050/
-          retention-days: 7
+          echo "PhoneAura 0.5.0 is deprecated because its PhoneAuraNativeFeatures companion hook caused runtime breakage on-device."
+          echo "Use the PhoneAura 0.5.1 Diagnostic Recovery workflow instead."

--- a/.github/workflows/build-phoneaura-051-diagnostic.yml
+++ b/.github/workflows/build-phoneaura-051-diagnostic.yml
@@ -54,7 +54,7 @@ jobs:
           xcrun --sdk iphoneos clang \
             -fobjc-arc -arch arm64 -miphoneos-version-min=15.0 \
             -isysroot "$SDK" -O2 -Wall -Wextra \
-            -framework UIKit -framework Foundation -framework CoreFoundation \
+            -framework UIKit -framework Foundation -framework CoreFoundation -framework CoreGraphics -framework QuartzCore \
             "$P/ConsoleApp.m" -o "$RUNNER_TEMP/PhoneAuraConsole"
           ldid -S "$RUNNER_TEMP/PhoneAuraConsole"
           file "$RUNNER_TEMP/PhoneAuraConsole"

--- a/.github/workflows/build-phoneaura-051-diagnostic.yml
+++ b/.github/workflows/build-phoneaura-051-diagnostic.yml
@@ -1,0 +1,212 @@
+name: Build PhoneAura 0.5.1 Diagnostic
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "PhoneAuraDiagnostics/**"
+      - ".github/workflows/build-phoneaura-051-diagnostic.yml"
+  push:
+    branches:
+      - fix/phoneaura-0416-tabs-and-recent
+    paths:
+      - "PhoneAuraDiagnostics/**"
+      - ".github/workflows/build-phoneaura-051-diagnostic.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: brew install dpkg ldid
+
+      - name: Validate source
+        shell: bash
+        run: |
+          set -euo pipefail
+          P="$GITHUB_WORKSPACE/PhoneAuraDiagnostics"
+          for f in Makefile control PhoneAuraDiagnostics.plist DiagnosticsTweak.m ConsoleApp.m ConsoleInfo.plist prepare_package.py README.md; do test -f "$P/$f"; done
+          grep -q '^ARCHS = arm64 arm64e$' "$P/Makefile"
+          grep -q 'PhoneAuraDiagnostics.dylib' "$P/DiagnosticsTweak.m"
+          grep -q 'PhoneAuraNativeFeatures.dylib' "$P/DiagnosticsTweak.m"
+          grep -q 'Run Full Diagnosis' "$P/ConsoleApp.m"
+          grep -q 'Test Favorites' "$P/ConsoleApp.m"
+          grep -q 'Test Recents' "$P/ConsoleApp.m"
+          grep -q 'Test Contacts + Accounts' "$P/ConsoleApp.m"
+          grep -q 'Test Keypad' "$P/ConsoleApp.m"
+          grep -q 'Import Latest MobilePhone Crash' "$P/ConsoleApp.m"
+          python3 -m py_compile "$P/prepare_package.py"
+          plutil -lint "$P/PhoneAuraDiagnostics.plist" "$P/ConsoleInfo.plist"
+
+      - name: Build PhoneAura Console app
+        shell: bash
+        run: |
+          set -euo pipefail
+          P="$GITHUB_WORKSPACE/PhoneAuraDiagnostics"
+          SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
+          xcrun --sdk iphoneos clang \
+            -fobjc-arc -arch arm64 -miphoneos-version-min=15.0 \
+            -isysroot "$SDK" -O2 -Wall -Wextra \
+            -framework UIKit -framework Foundation -framework CoreFoundation \
+            "$P/ConsoleApp.m" -o "$RUNNER_TEMP/PhoneAuraConsole"
+          ldid -S "$RUNNER_TEMP/PhoneAuraConsole"
+          file "$RUNNER_TEMP/PhoneAuraConsole"
+          otool -L "$RUNNER_TEMP/PhoneAuraConsole"
+
+      - name: Build rootless passive diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+          P="$GITHUB_WORKSPACE/PhoneAuraDiagnostics"
+          git clone --recursive --depth 1 https://github.com/theos/theos.git "$RUNNER_TEMP/theos-rootless"
+          export THEOS="$RUNNER_TEMP/theos-rootless"
+          export THEOS_PACKAGE_SCHEME=rootless
+          rm -rf "$P/packages" "$P/.theos"
+          make -C "$P" clean package FINALPACKAGE=1 STRIP=0 2>&1 | tee "$RUNNER_TEMP/rootless-build.log"
+          DEB="$(find "$P/packages" -type f -name '*_iphoneos-arm64.deb' -print -quit)"
+          test -n "$DEB"
+          mkdir -p "$RUNNER_TEMP/diag-rootless"
+          dpkg-deb -x "$DEB" "$RUNNER_TEMP/diag-rootless"
+          test -f "$RUNNER_TEMP/diag-rootless/var/jb/Library/MobileSubstrate/DynamicLibraries/PhoneAuraDiagnostics.dylib"
+
+      - name: Build RootHide passive diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+          P="$GITHUB_WORKSPACE/PhoneAuraDiagnostics"
+          git init "$RUNNER_TEMP/theos-roothide"
+          git -C "$RUNNER_TEMP/theos-roothide" remote add origin https://github.com/roothide/theos.git
+          git -C "$RUNNER_TEMP/theos-roothide" fetch --depth 1 origin 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+          git -C "$RUNNER_TEMP/theos-roothide" checkout --detach 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+          git -C "$RUNNER_TEMP/theos-roothide" submodule update --init --recursive --depth 1
+          cp "$P/control" "$RUNNER_TEMP/control.backup"
+          sed -i '' 's/^Architecture: iphoneos-arm64$/Architecture: iphoneos-arm64e/' "$P/control"
+          export THEOS="$RUNNER_TEMP/theos-roothide"
+          export THEOS_PACKAGE_SCHEME=roothide
+          rm -rf "$P/packages" "$P/.theos"
+          make -C "$P" clean package FINALPACKAGE=1 STRIP=0 2>&1 | tee "$RUNNER_TEMP/roothide-build.log"
+          mv "$RUNNER_TEMP/control.backup" "$P/control"
+          DEB="$(find "$P/packages" -type f -name '*_iphoneos-arm64e.deb' -print -quit)"
+          test -n "$DEB"
+          mkdir -p "$RUNNER_TEMP/diag-roothide"
+          dpkg-deb -x "$DEB" "$RUNNER_TEMP/diag-roothide"
+          test -f "$RUNNER_TEMP/diag-roothide/Library/MobileSubstrate/DynamicLibraries/PhoneAuraDiagnostics.dylib"
+
+      - name: Assemble diagnostic recovery packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/phoneaura-051-diagnostic"
+          mkdir -p "$OUT"
+
+          assemble() {
+            kind="$1"; base="$2"; prefix="$3"; diagdir="$4"; output="$5"
+            layout="$RUNNER_TEMP/layout-$kind"
+            rm -rf "$layout"
+            dpkg-deb -R "$base" "$layout"
+
+            dynamic="$layout/$prefix/Library/MobileSubstrate/DynamicLibraries"
+            apps="$layout/$prefix/Applications"
+            mkdir -p "$dynamic" "$apps/PhoneAuraConsole.app"
+
+            rm -f "$dynamic/PhoneAuraNativeFeatures.dylib" "$dynamic/PhoneAuraNativeFeatures.plist"
+
+            cp "$diagdir/PhoneAuraDiagnostics.dylib" "$dynamic/PhoneAuraDiagnostics.dylib"
+            cp "$GITHUB_WORKSPACE/PhoneAuraDiagnostics/PhoneAuraDiagnostics.plist" "$dynamic/PhoneAuraDiagnostics.plist"
+            ldid -S "$dynamic/PhoneAuraDiagnostics.dylib"
+
+            cp "$RUNNER_TEMP/PhoneAuraConsole" "$apps/PhoneAuraConsole.app/PhoneAuraConsole"
+            cp "$GITHUB_WORKSPACE/PhoneAuraDiagnostics/ConsoleInfo.plist" "$apps/PhoneAuraConsole.app/Info.plist"
+            cp "$apps/PhoneAuraStudio.app/icon.png" "$apps/PhoneAuraConsole.app/icon.png"
+            chmod 755 "$apps/PhoneAuraConsole.app/PhoneAuraConsole"
+            ldid -S "$apps/PhoneAuraConsole.app/PhoneAuraConsole"
+
+            python3 "$GITHUB_WORKSPACE/PhoneAuraDiagnostics/prepare_package.py" "$layout" --root-prefix "$prefix"
+            chmod 755 "$layout/DEBIAN/postinst" "$layout/DEBIAN/prerm" || true
+            dpkg-deb -b "$layout" "$OUT/$output"
+          }
+
+          assemble rootless \
+            "$GITHUB_WORKSPACE/debfiles/PhoneAura_0.4.16_Rootless_iOS16.deb" \
+            "var/jb" \
+            "$RUNNER_TEMP/diag-rootless/var/jb/Library/MobileSubstrate/DynamicLibraries" \
+            "PhoneAura_0.5.1_Diagnostic_Rootless_iOS16.deb"
+
+          assemble roothide \
+            "$GITHUB_WORKSPACE/debfiles/PhoneAura_0.4.16_RootHide_iOS16.deb" \
+            "" \
+            "$RUNNER_TEMP/diag-roothide/Library/MobileSubstrate/DynamicLibraries" \
+            "PhoneAura_0.5.1_Diagnostic_RootHide_iOS16.deb"
+
+      - name: Validate final packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/phoneaura-051-diagnostic"
+          validate() {
+            deb="$1"; base="$2"; arch="$3"; prefix="$4"; x="$(mktemp -d)"; b="$(mktemp -d)"
+            test "$(dpkg-deb -f "$deb" Package)" = com.zeshan.phoneaura
+            test "$(dpkg-deb -f "$deb" Version)" = 0.5.1
+            test "$(dpkg-deb -f "$deb" Architecture)" = "$arch"
+            dpkg-deb -x "$deb" "$x"
+            dpkg-deb -x "$base" "$b"
+            dynamic="$x/$prefix/Library/MobileSubstrate/DynamicLibraries"
+            basedynamic="$b/$prefix/Library/MobileSubstrate/DynamicLibraries"
+            apps="$x/$prefix/Applications"
+
+            test -f "$dynamic/PhoneAura.dylib"
+            test -f "$dynamic/PhoneAuraDiagnostics.dylib"
+            test -f "$dynamic/PhoneAuraDiagnostics.plist"
+            test ! -e "$dynamic/PhoneAuraNativeFeatures.dylib"
+            test ! -e "$dynamic/PhoneAuraNativeFeatures.plist"
+            cmp "$dynamic/PhoneAura.dylib" "$basedynamic/PhoneAura.dylib"
+
+            test -f "$apps/PhoneAuraStudio.app/PhoneAuraStudio"
+            test -f "$apps/PhoneAuraConsole.app/PhoneAuraConsole"
+            test -f "$apps/PhoneAuraConsole.app/Info.plist"
+            plutil -lint "$apps/PhoneAuraConsole.app/Info.plist"
+            plutil -p "$apps/PhoneAuraConsole.app/Info.plist" | grep -q 'com.zeshan.phoneaura.console'
+
+            grep -q com.apple.mobilephone "$dynamic/PhoneAuraDiagnostics.plist"
+            strings -a "$dynamic/PhoneAuraDiagnostics.dylib" | grep -q 'FULL DIAGNOSIS START'
+            strings -a "$dynamic/PhoneAuraDiagnostics.dylib" | grep -q 'PhoneAuraNativeFeatures.dylib'
+            strings -a "$apps/PhoneAuraConsole.app/PhoneAuraConsole" | grep -q 'Run Full Diagnosis'
+            strings -a "$apps/PhoneAuraConsole.app/PhoneAuraConsole" | grep -q 'Import Latest MobilePhone Crash'
+
+            root="$x/$prefix/Library/PreferenceBundles/PhoneAuraPrefs.bundle/Root.plist"
+            plutil -lint "$root"
+            plutil -p "$root" | grep -q 'PHONEAURA 0.5.1 DIAGNOSTIC'
+            plutil -p "$root" | grep -q 'DIAGNOSTIC CONSOLE'
+            ! plutil -p "$root" | grep -q 'Contact Book Selector'
+            rm -rf "$x" "$b"
+          }
+
+          validate "$OUT/PhoneAura_0.5.1_Diagnostic_Rootless_iOS16.deb" \
+            "$GITHUB_WORKSPACE/debfiles/PhoneAura_0.4.16_Rootless_iOS16.deb" iphoneos-arm64 var/jb
+          validate "$OUT/PhoneAura_0.5.1_Diagnostic_RootHide_iOS16.deb" \
+            "$GITHUB_WORKSPACE/debfiles/PhoneAura_0.4.16_RootHide_iOS16.deb" iphoneos-arm64e ""
+
+          shasum -a 256 "$OUT"/*.deb | tee "$OUT/SHA256SUMS.txt"
+          cp "$RUNNER_TEMP/rootless-build.log" "$OUT/"
+          cp "$RUNNER_TEMP/roothide-build.log" "$OUT/"
+          printf '%s\n' \
+            'PhoneAura 0.5.1 Diagnostic Recovery' \
+            'Base PhoneAura.dylib: unchanged from 0.4.16' \
+            'PhoneAuraNativeFeatures 0.5.0 hook: removed from package' \
+            'Passive PhoneAuraDiagnostics dylib: included' \
+            'PhoneAura Console app: included' \
+            > "$OUT/VALIDATION.txt"
+
+      - name: Upload diagnostic packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: PhoneAura-0.5.1-diagnostic-debs
+          path: ${{ runner.temp }}/phoneaura-051-diagnostic/
+          retention-days: 14

--- a/.github/workflows/export-phoneaura-source.yml
+++ b/.github/workflows/export-phoneaura-source.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - fix/phoneaura-0416-tabs-and-recent
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/export-phoneaura-source.yml
+++ b/.github/workflows/export-phoneaura-source.yml
@@ -1,12 +1,6 @@
-name: Export PhoneAura source
+name: Export PhoneAura source (manual)
 
 on:
-  push:
-    branches:
-      - fix/phoneaura-0416-tabs-and-recent
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/export-phoneaura-source.yml
+++ b/.github/workflows/export-phoneaura-source.yml
@@ -1,0 +1,26 @@
+name: Export PhoneAura source
+
+on:
+  push:
+    branches:
+      - fix/phoneaura-0416-tabs-and-recent
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@v4
+      - name: Archive source tree
+        run: |
+          zip -r phoneaura-source.zip . -x '.git/*' 'phoneaura-source.zip'
+      - name: Upload source archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: phoneaura-source
+          path: phoneaura-source.zip
+          retention-days: 1

--- a/PhoneAuraDiagnostics/ConsoleApp.m
+++ b/PhoneAuraDiagnostics/ConsoleApp.m
@@ -1,0 +1,340 @@
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <CoreFoundation/CoreFoundation.h>
+
+static NSString * const PAStatusPath = @"/var/mobile/Library/Preferences/com.zeshan.phoneaura.diagnostics.plist";
+static NSString * const PALogDirectory = @"/var/mobile/Library/Logs/PhoneAura";
+static NSString * const PALogPath = @"/var/mobile/Library/Logs/PhoneAura/PhoneAuraDiagnostics.log";
+
+static NSString *PAString(id value) {
+    if (!value || value == NSNull.null) return @"—";
+    if ([value isKindOfClass:NSString.class]) return value;
+    return [value description];
+}
+
+@interface PAConsoleViewController : UIViewController
+@property (nonatomic, strong) UIScrollView *scrollView;
+@property (nonatomic, strong) UIStackView *stack;
+@property (nonatomic, strong) UILabel *runningValue;
+@property (nonatomic, strong) UILabel *versionValue;
+@property (nonatomic, strong) UILabel *processValue;
+@property (nonatomic, strong) UILabel *environmentValue;
+@property (nonatomic, strong) UILabel *baseRuntimeValue;
+@property (nonatomic, strong) UILabel *oldHookValue;
+@property (nonatomic, strong) UILabel *heartbeatValue;
+@property (nonatomic, strong) UILabel *screenValue;
+@property (nonatomic, strong) UILabel *commandValue;
+@property (nonatomic, strong) UITextView *logView;
+@property (nonatomic, strong) NSTimer *timer;
+@end
+
+@implementation PAConsoleViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"PhoneAura Console";
+    self.view.backgroundColor = UIColor.systemGroupedBackgroundColor;
+    [self buildUI];
+    [self refreshConsole];
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(refreshConsole) userInfo:nil repeats:YES];
+}
+
+- (void)dealloc {
+    [self.timer invalidate];
+}
+
+- (UILabel *)valueLabel {
+    UILabel *label = [UILabel new];
+    label.font = [UIFont monospacedSystemFontOfSize:13 weight:UIFontWeightSemibold];
+    label.textColor = UIColor.labelColor;
+    label.numberOfLines = 0;
+    label.textAlignment = NSTextAlignmentRight;
+    return label;
+}
+
+- (UIView *)cardWithTitle:(NSString *)title content:(UIView *)content {
+    UIView *card = [UIView new];
+    card.backgroundColor = UIColor.secondarySystemGroupedBackgroundColor;
+    card.layer.cornerRadius = 16;
+    card.layer.cornerCurve = kCACornerCurveContinuous;
+    card.translatesAutoresizingMaskIntoConstraints = NO;
+
+    UILabel *header = [UILabel new];
+    header.text = title;
+    header.font = [UIFont systemFontOfSize:15 weight:UIFontWeightBold];
+
+    UIStackView *inner = [[UIStackView alloc] initWithArrangedSubviews:@[header, content]];
+    inner.axis = UILayoutConstraintAxisVertical;
+    inner.spacing = 10;
+    inner.translatesAutoresizingMaskIntoConstraints = NO;
+    [card addSubview:inner];
+    [NSLayoutConstraint activateConstraints:@[
+        [inner.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:14],
+        [inner.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-14],
+        [inner.topAnchor constraintEqualToAnchor:card.topAnchor constant:14],
+        [inner.bottomAnchor constraintEqualToAnchor:card.bottomAnchor constant:-14]
+    ]];
+    return card;
+}
+
+- (UIView *)statusRows {
+    UIStackView *rows = [UIStackView new];
+    rows.axis = UILayoutConstraintAxisVertical;
+    rows.spacing = 8;
+    NSArray *titles = @[@"Running", @"Version", @"Process", @"Environment", @"Base PhoneAura", @"Old 0.5.0 Hook", @"Heartbeat", @"Current Screen", @"Last Command"];
+    self.runningValue = [self valueLabel];
+    self.versionValue = [self valueLabel];
+    self.processValue = [self valueLabel];
+    self.environmentValue = [self valueLabel];
+    self.baseRuntimeValue = [self valueLabel];
+    self.oldHookValue = [self valueLabel];
+    self.heartbeatValue = [self valueLabel];
+    self.screenValue = [self valueLabel];
+    self.commandValue = [self valueLabel];
+    NSArray *values = @[self.runningValue, self.versionValue, self.processValue, self.environmentValue, self.baseRuntimeValue, self.oldHookValue, self.heartbeatValue, self.screenValue, self.commandValue];
+    [titles enumerateObjectsUsingBlock:^(NSString *title, NSUInteger idx, BOOL *stop) {
+        UILabel *key = [UILabel new];
+        key.text = title;
+        key.font = [UIFont systemFontOfSize:13 weight:UIFontWeightRegular];
+        key.textColor = UIColor.secondaryLabelColor;
+        UIStackView *row = [[UIStackView alloc] initWithArrangedSubviews:@[key, values[idx]]];
+        row.axis = UILayoutConstraintAxisHorizontal;
+        row.alignment = UIStackViewAlignmentFirstBaseline;
+        row.distribution = UIStackViewDistributionFill;
+        [key setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+        [rows addArrangedSubview:row];
+    }];
+    return rows;
+}
+
+- (UIButton *)button:(NSString *)title action:(SEL)action {
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    [button setTitle:title forState:UIControlStateNormal];
+    button.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold];
+    button.backgroundColor = UIColor.tertiarySystemFillColor;
+    button.layer.cornerRadius = 12;
+    button.layer.cornerCurve = kCACornerCurveContinuous;
+    button.contentEdgeInsets = UIEdgeInsetsMake(11, 12, 11, 12);
+    [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+    return button;
+}
+
+- (void)buildUI {
+    self.scrollView = [UIScrollView new];
+    self.scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:self.scrollView];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.scrollView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.scrollView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.scrollView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor],
+        [self.scrollView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+    ]];
+
+    self.stack = [UIStackView new];
+    self.stack.axis = UILayoutConstraintAxisVertical;
+    self.stack.spacing = 12;
+    self.stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.scrollView addSubview:self.stack];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.stack.leadingAnchor constraintEqualToAnchor:self.scrollView.frameLayoutGuide.leadingAnchor constant:14],
+        [self.stack.trailingAnchor constraintEqualToAnchor:self.scrollView.frameLayoutGuide.trailingAnchor constant:-14],
+        [self.stack.topAnchor constraintEqualToAnchor:self.scrollView.contentLayoutGuide.topAnchor constant:14],
+        [self.stack.bottomAnchor constraintEqualToAnchor:self.scrollView.contentLayoutGuide.bottomAnchor constant:-24],
+        [self.stack.widthAnchor constraintEqualToAnchor:self.scrollView.frameLayoutGuide.widthAnchor constant:-28]
+    ]];
+
+    UILabel *intro = [UILabel new];
+    intro.text = @"Diagnostic build: keep this console available, open PhoneAura, reproduce one broken feature, then return here and tap that feature test. The report records what loaded and what did not.";
+    intro.font = [UIFont systemFontOfSize:13];
+    intro.textColor = UIColor.secondaryLabelColor;
+    intro.numberOfLines = 0;
+    [self.stack addArrangedSubview:[self cardWithTitle:@"How to diagnose" content:intro]];
+    [self.stack addArrangedSubview:[self cardWithTitle:@"Runtime Status" content:[self statusRows]]];
+
+    UIStackView *mainActions = [UIStackView new];
+    mainActions.axis = UILayoutConstraintAxisVertical;
+    mainActions.spacing = 8;
+    [mainActions addArrangedSubview:[self button:@"Run Full Diagnosis" action:@selector(runFull)]];
+    [mainActions addArrangedSubview:[self button:@"Snapshot Current Phone UI" action:@selector(runSnapshot)]];
+    [mainActions addArrangedSubview:[self button:@"Import Latest MobilePhone Crash" action:@selector(importCrash)]];
+    [self.stack addArrangedSubview:[self cardWithTitle:@"Diagnosis" content:mainActions]];
+
+    UIStackView *features = [UIStackView new];
+    features.axis = UILayoutConstraintAxisVertical;
+    features.spacing = 8;
+    [features addArrangedSubview:[self button:@"Test Favorites" action:@selector(testFavorites)]];
+    [features addArrangedSubview:[self button:@"Test Recents" action:@selector(testRecents)]];
+    [features addArrangedSubview:[self button:@"Test Contacts + Accounts" action:@selector(testContacts)]];
+    [features addArrangedSubview:[self button:@"Test Keypad" action:@selector(testKeypad)]];
+    [features addArrangedSubview:[self button:@"Test Voicemail / System Tab" action:@selector(testVoicemail)]];
+    [self.stack addArrangedSubview:[self cardWithTitle:@"Feature Tests" content:features]];
+
+    self.logView = [UITextView new];
+    self.logView.editable = NO;
+    self.logView.selectable = YES;
+    self.logView.scrollEnabled = YES;
+    self.logView.font = [UIFont monospacedSystemFontOfSize:10.5 weight:UIFontWeightRegular];
+    self.logView.backgroundColor = UIColor.systemBackgroundColor;
+    self.logView.layer.cornerRadius = 10;
+    self.logView.layer.borderWidth = 0.5;
+    self.logView.layer.borderColor = UIColor.separatorColor.CGColor;
+    [self.logView.heightAnchor constraintEqualToConstant:360].active = YES;
+    [self.stack addArrangedSubview:[self cardWithTitle:@"Live Diagnostic Log" content:self.logView]];
+
+    UIStackView *logActions = [UIStackView new];
+    logActions.axis = UILayoutConstraintAxisVertical;
+    logActions.spacing = 8;
+    [logActions addArrangedSubview:[self button:@"Copy Log" action:@selector(copyLog)]];
+    [logActions addArrangedSubview:[self button:@"Share Log" action:@selector(shareLog)]];
+    [logActions addArrangedSubview:[self button:@"Clear Log" action:@selector(clearLog)]];
+    [self.stack addArrangedSubview:[self cardWithTitle:@"Log Actions" content:logActions]];
+}
+
+- (void)postCommand:(NSString *)suffix {
+    NSString *name = [@"com.zeshan.phoneaura.diag.command." stringByAppendingString:suffix];
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(),
+                                         (__bridge CFStringRef)name,
+                                         NULL, NULL, true);
+    [self refreshConsole];
+}
+
+- (void)runFull { [self postCommand:@"full"]; }
+- (void)runSnapshot { [self postCommand:@"snapshot"]; }
+- (void)testFavorites { [self postCommand:@"favorites"]; }
+- (void)testRecents { [self postCommand:@"recents"]; }
+- (void)testContacts { [self postCommand:@"contacts"]; }
+- (void)testKeypad { [self postCommand:@"keypad"]; }
+- (void)testVoicemail { [self postCommand:@"voicemail"]; }
+
+- (NSString *)currentLog {
+    NSString *log = [NSString stringWithContentsOfFile:PALogPath encoding:NSUTF8StringEncoding error:nil];
+    return log ?: @"No diagnostic log yet. Open the Phone app once after installing this build.";
+}
+
+- (void)refreshConsole {
+    NSDictionary *status = [NSDictionary dictionaryWithContentsOfFile:PAStatusPath] ?: @{};
+    NSTimeInterval heartbeat = [status[@"heartbeatEpoch"] doubleValue];
+    NSTimeInterval age = heartbeat > 0 ? [[NSDate date] timeIntervalSince1970] - heartbeat : DBL_MAX;
+    BOOL running = age <= 12.0;
+    self.runningValue.text = running ? @"YES" : @"NO";
+    self.runningValue.textColor = running ? UIColor.systemGreenColor : UIColor.systemRedColor;
+    self.versionValue.text = PAString(status[@"diagnosticVersion"]);
+    self.processValue.text = [NSString stringWithFormat:@"%@ (%@)", PAString(status[@"process"]), PAString(status[@"pid"])];
+    self.environmentValue.text = PAString(status[@"environment"]);
+    self.baseRuntimeValue.text = [status[@"baseRuntimeLoaded"] boolValue] ? @"LOADED" : @"NOT LOADED";
+    self.baseRuntimeValue.textColor = [status[@"baseRuntimeLoaded"] boolValue] ? UIColor.systemGreenColor : UIColor.systemRedColor;
+    self.oldHookValue.text = [status[@"oldNativeFeatureLoaded"] boolValue] ? @"STILL LOADED" : @"NOT LOADED";
+    self.oldHookValue.textColor = [status[@"oldNativeFeatureLoaded"] boolValue] ? UIColor.systemOrangeColor : UIColor.systemGreenColor;
+    self.heartbeatValue.text = heartbeat > 0 ? [NSString stringWithFormat:@"%@ (%.0fs ago)", PAString(status[@"heartbeat"]), MAX(age, 0)] : @"Never";
+    self.screenValue.text = PAString(status[@"topController"]);
+    self.commandValue.text = PAString(status[@"lastCommand"]);
+
+    NSString *newLog = [self currentLog];
+    if (![self.logView.text isEqualToString:newLog]) {
+        BOOL nearBottom = self.logView.contentOffset.y + self.logView.bounds.size.height >= self.logView.contentSize.height - 50;
+        self.logView.text = newLog;
+        if (nearBottom && newLog.length) {
+            [self.logView scrollRangeToVisible:NSMakeRange(newLog.length - 1, 1)];
+        }
+    }
+}
+
+- (void)copyLog {
+    UIPasteboard.generalPasteboard.string = [self currentLog];
+    [self showMessage:@"Copied" body:@"The complete PhoneAura diagnostic log is on the clipboard."];
+}
+
+- (void)shareLog {
+    [[NSFileManager defaultManager] createDirectoryAtPath:PALogDirectory withIntermediateDirectories:YES attributes:nil error:nil];
+    if (![[NSFileManager defaultManager] fileExistsAtPath:PALogPath]) {
+        [[self currentLog] writeToFile:PALogPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    }
+    UIActivityViewController *share = [[UIActivityViewController alloc] initWithActivityItems:@[[NSURL fileURLWithPath:PALogPath]] applicationActivities:nil];
+    share.popoverPresentationController.sourceView = self.view;
+    share.popoverPresentationController.sourceRect = CGRectMake(CGRectGetMidX(self.view.bounds), CGRectGetMaxY(self.view.bounds) - 40, 1, 1);
+    [self presentViewController:share animated:YES completion:nil];
+}
+
+- (void)clearLog {
+    [[NSFileManager defaultManager] removeItemAtPath:PALogPath error:nil];
+    [self postCommand:@"clear"];
+    self.logView.text = @"Log cleared. Reproduce the issue, then run the matching feature test.";
+}
+
+- (NSArray<NSString *> *)crashDirectories {
+    return @[@"/var/mobile/Library/Logs/CrashReporter",
+             @"/var/mobile/Library/Logs/CrashReporter/Retired",
+             @"/var/mobile/Library/Logs/CrashReporter/DiagnosticLogs"];
+}
+
+- (void)importCrash {
+    NSFileManager *fm = NSFileManager.defaultManager;
+    NSString *bestPath = nil;
+    NSDate *bestDate = nil;
+    for (NSString *directory in [self crashDirectories]) {
+        NSDirectoryEnumerator *enumerator = [fm enumeratorAtPath:directory];
+        for (NSString *relative in enumerator) {
+            NSString *lower = relative.lowercaseString;
+            if (!([lower containsString:@"mobilephone"] || [lower containsString:@"phoneaura"])) continue;
+            if (!([lower hasSuffix:@".ips"] || [lower hasSuffix:@".crash"] || [lower hasSuffix:@".log"])) continue;
+            NSString *path = [directory stringByAppendingPathComponent:relative];
+            NSDictionary *attrs = [fm attributesOfItemAtPath:path error:nil];
+            NSDate *date = attrs[NSFileModificationDate];
+            if (!bestDate || [date compare:bestDate] == NSOrderedDescending) {
+                bestDate = date;
+                bestPath = path;
+            }
+        }
+    }
+    if (!bestPath) {
+        [self showMessage:@"No crash log found" body:@"The console could not find a MobilePhone/PhoneAura .ips or .crash file in the usual CrashReporter folders."];
+        return;
+    }
+    NSData *data = [NSData dataWithContentsOfFile:bestPath];
+    if (!data.length) {
+        [self showMessage:@"Crash log unreadable" body:bestPath];
+        return;
+    }
+    NSUInteger maxBytes = 180 * 1024;
+    if (data.length > maxBytes) data = [data subdataWithRange:NSMakeRange(data.length - maxBytes, maxBytes)];
+    NSString *text = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: @"<binary/unreadable crash log>";
+    NSString *block = [NSString stringWithFormat:@"\n[%@] [INFO] [CRASH-IMPORT] source=%@ modified=%@\n%@\n[END CRASH IMPORT]\n",
+                       [NSDate date], bestPath, bestDate ?: [NSDate date], text];
+    [[NSFileManager defaultManager] createDirectoryAtPath:PALogDirectory withIntermediateDirectories:YES attributes:nil error:nil];
+    if (![fm fileExistsAtPath:PALogPath]) [@"" writeToFile:PALogPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    NSFileHandle *handle = [NSFileHandle fileHandleForWritingAtPath:PALogPath];
+    [handle seekToEndOfFile];
+    [handle writeData:[block dataUsingEncoding:NSUTF8StringEncoding]];
+    [handle closeFile];
+    [self refreshConsole];
+    [self showMessage:@"Crash imported" body:[NSString stringWithFormat:@"Added the latest crash log to the report:\n%@", bestPath.lastPathComponent]];
+}
+
+- (void)showMessage:(NSString *)title body:(NSString *)body {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:body preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+@end
+
+@interface PAConsoleAppDelegate : UIResponder <UIApplicationDelegate>
+@property (nonatomic, strong) UIWindow *window;
+@end
+
+@implementation PAConsoleAppDelegate
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    PAConsoleViewController *root = [PAConsoleViewController new];
+    UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:root];
+    self.window.rootViewController = nav;
+    [self.window makeKeyAndVisible];
+    return YES;
+}
+@end
+
+int main(int argc, char *argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass(PAConsoleAppDelegate.class));
+    }
+}

--- a/PhoneAuraDiagnostics/ConsoleInfo.plist
+++ b/PhoneAuraDiagnostics/ConsoleInfo.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key><string>PhoneAura Console</string>
+    <key>CFBundleExecutable</key><string>PhoneAuraConsole</string>
+    <key>CFBundleIdentifier</key><string>com.zeshan.phoneaura.console</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>CFBundleName</key><string>PhoneAura Console</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleShortVersionString</key><string>0.5.1</string>
+    <key>CFBundleVersion</key><string>51</string>
+    <key>LSRequiresIPhoneOS</key><true/>
+    <key>MinimumOSVersion</key><string>15.0</string>
+    <key>UIApplicationSupportsIndirectInputEvents</key><true/>
+    <key>UILaunchScreen</key><dict/>
+    <key>UIRequiredDeviceCapabilities</key><array><string>arm64</string></array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array><string>UIInterfaceOrientationPortrait</string></array>
+    <key>CFBundleIcons</key>
+    <dict><key>CFBundlePrimaryIcon</key><dict><key>CFBundleIconFiles</key><array><string>icon</string></array></dict></dict>
+</dict>
+</plist>

--- a/PhoneAuraDiagnostics/DiagnosticsTweak.m
+++ b/PhoneAuraDiagnostics/DiagnosticsTweak.m
@@ -1,0 +1,502 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <Contacts/Contacts.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <objc/runtime.h>
+#import <mach-o/dyld.h>
+
+static NSString * const PADiagnosticsVersion = @"0.5.1-diagnostic";
+static NSString * const PAPreferencesDomain = @"com.zeshan.phoneaura";
+static NSString * const PAStatusPath = @"/var/mobile/Library/Preferences/com.zeshan.phoneaura.diagnostics.plist";
+static NSString * const PALogDirectory = @"/var/mobile/Library/Logs/PhoneAura";
+static NSString * const PALogPath = @"/var/mobile/Library/Logs/PhoneAura/PhoneAuraDiagnostics.log";
+
+static NSUncaughtExceptionHandler *PAPreviousExceptionHandler = NULL;
+static dispatch_source_t PAHeartbeatTimer = nil;
+
+static NSString *PATimestamp(void) {
+    static NSDateFormatter *formatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [NSDateFormatter new];
+        formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss.SSS";
+    });
+    return [formatter stringFromDate:[NSDate date]];
+}
+
+static void PAEnsureLogDirectory(void) {
+    [[NSFileManager defaultManager] createDirectoryAtPath:PALogDirectory
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+}
+
+static void PAAppendLine(NSString *line) {
+    if (!line.length) return;
+    @synchronized (NSFileManager.defaultManager) {
+        PAEnsureLogDirectory();
+        NSData *data = [[line stringByAppendingString:@"\n"] dataUsingEncoding:NSUTF8StringEncoding];
+        if (![[NSFileManager defaultManager] fileExistsAtPath:PALogPath]) {
+            [data writeToFile:PALogPath atomically:YES];
+            return;
+        }
+        NSFileHandle *handle = [NSFileHandle fileHandleForWritingAtPath:PALogPath];
+        if (!handle) return;
+        @try {
+            [handle seekToEndOfFile];
+            [handle writeData:data];
+        } @catch (__unused NSException *exception) {
+        }
+        [handle closeFile];
+    }
+}
+
+static void PALog(NSString *level, NSString *area, NSString *format, ...) NS_FORMAT_FUNCTION(3,4);
+static void PALog(NSString *level, NSString *area, NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+    NSString *line = [NSString stringWithFormat:@"[%@] [%@] [%@] %@",
+                      PATimestamp(), level ?: @"INFO", area ?: @"GENERAL", message ?: @""];
+    PAAppendLine(line);
+}
+
+static NSMutableDictionary *PAReadStatusMutable(void) {
+    NSDictionary *existing = [NSDictionary dictionaryWithContentsOfFile:PAStatusPath];
+    return existing ? [existing mutableCopy] : [NSMutableDictionary dictionary];
+}
+
+static void PAUpdateStatus(NSDictionary *changes) {
+    @synchronized (PAStatusPath) {
+        NSMutableDictionary *status = PAReadStatusMutable();
+        [status addEntriesFromDictionary:changes ?: @{}];
+        status[@"diagnosticVersion"] = PADiagnosticsVersion;
+        status[@"updatedEpoch"] = @([[NSDate date] timeIntervalSince1970]);
+        [status writeToFile:PAStatusPath atomically:YES];
+    }
+}
+
+static id PACopyPreference(NSString *key) {
+    CFPropertyListRef value = CFPreferencesCopyAppValue((__bridge CFStringRef)key,
+                                                        (__bridge CFStringRef)PAPreferencesDomain);
+    return CFBridgingRelease(value);
+}
+
+static BOOL PABoolPreference(NSString *key, BOOL fallback) {
+    id value = PACopyPreference(key);
+    return value ? [value boolValue] : fallback;
+}
+
+static BOOL PAImageLoadedContaining(NSString *needle, NSString **matchedPath) {
+    uint32_t count = _dyld_image_count();
+    for (uint32_t index = 0; index < count; index++) {
+        const char *name = _dyld_get_image_name(index);
+        if (!name) continue;
+        NSString *path = [NSString stringWithUTF8String:name];
+        if ([path rangeOfString:needle options:NSCaseInsensitiveSearch].location != NSNotFound) {
+            if (matchedPath) *matchedPath = path;
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static NSString *PAEnvironment(void) {
+    NSFileManager *fm = NSFileManager.defaultManager;
+    if ([fm fileExistsAtPath:@"/var/jb/Library/MobileSubstrate/DynamicLibraries/PhoneAura.dylib"]) return @"Rootless";
+    if ([fm fileExistsAtPath:@"/Library/MobileSubstrate/DynamicLibraries/PhoneAura.dylib"]) return @"RootHide/Rootful";
+    return @"Unknown";
+}
+
+static NSArray<UIWindow *> *PAWindows(void) {
+    NSMutableArray<UIWindow *> *windows = [NSMutableArray array];
+    UIApplication *app = UIApplication.sharedApplication;
+    if (@available(iOS 13.0, *)) {
+        for (UIScene *scene in app.connectedScenes) {
+            if (![scene isKindOfClass:UIWindowScene.class]) continue;
+            [windows addObjectsFromArray:((UIWindowScene *)scene).windows ?: @[]];
+        }
+    }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if (!windows.count && app.windows.count) [windows addObjectsFromArray:app.windows];
+#pragma clang diagnostic pop
+    return windows;
+}
+
+static UIViewController *PAVisibleController(UIViewController *controller) {
+    if (!controller) return nil;
+    if (controller.presentedViewController) return PAVisibleController(controller.presentedViewController);
+    if ([controller isKindOfClass:UINavigationController.class]) {
+        return PAVisibleController(((UINavigationController *)controller).visibleViewController);
+    }
+    if ([controller isKindOfClass:UITabBarController.class]) {
+        return PAVisibleController(((UITabBarController *)controller).selectedViewController);
+    }
+    return controller;
+}
+
+static UITabBarController *PAFindTabController(UIViewController *controller) {
+    if (!controller) return nil;
+    if ([controller isKindOfClass:UITabBarController.class]) return (UITabBarController *)controller;
+    for (UIViewController *child in controller.childViewControllers) {
+        UITabBarController *found = PAFindTabController(child);
+        if (found) return found;
+    }
+    if (controller.presentedViewController) return PAFindTabController(controller.presentedViewController);
+    return nil;
+}
+
+static UIViewController *PARootController(void) {
+    for (UIWindow *window in PAWindows()) {
+        if (window.isHidden || window.alpha <= 0.01 || !window.rootViewController) continue;
+        if (window.isKeyWindow) return window.rootViewController;
+    }
+    for (UIWindow *window in PAWindows()) {
+        if (window.rootViewController) return window.rootViewController;
+    }
+    return nil;
+}
+
+static BOOL PAControllerTreeContainsClass(UIViewController *controller, NSArray<NSString *> *names) {
+    if (!controller) return NO;
+    NSString *current = NSStringFromClass(controller.class);
+    if ([names containsObject:current]) return YES;
+    for (UIViewController *child in controller.childViewControllers) {
+        if (PAControllerTreeContainsClass(child, names)) return YES;
+    }
+    if (controller.presentedViewController && PAControllerTreeContainsClass(controller.presentedViewController, names)) return YES;
+    return NO;
+}
+
+static NSDictionary *PAClassReport(NSArray<NSString *> *classNames) {
+    NSMutableDictionary *report = [NSMutableDictionary dictionary];
+    for (NSString *name in classNames) {
+        Class cls = NSClassFromString(name);
+        NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+        entry[@"loaded"] = @(cls != Nil);
+        if (cls) {
+            entry[@"viewDidLoad"] = @(class_getInstanceMethod(cls, @selector(viewDidLoad)) != NULL);
+            entry[@"viewDidAppear"] = @(class_getInstanceMethod(cls, @selector(viewDidAppear:)) != NULL);
+            entry[@"superclass"] = NSStringFromClass(class_getSuperclass(cls)) ?: @"";
+        }
+        report[name] = entry;
+    }
+    return report;
+}
+
+static NSDictionary *PAFeatureReport(NSString *name, NSString *preferenceKey, NSArray<NSString *> *classes) {
+    UIViewController *root = PARootController();
+    BOOL classLoaded = NO;
+    NSMutableArray *loaded = [NSMutableArray array];
+    for (NSString *className in classes) {
+        if (NSClassFromString(className)) {
+            classLoaded = YES;
+            [loaded addObject:className];
+        }
+    }
+    BOOL active = PAControllerTreeContainsClass(root, classes);
+    NSMutableDictionary *report = [NSMutableDictionary dictionary];
+    report[@"name"] = name;
+    report[@"preference"] = preferenceKey.length ? @(PABoolPreference(preferenceKey, YES)) : [NSNull null];
+    report[@"classLoaded"] = @(classLoaded);
+    report[@"activeInControllerTree"] = @(active);
+    report[@"loadedClasses"] = loaded;
+    return report;
+}
+
+static NSDictionary *PAAllFeatureReports(void) {
+    return @{
+        @"favorites": PAFeatureReport(@"Favorites", @"fullFavorites", @[@"PAFavoritesDashboardV46", @"PAFavoritesDashboardView", @"PAFavoriteCardV46"]),
+        @"recents": PAFeatureReport(@"Recents", @"fullRecents", @[@"PARecentsDashboardView", @"PARecentCellV47", @"PARecentDetailOverlayV47"]),
+        @"contacts": PAFeatureReport(@"Contacts", @"fullContacts", @[@"PAContactsDashboardV46", @"PAContactsDashboardView", @"PAContactDirectoryV46", @"PAContactRowV46"]),
+        @"keypad": PAFeatureReport(@"Keypad", @"fullKeypad", @[@"PAStudioKeypadView", @"PAKeypadEnhancementsV49", @"PAKeypadStableSuggestionsV411", @"PAKeypadHeaderBrandV414", @"PAKeypadContactMenuV410"])
+    };
+}
+
+static void PALogControllerTree(UIViewController *controller, NSUInteger depth) {
+    if (!controller || depth > 10) return;
+    NSString *indent = [@"" stringByPaddingToLength:depth * 2 withString:@" " startingAtIndex:0];
+    NSString *title = controller.title ?: controller.tabBarItem.title ?: @"";
+    PALog(@"DEBUG", @"UI", @"%@%@ title='%@' children=%lu presented=%@",
+          indent, NSStringFromClass(controller.class), title,
+          (unsigned long)controller.childViewControllers.count,
+          controller.presentedViewController ? NSStringFromClass(controller.presentedViewController.class) : @"none");
+    for (UIViewController *child in controller.childViewControllers) PALogControllerTree(child, depth + 1);
+    if (controller.presentedViewController) PALogControllerTree(controller.presentedViewController, depth + 1);
+}
+
+static void PASnapshotUI(void) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *root = PARootController();
+        UIViewController *visible = PAVisibleController(root);
+        UITabBarController *tabs = PAFindTabController(root);
+        PALog(@"INFO", @"UI", @"root=%@ visible=%@ tabController=%@ selectedIndex=%ld",
+              root ? NSStringFromClass(root.class) : @"nil",
+              visible ? NSStringFromClass(visible.class) : @"nil",
+              tabs ? NSStringFromClass(tabs.class) : @"nil",
+              tabs ? (long)tabs.selectedIndex : -1L);
+        if (tabs) {
+            [tabs.viewControllers enumerateObjectsUsingBlock:^(UIViewController *vc, NSUInteger idx, BOOL *stop) {
+                NSString *title = vc.tabBarItem.title ?: vc.title ?: @"";
+                PALog(@"INFO", @"TABS", @"index=%lu class=%@ title='%@' selected=%@",
+                      (unsigned long)idx, NSStringFromClass(vc.class), title,
+                      idx == tabs.selectedIndex ? @"YES" : @"NO");
+            }];
+        }
+        PALogControllerTree(root, 0);
+        PAUpdateStatus(@{
+            @"topController": visible ? NSStringFromClass(visible.class) : @"nil",
+            @"selectedTabIndex": tabs ? @(tabs.selectedIndex) : @(-1),
+            @"selectedTabTitle": tabs.selectedViewController.tabBarItem.title ?: @"",
+            @"featureStates": PAAllFeatureReports()
+        });
+    });
+}
+
+static void PAContactDiagnostics(void) {
+    CNAuthorizationStatus auth = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
+    NSString *authName = @"Unknown";
+    switch (auth) {
+        case CNAuthorizationStatusNotDetermined: authName = @"NotDetermined"; break;
+        case CNAuthorizationStatusRestricted: authName = @"Restricted"; break;
+        case CNAuthorizationStatusDenied: authName = @"Denied"; break;
+        case CNAuthorizationStatusAuthorized: authName = @"Authorized"; break;
+    }
+    CNContactStore *store = [CNContactStore new];
+    NSError *error = nil;
+    NSArray<CNContainer *> *containers = [store containersMatchingPredicate:nil error:&error];
+    PALog(error ? @"ERROR" : @"INFO", @"CONTACTS", @"authorization=%@ containers=%lu error=%@",
+          authName, (unsigned long)containers.count, error.localizedDescription ?: @"none");
+    for (CNContainer *container in containers) {
+        NSError *groupError = nil;
+        NSArray<CNGroup *> *groups = [store groupsMatchingPredicate:[CNGroup predicateForGroupsInContainerWithIdentifier:container.identifier]
+                                                               error:&groupError];
+        PALog(groupError ? @"WARNING" : @"INFO", @"CONTACTS", @"container='%@' id=%@ type=%ld groups=%lu error=%@",
+              container.name ?: @"", container.identifier ?: @"", (long)container.type,
+              (unsigned long)groups.count, groupError.localizedDescription ?: @"none");
+    }
+    PAUpdateStatus(@{@"contactsAuthorization": authName,
+                     @"contactsContainers": @(containers.count),
+                     @"contactsLastError": error.localizedDescription ?: @""});
+}
+
+static void PALogFeature(NSString *featureKey) {
+    NSDictionary *features = PAAllFeatureReports();
+    NSDictionary *report = features[featureKey];
+    if (!report) {
+        PALog(@"WARNING", @"FEATURE", @"Unknown feature command: %@", featureKey);
+        return;
+    }
+    PALog(@"INFO", [featureKey uppercaseString], @"preference=%@ classLoaded=%@ active=%@ loadedClasses=%@",
+          report[@"preference"], report[@"classLoaded"], report[@"activeInControllerTree"], report[@"loadedClasses"]);
+    NSArray *classes = nil;
+    if ([featureKey isEqualToString:@"favorites"]) classes = @[@"PAFavoritesDashboardV46", @"PAFavoritesDashboardView", @"PAFavoriteCardV46"];
+    if ([featureKey isEqualToString:@"recents"]) classes = @[@"PARecentsDashboardView", @"PARecentCellV47", @"PARecentDetailOverlayV47"];
+    if ([featureKey isEqualToString:@"contacts"]) classes = @[@"PAContactsDashboardV46", @"PAContactsDashboardView", @"PAContactDirectoryV46", @"PAContactRowV46"];
+    if ([featureKey isEqualToString:@"keypad"]) classes = @[@"PAStudioKeypadView", @"PAKeypadEnhancementsV49", @"PAKeypadStableSuggestionsV411", @"PAKeypadHeaderBrandV414", @"PAKeypadContactMenuV410"];
+    if (classes) PALog(@"DEBUG", [featureKey uppercaseString], @"classReport=%@", PAClassReport(classes));
+    if ([featureKey isEqualToString:@"contacts"]) PAContactDiagnostics();
+    PASnapshotUI();
+}
+
+static void PABaseRuntimeDiagnostics(void) {
+    NSString *basePath = nil;
+    BOOL baseLoaded = PAImageLoadedContaining(@"PhoneAura.dylib", &basePath);
+    NSString *nativePath = nil;
+    BOOL nativeLoaded = PAImageLoadedContaining(@"PhoneAuraNativeFeatures.dylib", &nativePath);
+    NSString *diagPath = nil;
+    BOOL diagLoaded = PAImageLoadedContaining(@"PhoneAuraDiagnostics.dylib", &diagPath);
+
+    NSDictionary *prefs = @{
+        @"enabled": @(PABoolPreference(@"enabled", YES)),
+        @"fullFavorites": @(PABoolPreference(@"fullFavorites", YES)),
+        @"fullRecents": @(PABoolPreference(@"fullRecents", YES)),
+        @"fullContacts": @(PABoolPreference(@"fullContacts", YES)),
+        @"fullKeypad": @(PABoolPreference(@"fullKeypad", YES)),
+        @"haptics": @(PABoolPreference(@"haptics", YES)),
+        @"animations": @(PABoolPreference(@"animations", YES))
+    };
+
+    PALog(baseLoaded ? @"SUCCESS" : @"ERROR", @"RUNTIME", @"PhoneAura.dylib loaded=%@ path=%@",
+          baseLoaded ? @"YES" : @"NO", basePath ?: @"not found");
+    PALog(nativeLoaded ? @"WARNING" : @"SUCCESS", @"RUNTIME", @"old PhoneAuraNativeFeatures loaded=%@ path=%@",
+          nativeLoaded ? @"YES" : @"NO", nativePath ?: @"not loaded");
+    PALog(diagLoaded ? @"SUCCESS" : @"ERROR", @"RUNTIME", @"PhoneAuraDiagnostics loaded=%@ path=%@",
+          diagLoaded ? @"YES" : @"NO", diagPath ?: @"not found");
+    PALog(@"INFO", @"PREFERENCES", @"%@", prefs);
+
+    PAUpdateStatus(@{
+        @"process": NSProcessInfo.processInfo.processName ?: @"",
+        @"pid": @(NSProcessInfo.processInfo.processIdentifier),
+        @"bundle": NSBundle.mainBundle.bundleIdentifier ?: @"",
+        @"environment": PAEnvironment(),
+        @"baseRuntimeLoaded": @(baseLoaded),
+        @"baseRuntimePath": basePath ?: @"",
+        @"oldNativeFeatureLoaded": @(nativeLoaded),
+        @"oldNativeFeaturePath": nativePath ?: @"",
+        @"diagnosticsLoaded": @(diagLoaded),
+        @"diagnosticsPath": diagPath ?: @"",
+        @"preferences": prefs,
+        @"featureStates": PAAllFeatureReports()
+    });
+}
+
+static void PAFullDiagnosis(NSString *reason) {
+    PALog(@"INFO", @"DIAG", @"===== FULL DIAGNOSIS START reason=%@ =====", reason ?: @"manual");
+    PABaseRuntimeDiagnostics();
+    PAContactDiagnostics();
+    PASnapshotUI();
+    PALog(@"INFO", @"DIAG", @"===== FULL DIAGNOSIS REQUESTED =====");
+    PAUpdateStatus(@{@"lastCommand": @"Full Diagnosis", @"lastResult": @"Completed request"});
+}
+
+static void PAClearLog(void) {
+    [[NSFileManager defaultManager] removeItemAtPath:PALogPath error:nil];
+    PALog(@"SUCCESS", @"CONSOLE", @"Diagnostic log cleared.");
+    PAUpdateStatus(@{@"lastCommand": @"Clear Log", @"lastResult": @"Log cleared"});
+}
+
+static void PAHandleCommand(NSString *name) {
+    if ([name hasSuffix:@".full"]) {
+        PAFullDiagnosis(@"console");
+    } else if ([name hasSuffix:@".snapshot"]) {
+        PALog(@"INFO", @"CONSOLE", @"Snapshot command received.");
+        PASnapshotUI();
+        PAUpdateStatus(@{@"lastCommand": @"Snapshot UI", @"lastResult": @"Snapshot requested"});
+    } else if ([name hasSuffix:@".favorites"]) {
+        PAUpdateStatus(@{@"lastCommand": @"Test Favorites"});
+        PALogFeature(@"favorites");
+    } else if ([name hasSuffix:@".recents"]) {
+        PAUpdateStatus(@{@"lastCommand": @"Test Recents"});
+        PALogFeature(@"recents");
+    } else if ([name hasSuffix:@".contacts"]) {
+        PAUpdateStatus(@{@"lastCommand": @"Test Contacts"});
+        PALogFeature(@"contacts");
+    } else if ([name hasSuffix:@".keypad"]) {
+        PAUpdateStatus(@{@"lastCommand": @"Test Keypad"});
+        PALogFeature(@"keypad");
+    } else if ([name hasSuffix:@".voicemail"]) {
+        PALog(@"INFO", @"VOICEMAIL", @"PhoneAura does not replace Voicemail in the 0.4.16 runtime. Capturing current tab/controller state for comparison.");
+        PASnapshotUI();
+        PAUpdateStatus(@{@"lastCommand": @"Test Voicemail", @"lastResult": @"System tab snapshot captured"});
+    } else if ([name hasSuffix:@".clear"]) {
+        PAClearLog();
+    }
+}
+
+static void PACommandCallback(CFNotificationCenterRef center,
+                              void *observer,
+                              CFStringRef name,
+                              const void *object,
+                              CFDictionaryRef userInfo) {
+    NSString *notificationName = (__bridge NSString *)name;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        PAHandleCommand(notificationName);
+    });
+}
+
+static void PARegisterCommand(NSString *name) {
+    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(),
+                                    NULL,
+                                    PACommandCallback,
+                                    (__bridge CFStringRef)name,
+                                    NULL,
+                                    CFNotificationSuspensionBehaviorDeliverImmediately);
+}
+
+static void PAExceptionHandler(NSException *exception) {
+    PALog(@"ERROR", @"EXCEPTION", @"name=%@ reason=%@ callStack=%@",
+          exception.name ?: @"", exception.reason ?: @"", exception.callStackSymbols ?: @[]);
+    PAUpdateStatus(@{@"lastExceptionName": exception.name ?: @"",
+                     @"lastExceptionReason": exception.reason ?: @"",
+                     @"lastExceptionEpoch": @([[NSDate date] timeIntervalSince1970])});
+    if (PAPreviousExceptionHandler && PAPreviousExceptionHandler != PAExceptionHandler) {
+        PAPreviousExceptionHandler(exception);
+    }
+}
+
+static void PAStartHeartbeat(void) {
+    if (PAHeartbeatTimer) return;
+    PAHeartbeatTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
+    dispatch_source_set_timer(PAHeartbeatTimer,
+                              dispatch_time(DISPATCH_TIME_NOW, 0),
+                              (uint64_t)(5.0 * NSEC_PER_SEC),
+                              (uint64_t)(0.5 * NSEC_PER_SEC));
+    dispatch_source_set_event_handler(PAHeartbeatTimer, ^{
+        UIViewController *visible = PAVisibleController(PARootController());
+        PAUpdateStatus(@{
+            @"heartbeatEpoch": @([[NSDate date] timeIntervalSince1970]),
+            @"heartbeat": PATimestamp(),
+            @"topController": visible ? NSStringFromClass(visible.class) : @"nil",
+            @"pid": @(NSProcessInfo.processInfo.processIdentifier)
+        });
+    });
+    dispatch_resume(PAHeartbeatTimer);
+}
+
+static void PAInitializeDiagnostics(void) {
+    NSString *bundle = NSBundle.mainBundle.bundleIdentifier ?: @"";
+    PALog(@"INFO", @"BOOT", @"PhoneAura diagnostics constructor version=%@ process=%@ pid=%d bundle=%@ environment=%@",
+          PADiagnosticsVersion, NSProcessInfo.processInfo.processName,
+          NSProcessInfo.processInfo.processIdentifier, bundle, PAEnvironment());
+
+    PAPreviousExceptionHandler = NSGetUncaughtExceptionHandler();
+    NSSetUncaughtExceptionHandler(&PAExceptionHandler);
+
+    NSArray<NSString *> *commands = @[
+        @"com.zeshan.phoneaura.diag.command.full",
+        @"com.zeshan.phoneaura.diag.command.snapshot",
+        @"com.zeshan.phoneaura.diag.command.favorites",
+        @"com.zeshan.phoneaura.diag.command.recents",
+        @"com.zeshan.phoneaura.diag.command.contacts",
+        @"com.zeshan.phoneaura.diag.command.keypad",
+        @"com.zeshan.phoneaura.diag.command.voicemail",
+        @"com.zeshan.phoneaura.diag.command.clear"
+    ];
+    for (NSString *command in commands) PARegisterCommand(command);
+
+    NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+    [center addObserverForName:UIApplicationDidBecomeActiveNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+        PALog(@"INFO", @"LIFECYCLE", @"MobilePhone became active.");
+        PABaseRuntimeDiagnostics();
+        PASnapshotUI();
+    }];
+    [center addObserverForName:UIApplicationDidEnterBackgroundNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+        PALog(@"INFO", @"LIFECYCLE", @"MobilePhone entered background.");
+    }];
+    [center addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+        PALog(@"WARNING", @"MEMORY", @"MobilePhone received a memory warning.");
+    }];
+    [center addObserverForName:CNContactStoreDidChangeNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+        PALog(@"INFO", @"CONTACTS", @"CNContactStoreDidChangeNotification received.");
+    }];
+
+    PAStartHeartbeat();
+    PAUpdateStatus(@{
+        @"diagnosticVersion": PADiagnosticsVersion,
+        @"startedEpoch": @([[NSDate date] timeIntervalSince1970]),
+        @"started": PATimestamp(),
+        @"environment": PAEnvironment(),
+        @"process": NSProcessInfo.processInfo.processName ?: @"",
+        @"pid": @(NSProcessInfo.processInfo.processIdentifier),
+        @"bundle": bundle
+    });
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.8 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        PABaseRuntimeDiagnostics();
+    });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        PAFullDiagnosis(@"startup");
+    });
+}
+
+__attribute__((constructor)) static void PhoneAuraDiagnosticsInitialize(void) {
+    @autoreleasepool {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            PAInitializeDiagnostics();
+        });
+    }
+}

--- a/PhoneAuraDiagnostics/Makefile
+++ b/PhoneAuraDiagnostics/Makefile
@@ -1,0 +1,11 @@
+ARCHS = arm64 arm64e
+TARGET = iphone:clang:latest:15.0
+
+include $(THEOS)/makefiles/common.mk
+
+TWEAK_NAME = PhoneAuraDiagnostics
+PhoneAuraDiagnostics_FILES = DiagnosticsTweak.m
+PhoneAuraDiagnostics_FRAMEWORKS = Foundation UIKit Contacts CoreFoundation
+PhoneAuraDiagnostics_CFLAGS = -fobjc-arc -Wall -Wextra
+
+include $(THEOS_MAKE_PATH)/tweak.mk

--- a/PhoneAuraDiagnostics/Makefile
+++ b/PhoneAuraDiagnostics/Makefile
@@ -6,6 +6,6 @@ include $(THEOS)/makefiles/common.mk
 TWEAK_NAME = PhoneAuraDiagnostics
 PhoneAuraDiagnostics_FILES = DiagnosticsTweak.m
 PhoneAuraDiagnostics_FRAMEWORKS = Foundation UIKit Contacts CoreFoundation
-PhoneAuraDiagnostics_CFLAGS = -fobjc-arc -Wall -Wextra
+PhoneAuraDiagnostics_CFLAGS = -fobjc-arc -Wall -Wextra -Wno-error -Wno-unused-parameter -Wno-switch
 
 include $(THEOS_MAKE_PATH)/tweak.mk

--- a/PhoneAuraDiagnostics/PhoneAuraDiagnostics.plist
+++ b/PhoneAuraDiagnostics/PhoneAuraDiagnostics.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Filter</key>
+    <dict>
+        <key>Bundles</key>
+        <array>
+            <string>com.apple.mobilephone</string>
+        </array>
+    </dict>
+</dict>
+</plist>

--- a/PhoneAuraDiagnostics/README.md
+++ b/PhoneAuraDiagnostics/README.md
@@ -1,0 +1,32 @@
+# PhoneAura 0.5.1 Diagnostic Recovery Build
+
+This build intentionally restores the untouched PhoneAura 0.4.16 runtime and does **not** load the 0.5.0 `PhoneAuraNativeFeatures` contact-book hook.
+
+It adds two diagnostic components only:
+
+- `PhoneAuraDiagnostics.dylib`: passive MobilePhone diagnostics. It does not replace PhoneAura controller methods.
+- `PhoneAuraConsole.app`: a separate console for runtime status, feature tests, live logs, crash import, copy/share, and clearing logs.
+
+## Console fields
+
+- Running / heartbeat
+- Diagnostic version
+- MobilePhone process and PID
+- Rootless vs RootHide/Rootful environment
+- Base PhoneAura runtime loaded state
+- Whether the old 0.5.0 feature hook is still loaded
+- Current visible Phone controller
+- Last diagnostic command
+
+## Feature tests
+
+- Favorites
+- Recents
+- Contacts + account/container permission state
+- Keypad
+- Voicemail/system tab
+- Full diagnosis
+- Current UI/controller snapshot
+- Import latest MobilePhone crash report
+
+Logs are stored at `/var/mobile/Library/Logs/PhoneAura/PhoneAuraDiagnostics.log` and can be shared from the console.

--- a/PhoneAuraDiagnostics/control
+++ b/PhoneAuraDiagnostics/control
@@ -1,0 +1,9 @@
+Package: com.zeshan.phoneaura.diagnostics.buildhelper
+Name: PhoneAura Diagnostics Build Helper
+Version: 0.5.1
+Architecture: iphoneos-arm64
+Description: Build helper for the PhoneAura passive diagnostic runtime.
+Maintainer: Next Solution
+Author: Next Solution
+Section: Development
+Depends: mobilesubstrate

--- a/PhoneAuraDiagnostics/prepare_package.py
+++ b/PhoneAuraDiagnostics/prepare_package.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import plistlib
+import re
+from pathlib import Path
+
+VERSION = "0.5.1"
+
+
+def load_plist(path: Path):
+    with path.open("rb") as handle:
+        return plistlib.load(handle)
+
+
+def save_plist(path: Path, value) -> None:
+    with path.open("wb") as handle:
+        plistlib.dump(value, handle, fmt=plistlib.FMT_XML, sort_keys=False)
+
+
+def update_control(path: Path) -> None:
+    text = path.read_text()
+    text = re.sub(r"^Version: .*$", f"Version: {VERSION}", text, flags=re.MULTILINE)
+    description = (
+        "PhoneAura 0.5.1 Diagnostic restores the stable 0.4.16 PhoneAura runtime and adds a passive "
+        "PhoneAura Console for feature-by-feature diagnosis. The console records runtime loading, preferences, "
+        "Favorites, Recents, Contacts, Keypad, tabs, contact permissions, view-controller snapshots, heartbeats "
+        "and available MobilePhone crash reports without installing the unstable 0.5.0 contact-book hook."
+    )
+    text = re.sub(r"^Description: .*$", f"Description: {description}", text, flags=re.MULTILINE)
+    path.write_text(text)
+
+
+def update_bundle_version(path: Path) -> None:
+    info = load_plist(path)
+    info["CFBundleShortVersionString"] = VERSION
+    info["CFBundleVersion"] = "51"
+    save_plist(path, info)
+
+
+def update_root(path: Path) -> None:
+    root = load_plist(path)
+    if root and isinstance(root[0], dict):
+        root[0]["label"] = "PHONEAURA 0.5.1 DIAGNOSTIC"
+        root[0]["footerText"] = (
+            "Diagnostic recovery build. The unstable 0.5.0 contact-book companion hook is not loaded. "
+            "The original stable 0.4.16 PhoneAura runtime is preserved and a separate PhoneAura Console app "
+            "collects passive diagnostics for each Phone tab and feature."
+        )
+
+    root = [row for row in root if not (isinstance(row, dict) and row.get("key") == "contactBookSelector")]
+    root = [row for row in root if not (isinstance(row, dict) and row.get("label") == "CONTACT BOOKS")]
+    root.append({
+        "cell": "PSGroupCell",
+        "label": "DIAGNOSTIC CONSOLE",
+        "footerText": (
+            "A separate PhoneAura Console app is installed on the Home Screen. Open it, reproduce one PhoneAura issue, "
+            "tap the matching feature test, then Share Log and send the report for diagnosis."
+        ),
+    })
+    save_plist(path, root)
+
+
+def update_scripts(layout: Path) -> None:
+    for name in ("postinst", "prerm"):
+        path = layout / "DEBIAN" / name
+        if not path.exists():
+            continue
+        text = path.read_text()
+        if "PhoneAuraConsole" not in text:
+            text = text.replace("exit 0", "killall -9 PhoneAuraConsole 2>/dev/null || true\nexit 0")
+        path.write_text(text)
+        path.chmod(0o755)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("layout", type=Path)
+    parser.add_argument("--root-prefix", default="")
+    args = parser.parse_args()
+
+    layout = args.layout
+    prefix = layout / args.root_prefix if args.root_prefix else layout
+    update_control(layout / "DEBIAN" / "control")
+    update_bundle_version(prefix / "Library" / "PreferenceBundles" / "PhoneAuraPrefs.bundle" / "Info.plist")
+    update_bundle_version(prefix / "Applications" / "PhoneAuraStudio.app" / "Info.plist")
+    update_root(prefix / "Library" / "PreferenceBundles" / "PhoneAuraPrefs.bundle" / "Root.plist")
+    update_scripts(layout)
+
+
+if __name__ == "__main__":
+    main()

--- a/PhoneAuraFeaturePack/Makefile
+++ b/PhoneAuraFeaturePack/Makefile
@@ -1,0 +1,13 @@
+ARCHS = arm64 arm64e
+TARGET = iphone:clang:latest:16.0
+INSTALL_TARGET_PROCESSES = MobilePhone
+
+include $(THEOS)/makefiles/common.mk
+
+TWEAK_NAME = PhoneAuraNativeFeatures
+PhoneAuraNativeFeatures_FILES = Tweak.m
+PhoneAuraNativeFeatures_FRAMEWORKS = UIKit Foundation Contacts ContactsUI
+PhoneAuraNativeFeatures_CFLAGS = -fobjc-arc -Wno-deprecated-declarations -Wno-unused-function
+PhoneAuraNativeFeatures_LDFLAGS = -Wl,-segalign,4000
+
+include $(THEOS_MAKE_PATH)/tweak.mk

--- a/PhoneAuraFeaturePack/PhoneAuraNativeFeatures.plist
+++ b/PhoneAuraFeaturePack/PhoneAuraNativeFeatures.plist
@@ -1,0 +1,7 @@
+{
+    Filter = {
+        Bundles = (
+            "com.apple.mobilephone"
+        );
+    };
+}

--- a/PhoneAuraFeaturePack/README.md
+++ b/PhoneAuraFeaturePack/README.md
@@ -1,0 +1,17 @@
+# PhoneAura 0.5.0 Native Features Companion
+
+This source builds a small companion dylib that runs beside the published PhoneAura 0.4.16 runtime. The original PhoneAura dylib, Studio app, preferences bundle, visual design, tab replacements and package identifier remain in place.
+
+## Added
+
+- Native-style **Contact Books** selector inside the existing PhoneAura Contacts header.
+- All Contacts, individual contact accounts/containers, and contact groups/lists.
+- Saved selection across Phone app launches.
+- Refresh after Contacts database changes.
+- RootHide and standard rootless packages.
+
+## Native feature compatibility
+
+PhoneAura continues to delegate cellular calls, incoming calls, active-call controls, conference calls, Visual/Live Voicemail, Caller ID, spam handling, blocked callers, emergency calling, Dual SIM, Wi-Fi Calling, Bluetooth, CarPlay, Siri and Handoff to Apple's original controllers. Availability depends on iOS, device, language, region and carrier.
+
+Features introduced only in later iOS versions—such as Apple's call recording/transcription, Apple Intelligence summaries, Live Translation, Contact Posters and third-party default calling apps—cannot be added as genuine native iOS 16 services by a tweak. PhoneAura does not simulate or falsely label those services.

--- a/PhoneAuraFeaturePack/Tweak.m
+++ b/PhoneAuraFeaturePack/Tweak.m
@@ -1,0 +1,444 @@
+#import <UIKit/UIKit.h>
+#import <Contacts/Contacts.h>
+#import <objc/runtime.h>
+
+static NSString * const PADomain = @"com.zeshan.phoneaura";
+static NSString * const PASelectionKey = @"contactBookSelection";
+static NSString * const PASelectionLabelKey = @"contactBookSelectionLabel";
+static NSString * const PASelectorEnabledKey = @"contactBookSelector";
+
+static const void *PAButtonAssociationKey = &PAButtonAssociationKey;
+static const void *PAMasterContactsAssociationKey = &PAMasterContactsAssociationKey;
+static const void *PAApplyingAssociationKey = &PAApplyingAssociationKey;
+
+static IMP PAOriginalViewDidAppear = NULL;
+static IMP PAOriginalContactsRefresh = NULL;
+static IMP PAOriginalContactsChanged = NULL;
+
+@interface PABookChoice : NSObject
+@property (nonatomic, copy) NSString *identifier;
+@property (nonatomic, copy) NSString *title;
+@property (nonatomic, copy) NSString *kind;
+@property (nonatomic, copy) NSArray<PABookChoice *> *children;
+@end
+@implementation PABookChoice
+@end
+
+static id PACopyPreference(NSString *key) {
+    CFPropertyListRef value = CFPreferencesCopyAppValue((__bridge CFStringRef)key,
+                                                        (__bridge CFStringRef)PADomain);
+    return CFBridgingRelease(value);
+}
+
+static BOOL PABoolPreference(NSString *key, BOOL fallback) {
+    id value = PACopyPreference(key);
+    return value ? [value boolValue] : fallback;
+}
+
+static void PASetPreference(NSString *key, id value) {
+    CFPreferencesSetAppValue((__bridge CFStringRef)key,
+                             (__bridge CFPropertyListRef)value,
+                             (__bridge CFStringRef)PADomain);
+    CFPreferencesAppSynchronize((__bridge CFStringRef)PADomain);
+}
+
+static NSString *PASelectedIdentifier(void) {
+    NSString *value = PACopyPreference(PASelectionKey);
+    return [value isKindOfClass:NSString.class] && value.length ? value : @"all";
+}
+
+static NSString *PASelectedLabel(void) {
+    NSString *value = PACopyPreference(PASelectionLabelKey);
+    return [value isKindOfClass:NSString.class] && value.length ? value : @"All Contacts";
+}
+
+static UIView *PAFindViewNamed(UIView *root, NSString *className) {
+    if (!root) return nil;
+    if ([NSStringFromClass(root.class) isEqualToString:className]) return root;
+    for (UIView *child in root.subviews) {
+        UIView *match = PAFindViewNamed(child, className);
+        if (match) return match;
+    }
+    return nil;
+}
+
+static void PAReloadTables(UIView *root) {
+    if (!root) return;
+    if ([root isKindOfClass:UITableView.class]) {
+        [(UITableView *)root reloadData];
+    }
+    for (UIView *child in root.subviews) {
+        PAReloadTables(child);
+    }
+}
+
+static NSArray<id<CNKeyDescriptor>> *PAContactKeys(void) {
+    return @[
+        CNContactIdentifierKey,
+        CNContactNamePrefixKey,
+        CNContactGivenNameKey,
+        CNContactMiddleNameKey,
+        CNContactFamilyNameKey,
+        CNContactNameSuffixKey,
+        CNContactNicknameKey,
+        CNContactOrganizationNameKey,
+        CNContactPhoneNumbersKey,
+        CNContactThumbnailImageDataKey,
+        CNContactImageDataAvailableKey,
+        [CNContactFormatter descriptorForRequiredKeysForStyle:CNContactFormatterStyleFullName]
+    ];
+}
+
+static NSArray<CNContact *> *PAContactsForChoice(PABookChoice *choice, NSError **errorOut) {
+    CNContactStore *store = [CNContactStore new];
+    NSPredicate *predicate = nil;
+    if ([choice.kind isEqualToString:@"container"]) {
+        predicate = [CNContact predicateForContactsInContainerWithIdentifier:choice.identifier];
+    } else if ([choice.kind isEqualToString:@"group"]) {
+        predicate = [CNContact predicateForContactsInGroupWithIdentifier:choice.identifier];
+    }
+    if (!predicate) return @[];
+
+    NSArray<CNContact *> *contacts = [store unifiedContactsMatchingPredicate:predicate
+                                                                  keysToFetch:PAContactKeys()
+                                                                        error:errorOut];
+    return [contacts sortedArrayUsingComparator:^NSComparisonResult(CNContact *left, CNContact *right) {
+        NSString *a = [CNContactFormatter stringFromContact:left style:CNContactFormatterStyleFullName] ?: left.organizationName ?: @"";
+        NSString *b = [CNContactFormatter stringFromContact:right style:CNContactFormatterStyleFullName] ?: right.organizationName ?: @"";
+        return [a localizedCaseInsensitiveCompare:b];
+    }];
+}
+
+static NSArray<PABookChoice *> *PALoadBookChoices(void) {
+    CNContactStore *store = [CNContactStore new];
+    NSError *error = nil;
+    NSArray<CNContainer *> *containers = [store containersMatchingPredicate:nil error:&error];
+    if (error || !containers.count) return @[];
+
+    NSMutableArray<PABookChoice *> *result = [NSMutableArray array];
+    NSArray<CNContainer *> *sorted = [containers sortedArrayUsingComparator:^NSComparisonResult(CNContainer *left, CNContainer *right) {
+        return [left.name localizedCaseInsensitiveCompare:right.name];
+    }];
+
+    for (CNContainer *container in sorted) {
+        PABookChoice *containerChoice = [PABookChoice new];
+        containerChoice.identifier = container.identifier;
+        containerChoice.title = container.name.length ? container.name : @"Contacts Account";
+        containerChoice.kind = @"container";
+
+        NSPredicate *groupPredicate = [CNGroup predicateForGroupsInContainerWithIdentifier:container.identifier];
+        NSArray<CNGroup *> *groups = [store groupsMatchingPredicate:groupPredicate error:nil];
+        NSMutableArray<PABookChoice *> *children = [NSMutableArray array];
+        for (CNGroup *group in [groups sortedArrayUsingComparator:^NSComparisonResult(CNGroup *left, CNGroup *right) {
+            return [left.name localizedCaseInsensitiveCompare:right.name];
+        }]) {
+            PABookChoice *groupChoice = [PABookChoice new];
+            groupChoice.identifier = group.identifier;
+            groupChoice.title = group.name.length ? group.name : @"Contact List";
+            groupChoice.kind = @"group";
+            [children addObject:groupChoice];
+        }
+        containerChoice.children = children;
+        [result addObject:containerChoice];
+    }
+    return result;
+}
+
+static void PAUpdateButtonTitle(UIButton *button, NSString *title) {
+    NSString *display = title.length ? title : @"All Contacts";
+    if (button.configuration) {
+        UIButtonConfiguration *configuration = button.configuration;
+        configuration.title = display;
+        configuration.image = [UIImage systemImageNamed:@"chevron.down"];
+        configuration.imagePlacement = NSDirectionalRectEdgeTrailing;
+        configuration.imagePadding = 6.0;
+        button.configuration = configuration;
+    } else {
+        [button setTitle:[display stringByAppendingString:@"  ▾"] forState:UIControlStateNormal];
+    }
+    button.accessibilityLabel = [NSString stringWithFormat:@"Contact book: %@", display];
+}
+
+static NSArray *PAReadContactArray(id controller, NSString *key) {
+    @try {
+        id value = [controller valueForKey:key];
+        return [value isKindOfClass:NSArray.class] ? value : nil;
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static void PAWriteContactArray(id controller, NSString *key, NSArray *contacts) {
+    @try {
+        [controller setValue:contacts ?: @[] forKey:key];
+    } @catch (__unused NSException *exception) {
+    }
+}
+
+static void PACaptureMasterContacts(id controller) {
+    NSArray *current = PAReadContactArray(controller, @"allContacts");
+    if (current.count && !objc_getAssociatedObject(controller, PAMasterContactsAssociationKey)) {
+        objc_setAssociatedObject(controller, PAMasterContactsAssociationKey, current, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+
+static void PAApplyChoice(UIViewController *controller, PABookChoice *choice, BOOL persist) {
+    if (!controller || objc_getAssociatedObject(controller, PAApplyingAssociationKey)) return;
+    objc_setAssociatedObject(controller, PAApplyingAssociationKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    PACaptureMasterContacts(controller);
+
+    UIButton *button = objc_getAssociatedObject(controller, PAButtonAssociationKey);
+    NSString *title = choice.title.length ? choice.title : @"All Contacts";
+    PAUpdateButtonTitle(button, title);
+
+    if (persist) {
+        NSString *selection = [choice.kind isEqualToString:@"all"]
+            ? @"all"
+            : [NSString stringWithFormat:@"%@:%@", choice.kind, choice.identifier ?: @""];
+        PASetPreference(PASelectionKey, selection);
+        PASetPreference(PASelectionLabelKey, title);
+    }
+
+    if ([choice.kind isEqualToString:@"all"]) {
+        NSArray *master = objc_getAssociatedObject(controller, PAMasterContactsAssociationKey);
+        if (master) {
+            PAWriteContactArray(controller, @"allContacts", master);
+            PAWriteContactArray(controller, @"filteredContacts", master);
+            PAReloadTables(controller.view);
+        }
+        objc_setAssociatedObject(controller, PAApplyingAssociationKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSError *error = nil;
+        NSArray<CNContact *> *contacts = PAContactsForChoice(choice, &error);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!error) {
+                PAWriteContactArray(controller, @"allContacts", contacts);
+                PAWriteContactArray(controller, @"filteredContacts", contacts);
+                PAReloadTables(controller.view);
+            } else {
+                UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Contacts Unavailable"
+                                                                               message:@"PhoneAura could not read this contact book. Check Contacts permission and try again."
+                                                                        preferredStyle:UIAlertControllerStyleAlert];
+                [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+                [controller presentViewController:alert animated:YES completion:nil];
+            }
+            objc_setAssociatedObject(controller, PAApplyingAssociationKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        });
+    });
+}
+
+static PABookChoice *PAChoiceForStoredSelection(NSArray<PABookChoice *> *choices) {
+    NSString *selection = PASelectedIdentifier();
+    if ([selection isEqualToString:@"all"]) {
+        PABookChoice *all = [PABookChoice new];
+        all.kind = @"all";
+        all.title = @"All Contacts";
+        return all;
+    }
+
+    NSArray<NSString *> *parts = [selection componentsSeparatedByString:@":"];
+    if (parts.count < 2) return nil;
+    NSString *kind = parts.firstObject;
+    NSString *identifier = [[parts subarrayWithRange:NSMakeRange(1, parts.count - 1)] componentsJoinedByString:@":"];
+    for (PABookChoice *container in choices) {
+        if ([kind isEqualToString:@"container"] && [container.identifier isEqualToString:identifier]) return container;
+        for (PABookChoice *group in container.children) {
+            if ([kind isEqualToString:@"group"] && [group.identifier isEqualToString:identifier]) return group;
+        }
+    }
+    return nil;
+}
+
+static UIAction *PAActionForChoice(UIViewController *controller, PABookChoice *choice, NSString *storedSelection) {
+    NSString *selection = [choice.kind isEqualToString:@"all"]
+        ? @"all"
+        : [NSString stringWithFormat:@"%@:%@", choice.kind, choice.identifier ?: @""];
+    UIAction *action = [UIAction actionWithTitle:choice.title ?: @"Contacts"
+                                          image:nil
+                                     identifier:nil
+                                        handler:^(__kindof UIAction *unusedAction) {
+        PAApplyChoice(controller, choice, YES);
+    }];
+    action.state = [selection isEqualToString:storedSelection] ? UIMenuElementStateOn : UIMenuElementStateOff;
+    return action;
+}
+
+static void PABuildMenu(UIViewController *controller, UIButton *button) {
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSArray<PABookChoice *> *choices = PALoadBookChoices();
+        NSString *stored = PASelectedIdentifier();
+        dispatch_async(dispatch_get_main_queue(), ^{
+            PABookChoice *all = [PABookChoice new];
+            all.kind = @"all";
+            all.title = @"All Contacts";
+            NSMutableArray<UIMenuElement *> *elements = [NSMutableArray arrayWithObject:PAActionForChoice(controller, all, stored)];
+
+            for (PABookChoice *container in choices) {
+                NSMutableArray<UIMenuElement *> *children = [NSMutableArray array];
+                PABookChoice *containerAll = [PABookChoice new];
+                containerAll.kind = @"container";
+                containerAll.identifier = container.identifier;
+                containerAll.title = [NSString stringWithFormat:@"All %@", container.title ?: @"Contacts"];
+                [children addObject:PAActionForChoice(controller, containerAll, stored)];
+                for (PABookChoice *group in container.children) {
+                    [children addObject:PAActionForChoice(controller, group, stored)];
+                }
+                UIMenu *submenu = [UIMenu menuWithTitle:container.title ?: @"Contacts Account"
+                                                  image:[UIImage systemImageNamed:@"person.crop.circle"]
+                                             identifier:nil
+                                                options:UIMenuOptionsDisplayInline
+                                               children:children];
+                [elements addObject:submenu];
+            }
+
+            UIAction *refresh = [UIAction actionWithTitle:@"Refresh Contact Books"
+                                                    image:[UIImage systemImageNamed:@"arrow.clockwise"]
+                                               identifier:nil
+                                                  handler:^(__kindof UIAction *unusedAction) {
+                PABuildMenu(controller, button);
+            }];
+            [elements addObject:[UIMenu menuWithTitle:@"" children:@[refresh]]];
+            button.menu = [UIMenu menuWithTitle:@"Contact Books" children:elements];
+            button.showsMenuAsPrimaryAction = YES;
+
+            PABookChoice *storedChoice = PAChoiceForStoredSelection(choices);
+            if (storedChoice && ![stored isEqualToString:@"all"]) {
+                PAApplyChoice(controller, storedChoice, NO);
+            }
+        });
+    });
+}
+
+static UIButton *PACreateSelectorButton(void) {
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    if (@available(iOS 15.0, *)) {
+        UIButtonConfiguration *configuration = [UIButtonConfiguration tintedButtonConfiguration];
+        configuration.cornerStyle = UIButtonConfigurationCornerStyleCapsule;
+        configuration.baseForegroundColor = UIColor.labelColor;
+        configuration.baseBackgroundColor = [UIColor.secondarySystemFillColor colorWithAlphaComponent:0.92];
+        configuration.contentInsets = NSDirectionalEdgeInsetsMake(6, 11, 6, 11);
+        button.configuration = configuration;
+    } else {
+        button.backgroundColor = UIColor.secondarySystemFillColor;
+        button.layer.cornerRadius = 15.0;
+        button.contentEdgeInsets = UIEdgeInsetsMake(6, 11, 6, 11);
+    }
+    button.titleLabel.font = [UIFont systemFontOfSize:13.0 weight:UIFontWeightSemibold];
+    button.adjustsImageWhenHighlighted = YES;
+    PAUpdateButtonTitle(button, PASelectedLabel());
+    return button;
+}
+
+static void PAInstallSelector(UIViewController *controller) {
+    if (!PABoolPreference(PASelectorEnabledKey, YES)) return;
+    if (objc_getAssociatedObject(controller, PAButtonAssociationKey)) {
+        PACaptureMasterContacts(controller);
+        return;
+    }
+
+    PACaptureMasterContacts(controller);
+    UIButton *button = PACreateSelectorButton();
+    objc_setAssociatedObject(controller, PAButtonAssociationKey, button, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    UIView *header = PAFindViewNamed(controller.view, @"PAStudioHeaderView");
+    if (header) {
+        button.translatesAutoresizingMaskIntoConstraints = NO;
+        [header addSubview:button];
+        [NSLayoutConstraint activateConstraints:@[
+            [button.trailingAnchor constraintEqualToAnchor:header.trailingAnchor constant:-14.0],
+            [button.bottomAnchor constraintEqualToAnchor:header.bottomAnchor constant:-10.0],
+            [button.heightAnchor constraintEqualToConstant:32.0],
+            [button.widthAnchor constraintGreaterThanOrEqualToConstant:112.0],
+            [button.widthAnchor constraintLessThanOrEqualToConstant:210.0]
+        ]];
+    } else if (controller.navigationItem) {
+        controller.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:button];
+    } else {
+        button.translatesAutoresizingMaskIntoConstraints = NO;
+        [controller.view addSubview:button];
+        [NSLayoutConstraint activateConstraints:@[
+            [button.trailingAnchor constraintEqualToAnchor:controller.view.safeAreaLayoutGuide.trailingAnchor constant:-14.0],
+            [button.topAnchor constraintEqualToAnchor:controller.view.safeAreaLayoutGuide.topAnchor constant:8.0],
+            [button.heightAnchor constraintEqualToConstant:32.0]
+        ]];
+    }
+
+    PABuildMenu(controller, button);
+}
+
+static void PAHookedViewDidAppear(id self, SEL _cmd, BOOL animated) {
+    if (PAOriginalViewDidAppear) {
+        ((void (*)(id, SEL, BOOL))PAOriginalViewDidAppear)(self, _cmd, animated);
+    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([self isKindOfClass:UIViewController.class]) {
+            PAInstallSelector((UIViewController *)self);
+        }
+    });
+}
+
+static void PAHookedContactsRefresh(id self, SEL _cmd) {
+    if (PAOriginalContactsRefresh) {
+        ((void (*)(id, SEL))PAOriginalContactsRefresh)(self, _cmd);
+    }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if ([self isKindOfClass:UIViewController.class]) {
+            PACaptureMasterContacts(self);
+            UIButton *button = objc_getAssociatedObject(self, PAButtonAssociationKey);
+            if (button) PABuildMenu((UIViewController *)self, button);
+        }
+    });
+}
+
+static void PAHookedContactsChanged(id self, SEL _cmd, id notification) {
+    if (PAOriginalContactsChanged) {
+        ((void (*)(id, SEL, id))PAOriginalContactsChanged)(self, _cmd, notification);
+    }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.45 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if ([self isKindOfClass:UIViewController.class]) {
+            objc_setAssociatedObject(self, PAMasterContactsAssociationKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            PACaptureMasterContacts(self);
+            UIButton *button = objc_getAssociatedObject(self, PAButtonAssociationKey);
+            if (button) PABuildMenu((UIViewController *)self, button);
+        }
+    });
+}
+
+static IMP PAReplaceMethod(Class cls, SEL selector, IMP replacement) {
+    Method method = class_getInstanceMethod(cls, selector);
+    if (!method) return NULL;
+    const char *types = method_getTypeEncoding(method);
+    IMP original = class_getMethodImplementation(cls, selector);
+    class_replaceMethod(cls, selector, replacement, types);
+    return original;
+}
+
+static BOOL PAInstallHooks(void) {
+    NSArray<NSString *> *candidates = @[@"PAContactsDashboardV46", @"PAContactsDashboardView"];
+    for (NSString *name in candidates) {
+        Class cls = NSClassFromString(name);
+        if (!cls) continue;
+        PAOriginalViewDidAppear = PAReplaceMethod(cls, @selector(viewDidAppear:), (IMP)PAHookedViewDidAppear);
+        PAOriginalContactsRefresh = PAReplaceMethod(cls, NSSelectorFromString(@"pa47_contactsRefresh"), (IMP)PAHookedContactsRefresh);
+        PAOriginalContactsChanged = PAReplaceMethod(cls, NSSelectorFromString(@"pa47_contactsDidChange:"), (IMP)PAHookedContactsChanged);
+        return PAOriginalViewDidAppear != NULL;
+    }
+    return NO;
+}
+
+static void PAScheduleHookAttempt(NSUInteger attempt) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.30 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if (!PAInstallHooks() && attempt < 30) {
+            PAScheduleHookAttempt(attempt + 1);
+        }
+    });
+}
+
+__attribute__((constructor)) static void PhoneAuraNativeFeaturesInitialize(void) {
+    @autoreleasepool {
+        PAScheduleHookAttempt(0);
+    }
+}

--- a/PhoneAuraFeaturePack/control
+++ b/PhoneAuraFeaturePack/control
@@ -1,0 +1,9 @@
+Package: com.zeshan.phoneaura.nativefeatures.build
+Name: PhoneAura Native Features Build Component
+Version: 0.5.0
+Architecture: iphoneos-arm64
+Description: Build-only companion component for PhoneAura 0.5.0.
+Maintainer: Next Solution
+Author: Next Solution
+Section: Development
+Depends: mobilesubstrate

--- a/PhoneAuraFeaturePack/prepare_package.py
+++ b/PhoneAuraFeaturePack/prepare_package.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import plistlib
+import re
+from pathlib import Path
+
+VERSION = "0.5.0"
+
+
+def load_plist(path: Path):
+    with path.open("rb") as handle:
+        return plistlib.load(handle)
+
+
+def save_plist(path: Path, value) -> None:
+    with path.open("wb") as handle:
+        plistlib.dump(value, handle, fmt=plistlib.FMT_XML, sort_keys=False)
+
+
+def update_control(path: Path) -> None:
+    text = path.read_text()
+    text = re.sub(r"^Version: .*$", f"Version: {VERSION}", text, flags=re.MULTILINE)
+    description = (
+        "PhoneAura 0.5.0 keeps the existing 0.4.16 design and stable runtime, adds a native-style "
+        "contact book/account selector for All Contacts, iCloud, Exchange, Google and contact groups, "
+        "and preserves Apple's native call, voicemail, emergency, Dual SIM, Wi-Fi Calling, Bluetooth, "
+        "CarPlay, Siri and active-call controllers where supported by the installed iOS version, device, "
+        "region and carrier."
+    )
+    text = re.sub(r"^Description: .*$", f"Description: {description}", text, flags=re.MULTILINE)
+    path.write_text(text)
+
+
+def update_bundle_info(path: Path) -> None:
+    info = load_plist(path)
+    info["CFBundleShortVersionString"] = VERSION
+    info["CFBundleVersion"] = "60"
+    save_plist(path, info)
+
+
+def update_root(path: Path) -> None:
+    root = load_plist(path)
+    if root and isinstance(root[0], dict):
+        root[0]["label"] = "PHONEAURA 0.5.0"
+        root[0]["footerText"] = (
+            "PhoneAura 0.5.0 keeps the current design and stable 0.4.16 runtime. "
+            "It adds contact-book/account selection while Apple continues to handle native calling services."
+        )
+
+    existing_keys = {row.get("key") for row in root if isinstance(row, dict)}
+    if "contactBookSelector" not in existing_keys:
+        insert_at = len(root)
+        for index, row in enumerate(root):
+            if isinstance(row, dict) and row.get("label") == "APPEARANCE":
+                insert_at = index
+                break
+        additions = [
+            {
+                "cell": "PSGroupCell",
+                "label": "CONTACT BOOKS",
+                "footerText": (
+                    "Shows a native-style selector in the existing PhoneAura Contacts header. "
+                    "Choose All Contacts, an account such as iCloud or Google, or a contact group/list."
+                ),
+            },
+            {
+                "cell": "PSSwitchCell",
+                "default": True,
+                "defaults": "com.zeshan.phoneaura",
+                "key": "contactBookSelector",
+                "label": "Contact Book Selector",
+                "PostNotification": "com.zeshan.phoneaura/preferences.changed",
+            },
+        ]
+        root[insert_at:insert_at] = additions
+
+    if root and isinstance(root[-1], dict) and root[-1].get("cell") == "PSGroupCell":
+        root[-1]["footerText"] = (
+            "Restart the Phone app after changing complete tab replacements or the Contact Book Selector. "
+            "Native Phone features remain subject to iOS version, iPhone model, carrier, language and region."
+        )
+    save_plist(path, root)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("layout", type=Path)
+    parser.add_argument("--root-prefix", default="")
+    args = parser.parse_args()
+
+    layout = args.layout
+    prefix = layout / args.root_prefix if args.root_prefix else layout
+    update_control(layout / "DEBIAN" / "control")
+    update_bundle_info(prefix / "Library" / "PreferenceBundles" / "PhoneAuraPrefs.bundle" / "Info.plist")
+    update_bundle_info(prefix / "Applications" / "PhoneAuraStudio.app" / "Info.plist")
+    update_root(prefix / "Library" / "PreferenceBundles" / "PhoneAuraPrefs.bundle" / "Root.plist")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## PhoneAura 0.5.1 Diagnostic Recovery

The previous 0.5.0 feature experiment is deprecated after on-device testing showed that it broke PhoneAura behavior. This update changes direction: it restores the stable 0.4.16 PhoneAura runtime and adds passive diagnostics only.

### Recovery behavior
- Final package is built from the original PhoneAura 0.4.16 RootHide/rootless DEBs.
- `PhoneAura.dylib` is validated byte-for-byte against the matching 0.4.16 original.
- The 0.5.0 `PhoneAuraNativeFeatures.dylib` / plist are removed and are not shipped.
- The original PhoneAura design and existing feature runtime remain untouched.

### PhoneAura Console
Installs a separate `PhoneAura Console` app with:
- Running status and 5-second MobilePhone heartbeat
- Diagnostic version, process/PID and jailbreak environment
- Base PhoneAura runtime loaded status
- Warning if the old 0.5.0 feature hook is somehow still loaded
- Current visible Phone controller and last diagnostic command
- Full diagnosis and current UI/controller snapshot
- Feature tests for Favorites, Recents, Contacts + accounts, Keypad, and Voicemail/system tab
- Contacts authorization plus account/container/group inspection
- Timestamped INFO / SUCCESS / WARNING / ERROR / DEBUG logging
- Live log viewer, Copy Log, Share Log and Clear Log
- Latest MobilePhone/PhoneAura crash-report import from standard CrashReporter locations

Diagnostic log path: `/var/mobile/Library/Logs/PhoneAura/PhoneAuraDiagnostics.log`

### Runtime diagnostic dylib
`PhoneAuraDiagnostics.dylib` is filtered only to `com.apple.mobilephone` and is passive: it does not use `class_replaceMethod` or replace PhoneAura controller methods. It records runtime images, preferences, PhoneAura class availability, active controller tree, tabs, lifecycle events, Contacts database changes, exceptions and requested feature snapshots.

### Validation
GitHub Actions successfully completed for both packages:
- Console app compilation: passed
- Rootless diagnostics build: passed
- RootHide diagnostics build: passed
- Package assembly: passed
- Final metadata validation: passed
- Original `PhoneAura.dylib` byte comparison with 0.4.16: passed
- Old `PhoneAuraNativeFeatures` hook absent: passed
- Console app / diagnostic dylib inclusion: passed
- RootHide architecture `iphoneos-arm64e`: passed
- Rootless architecture `iphoneos-arm64`: passed

The old 0.5.0 automatic build workflow is disabled. This diagnostic build is intended for feature-by-feature on-device diagnosis before any further PhoneAura feature changes are attempted.