### PR TITLE
Add read-only tweak feed scanner

### DIFF
--- a/.github/workflows/tweak-feed-dry-run.yml
+++ b/.github/workflows/tweak-feed-dry-run.yml
@@ -1,0 +1,52 @@
+name: Tweak feed scanner — dry run
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "automation/**"
+      - ".github/workflows/tweak-feed-dry-run.yml"
+  schedule:
+    - cron: "17 */6 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tweak-feed-dry-run
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run deterministic tests
+        run: python3 -m unittest discover -s automation/tests -v
+
+      - name: Scan configured metadata feeds
+        run: |
+          python3 -m automation.scanner \
+            --tiers verified,observe \
+            --require-verified 1 \
+            --output automation/out/report.json \
+            --summary automation/out/summary.md
+
+      - name: Add report to workflow summary
+        if: always()
+        run: |
+          if [ -f automation/out/summary.md ]; then
+            cat automation/out/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload scanner report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tweak-feed-report-${{ github.run_number }}
+          path: automation/out/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/tweak-feed-dry-run.yml
+++ b/.github/workflows/tweak-feed-dry-run.yml
@@ -24,6 +24,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Restore scanner state
+        if: github.event_name != 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: automation/runtime-state
+          key: tweak-feed-state-v1-${{ github.run_id }}
+          restore-keys: |
+            tweak-feed-state-v1-
+
       - name: Run deterministic tests
         run: python3 -m unittest discover -s automation/tests -v
 
@@ -32,8 +41,18 @@ jobs:
           python3 -m automation.scanner \
             --tiers verified,observe \
             --require-verified 1 \
+            --state automation/runtime-state/known-packages.json \
+            --write-state \
+            --baseline-new-sources \
             --output automation/out/report.json \
             --summary automation/out/summary.md
+
+      - name: Save scanner state
+        if: github.event_name != 'pull_request' && success()
+        uses: actions/cache/save@v4
+        with:
+          path: automation/runtime-state
+          key: tweak-feed-state-v1-${{ github.run_id }}
 
       - name: Add report to workflow summary
         if: always()
@@ -47,6 +66,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tweak-feed-report-${{ github.run_number }}
-          path: automation/out/
+          path: |
+            automation/out/
+            automation/runtime-state/known-packages.json
           if-no-files-found: warn
           retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+automation/out/
+__pycache__/
+*.py[cod]

--- a/automation/README.md
+++ b/automation/README.md
@@ -33,7 +33,10 @@ python3 -m automation.scanner --only chariz,nextsolution --tiers verified
 
 Reports are written to `automation/out/` and ignored by Git. The committed state
 file remains unchanged unless `--write-state` is explicitly supplied. The
-scheduled workflow does not supply it.
+scheduled workflow stores runtime state in a GitHub Actions cache, not in the
+repository. Every source is baselined on its first successful scan so historical
+catalog entries—or entries from a source recovering later—cannot be mistaken for
+new releases.
 
 ## Rollout gates
 

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,49 @@
+# Next Solution content automation
+
+This directory contains the safe, metadata-only foundation for monitoring iOS
+jailbreak repositories. The first workflow is intentionally a dry run: it reads
+APT `Packages` indexes, produces a report artifact, and cannot modify the live
+website.
+
+## Safety and editorial rules
+
+- Never download, unpack, mirror, or execute third-party `.deb` files.
+- Only a `verified` source can produce a future publication candidate.
+- `observe` sources appear in health reports but always require a provenance
+  decision before publication. `excluded` sources are not fetched.
+- Conflicting SHA-256 values, a changed binary under an unchanged version,
+  incomplete factual metadata, and piracy/game-cheat language block a candidate.
+- A future writer must use only feed facts and linked developer/marketplace
+  information. It must not invent compatibility, testing results, rankings, or
+  personal experience.
+- Automatic publishing will be limited to one substantial article per day, with
+  version updates applied to an existing URL instead of creating near-duplicates.
+- ShrinkMe may only be offered as a clearly labelled, optional ad-supported link.
+  The official source/developer page must remain available directly.
+- No automated clicks, impressions, views, subscriptions, watch time, or other
+  fake engagement are permitted.
+
+## Run locally
+
+```bash
+python3 -m unittest discover -s automation/tests -v
+python3 -m automation.scanner --require-verified 0
+python3 -m automation.scanner --only chariz,nextsolution --tiers verified
+```
+
+Reports are written to `automation/out/` and ignored by Git. The committed state
+file remains unchanged unless `--write-state` is explicitly supplied. The
+scheduled workflow does not supply it.
+
+## Rollout gates
+
+1. **Dry-run scanner (current):** verify source health, parsing, deduplication,
+   change detection, and safety blockers.
+2. **Baseline:** approve the source report once and save the current package
+   snapshot so only future releases are treated as new.
+3. **Draft writer:** use the OpenAI API to create a factual HTML draft and quality
+   report; do not publish it yet.
+4. **Limited publisher:** publish at most one qualified article per day, update
+   navigation/RSS/sitemap, and keep an audit log plus an automatic kill switch.
+5. **Video assist:** create a script and asset bundle for original videos. Uploads
+   stay private until the channel workflow and YouTube policy review are proven.

--- a/automation/__init__.py
+++ b/automation/__init__.py
@@ -1,0 +1,1 @@
+"""Next Solution editorial automation."""

--- a/automation/debian.py
+++ b/automation/debian.py
@@ -1,0 +1,147 @@
+"""Small, dependency-free helpers for Debian repository metadata."""
+
+from __future__ import annotations
+
+from functools import cmp_to_key
+import re
+from typing import Iterable
+
+
+FIELD_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]*$")
+
+
+def parse_control(text: str) -> list[dict[str, str]]:
+    """Parse RFC822/Deb822 paragraphs used by APT Packages indexes.
+
+    Malformed paragraphs are ignored instead of aborting the whole source. This
+    scanner only consumes metadata and never downloads package binaries.
+    """
+
+    records: list[dict[str, str]] = []
+    fields: dict[str, str] = {}
+    current: str | None = None
+
+    def finish() -> None:
+        nonlocal fields, current
+        if fields:
+            records.append(fields)
+        fields = {}
+        current = None
+
+    for raw_line in text.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        if not raw_line:
+            finish()
+            continue
+        if raw_line[0] in " \t":
+            if current is not None:
+                continuation = raw_line[1:]
+                fields[current] += "\n" + ("" if continuation == "." else continuation)
+            continue
+        if ":" not in raw_line:
+            current = None
+            continue
+        key, value = raw_line.split(":", 1)
+        if not FIELD_RE.fullmatch(key):
+            current = None
+            continue
+        current = key.lower()
+        fields[current] = value.lstrip()
+    finish()
+    return records
+
+
+def _split_version(version: str) -> tuple[int, str, str]:
+    epoch = 0
+    remainder = version
+    if ":" in remainder:
+        possible_epoch, remainder = remainder.split(":", 1)
+        if possible_epoch.isdigit():
+            epoch = int(possible_epoch)
+        else:
+            remainder = version
+    if "-" in remainder:
+        upstream, revision = remainder.rsplit("-", 1)
+    else:
+        upstream, revision = remainder, "0"
+    return epoch, upstream, revision
+
+
+def _char_order(char: str) -> int:
+    if char == "~":
+        return -1
+    if not char:
+        return 0
+    if char.isalpha():
+        return ord(char)
+    return ord(char) + 256
+
+
+def _compare_part(left: str, right: str) -> int:
+    li = ri = 0
+    while li < len(left) or ri < len(right):
+        while (li < len(left) and not left[li].isdigit()) or (
+            ri < len(right) and not right[ri].isdigit()
+        ):
+            lc = left[li] if li < len(left) and not left[li].isdigit() else ""
+            rc = right[ri] if ri < len(right) and not right[ri].isdigit() else ""
+            lo, ro = _char_order(lc), _char_order(rc)
+            if lo != ro:
+                return -1 if lo < ro else 1
+            if lc:
+                li += 1
+            if rc:
+                ri += 1
+
+        left_start = li
+        right_start = ri
+        while left_start < len(left) and left[left_start] == "0":
+            left_start += 1
+        while right_start < len(right) and right[right_start] == "0":
+            right_start += 1
+        left_end = left_start
+        right_end = right_start
+        while left_end < len(left) and left[left_end].isdigit():
+            left_end += 1
+        while right_end < len(right) and right[right_end].isdigit():
+            right_end += 1
+        left_digits = left[left_start:left_end]
+        right_digits = right[right_start:right_end]
+        if len(left_digits) != len(right_digits):
+            return -1 if len(left_digits) < len(right_digits) else 1
+        if left_digits != right_digits:
+            return -1 if left_digits < right_digits else 1
+
+        while li < len(left) and left[li].isdigit():
+            li += 1
+        while ri < len(right) and right[ri].isdigit():
+            ri += 1
+    return 0
+
+
+def compare_versions(left: str, right: str) -> int:
+    """Compare Debian versions using epoch, upstream, and revision ordering."""
+
+    left_epoch, left_upstream, left_revision = _split_version(left)
+    right_epoch, right_upstream, right_revision = _split_version(right)
+    if left_epoch != right_epoch:
+        return -1 if left_epoch < right_epoch else 1
+    upstream_result = _compare_part(left_upstream, right_upstream)
+    if upstream_result:
+        return upstream_result
+    return _compare_part(left_revision, right_revision)
+
+
+def newest(records: Iterable[dict[str, object]]) -> dict[str, object]:
+    """Return the record with the newest ``version`` field."""
+
+    values = list(records)
+    if not values:
+        raise ValueError("newest() requires at least one record")
+    return sorted(
+        values,
+        key=cmp_to_key(
+            lambda left, right: compare_versions(
+                str(left.get("version", "")), str(right.get("version", ""))
+            )
+        ),
+    )[-1]

--- a/automation/scanner.py
+++ b/automation/scanner.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""Read-only APT feed scanner for Next Solution editorial automation."""
+
+from __future__ import annotations
+
+import argparse
+import bz2
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import gzip
+import ipaddress
+import io
+import json
+import lzma
+from pathlib import Path
+import re
+import socket
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from automation.debian import compare_versions, newest, parse_control
+
+
+DEFAULT_FEED_PATHS = ["Packages.xz", "Packages.gz", "Packages.bz2", "Packages"]
+ALLOWED_TIERS = {"verified", "observe", "excluded"}
+MAX_COMPRESSED_BYTES = 24 * 1024 * 1024
+MAX_EXPANDED_BYTES = 64 * 1024 * 1024
+USER_AGENT = "NextSolutionFeedScanner/0.1 (+https://nextsolution.cc/)"
+RISK_PATTERNS = {
+    "piracy_language": re.compile(r"\b(crack(?:ed)?|pirated?|warez)\b", re.I),
+    "game_cheat_language": re.compile(
+        r"\b(aimbot|wallhack|mod[ -]?menu|game[ -]?cheat|unlimited[ -]?(?:coins|gems))\b",
+        re.I,
+    ),
+    "purchase_bypass_language": re.compile(
+        r"\b(free[ -]?in[ -]?app[ -]?purchase|iap[ -]?bypass|license[ -]?bypass)\b",
+        re.I,
+    ),
+}
+
+
+@dataclass
+class SourceScan:
+    source: dict[str, Any]
+    feed_url: str | None
+    packages: list[dict[str, Any]]
+    error: str | None
+    attempts: list[str]
+
+
+class SafeRedirectHandler(HTTPRedirectHandler):
+    def __init__(self, allowed_hosts: set[str]) -> None:
+        super().__init__()
+        self.allowed_hosts = allowed_hosts
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        _validate_remote_url(newurl, self.allowed_hosts)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _is_public_hostname(hostname: str) -> bool:
+    lowered = hostname.lower().rstrip(".")
+    if lowered in {"localhost", "localhost.localdomain"} or lowered.endswith(".local"):
+        return False
+    try:
+        address = ipaddress.ip_address(lowered)
+    except ValueError:
+        return True
+    return not (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    )
+
+
+def _validate_remote_url(url: str, allowed_hosts: set[str]) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("only HTTP(S) feed URLs are allowed")
+    if parsed.username or parsed.password:
+        raise ValueError("credentials are not allowed in feed URLs")
+    hostname = (parsed.hostname or "").lower()
+    if not hostname or not _is_public_hostname(hostname):
+        raise ValueError("feed URL must use a public hostname")
+    if hostname not in allowed_hosts:
+        raise ValueError(f"redirected to unapproved host {hostname}")
+
+
+def _read_limited(response, limit: int) -> bytes:  # type: ignore[no-untyped-def]
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = response.read(min(64 * 1024, limit + 1 - total))
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > limit:
+            raise ValueError(f"response exceeds {limit} bytes")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _expand_limited(payload: bytes, feed_url: str) -> bytes:
+    if feed_url.endswith(".gz"):
+        reader = gzip.GzipFile(fileobj=io.BytesIO(payload))
+    elif feed_url.endswith(".bz2"):
+        reader = bz2.BZ2File(io.BytesIO(payload))
+    elif feed_url.endswith(".xz"):
+        reader = lzma.LZMAFile(io.BytesIO(payload))
+    else:
+        if len(payload) > MAX_EXPANDED_BYTES:
+            raise ValueError("uncompressed Packages index is too large")
+        return payload
+    try:
+        expanded = reader.read(MAX_EXPANDED_BYTES + 1)
+    finally:
+        reader.close()
+    if len(expanded) > MAX_EXPANDED_BYTES:
+        raise ValueError("expanded Packages index is too large")
+    return expanded
+
+
+def _fetch(url: str, source: dict[str, Any], timeout: float) -> bytes:
+    base_host = (urlparse(str(source["url"])).hostname or "").lower()
+    allowed_hosts = {base_host}
+    allowed_hosts.update(str(value).lower() for value in source.get("redirect_hosts", []))
+    _validate_remote_url(url, allowed_hosts)
+    opener = build_opener(SafeRedirectHandler(allowed_hosts))
+    request = Request(url, headers={"User-Agent": USER_AGENT, "Accept": "*/*"})
+    with opener.open(request, timeout=timeout) as response:
+        return _read_limited(response, MAX_COMPRESSED_BYTES)
+
+
+def _clean_text(value: str, limit: int = 1400) -> str:
+    return re.sub(r"\s+", " ", value).strip()[:limit]
+
+
+def normalize_package(fields: dict[str, str], source: dict[str, Any]) -> dict[str, Any] | None:
+    package = fields.get("package", "").strip().lower()
+    version = fields.get("version", "").strip()
+    architecture = fields.get("architecture", "").strip().lower()
+    if not package or not version or not architecture:
+        return None
+    if not re.fullmatch(r"[a-z0-9][a-z0-9+.-]{1,254}", package):
+        return None
+    if not re.fullmatch(r"[0-9][A-Za-z0-9.+:~_-]{0,127}", version):
+        return None
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,63}", architecture):
+        return None
+
+    description = _clean_text(fields.get("description", ""))
+    name = _clean_text(fields.get("name", ""), 180) or package
+    author = _clean_text(fields.get("author", "") or fields.get("maintainer", ""), 240)
+    sha256 = fields.get("sha256", "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", sha256):
+        sha256 = ""
+
+    source_url = str(source["url"])
+    depiction = fields.get("sileodepiction", "") or fields.get("depiction", "")
+    homepage = fields.get("homepage", "")
+    facts_url = next(
+        (
+            value.strip()
+            for value in (depiction, homepage, source_url)
+            if value.strip().startswith(("https://", "http://"))
+        ),
+        source_url,
+    )
+
+    blockers: list[str] = []
+    if source["tier"] != "verified":
+        blockers.append("source_requires_review")
+    if not sha256:
+        blockers.append("missing_sha256")
+    if not author:
+        blockers.append("missing_author")
+    if len(description) < 24:
+        blockers.append("description_too_short")
+    risk_text = " ".join((package, name, description, fields.get("section", "")))
+    for label, pattern in RISK_PATTERNS.items():
+        if pattern.search(risk_text):
+            blockers.append(label)
+
+    return {
+        "identity": f"{package}|{architecture}",
+        "release_identity": f"{package}|{version}|{architecture}",
+        "package": package,
+        "name": name,
+        "version": version,
+        "architecture": architecture,
+        "description": description,
+        "author": author,
+        "section": _clean_text(fields.get("section", ""), 120),
+        "depends": _clean_text(fields.get("depends", ""), 600),
+        "tags": _clean_text(fields.get("tag", ""), 600),
+        "sha256": sha256,
+        "filename": _clean_text(fields.get("filename", ""), 600),
+        "facts_url": facts_url,
+        "source_id": source["id"],
+        "source_name": source["name"],
+        "source_url": source_url,
+        "source_tier": source["tier"],
+        "blockers": sorted(set(blockers)),
+    }
+
+
+def scan_source(source: dict[str, Any], timeout: float) -> SourceScan:
+    attempts: list[str] = []
+    base_url = str(source["url"])
+    feed_paths = source.get("feed_paths") or DEFAULT_FEED_PATHS
+    last_error = "no Packages index candidates configured"
+    for relative_path in feed_paths:
+        feed_url = urljoin(base_url if base_url.endswith("/") else base_url + "/", relative_path)
+        try:
+            payload = _fetch(feed_url, source, timeout)
+            text = _expand_limited(payload, feed_url).decode("utf-8", errors="replace")
+            parsed = parse_control(text)
+            normalized = [normalize_package(record, source) for record in parsed]
+            packages = [record for record in normalized if record is not None]
+            if not packages:
+                raise ValueError("response did not contain valid package records")
+            return SourceScan(source, feed_url, packages, None, attempts)
+        except (
+            EOFError,
+            HTTPError,
+            URLError,
+            TimeoutError,
+            socket.timeout,
+            OSError,
+            ValueError,
+        ) as exc:
+            reason = f"{type(exc).__name__}: {str(exc)[:180]}"
+            attempts.append(f"{feed_url} — {reason}")
+            last_error = reason
+    return SourceScan(source, None, [], last_error, attempts)
+
+
+def load_registry(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema_version") != 1 or not isinstance(data.get("sources"), list):
+        raise ValueError("source registry must use schema_version 1 and contain sources[]")
+    seen: set[str] = set()
+    for index, source in enumerate(data["sources"]):
+        if not isinstance(source, dict):
+            raise ValueError(f"source #{index + 1} must be an object")
+        missing = {"id", "name", "url", "tier"} - set(source)
+        if missing:
+            raise ValueError(f"source #{index + 1} is missing: {', '.join(sorted(missing))}")
+        if not all(isinstance(source[key], str) for key in ("id", "name", "url", "tier")):
+            raise ValueError(f"source #{index + 1} has a non-string required field")
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]{1,63}", source["id"]):
+            raise ValueError(f"invalid source id: {source['id']}")
+        if source["id"] in seen:
+            raise ValueError(f"duplicate source id: {source['id']}")
+        if source["tier"] not in ALLOWED_TIERS:
+            raise ValueError(f"invalid tier for {source['id']}: {source['tier']}")
+        _validate_remote_url(source["url"], {(urlparse(source["url"]).hostname or "").lower()})
+        for host in source.get("redirect_hosts", []):
+            if not isinstance(host, str) or not _is_public_hostname(host):
+                raise ValueError(f"invalid redirect host for {source['id']}: {host}")
+        for feed_path in source.get("feed_paths", DEFAULT_FEED_PATHS):
+            if not isinstance(feed_path, str):
+                raise ValueError(f"invalid feed path for {source['id']}: {feed_path}")
+            parsed_path = urlparse(feed_path)
+            if (
+                parsed_path.scheme
+                or parsed_path.netloc
+                or feed_path.startswith("/")
+                or ".." in parsed_path.path.split("/")
+            ):
+                raise ValueError(f"invalid feed path for {source['id']}: {feed_path}")
+        seen.add(source["id"])
+    return data
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"schema_version": 1, "packages": {}}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema_version") != 1 or not isinstance(data.get("packages"), dict):
+        raise ValueError("state file must use schema_version 1 and contain packages{}")
+    return data
+
+
+def deduplicate(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    tier_rank = {"verified": 0, "observe": 1, "excluded": 2}
+    release_groups: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        release_groups.setdefault(record["release_identity"], []).append(record)
+
+    selected: list[dict[str, Any]] = []
+    conflicts: list[dict[str, Any]] = []
+    for release_identity, values in sorted(release_groups.items()):
+        hashes = sorted({value["sha256"] for value in values if value["sha256"]})
+        values.sort(key=lambda value: (tier_rank[value["source_tier"]], value["source_id"]))
+        chosen = dict(values[0])
+        chosen["also_seen_at"] = sorted({value["source_id"] for value in values[1:]})
+        if len(hashes) > 1:
+            chosen["blockers"] = sorted(set(chosen["blockers"] + ["checksum_conflict"]))
+            conflicts.append(
+                {
+                    "release_identity": release_identity,
+                    "sources": sorted({value["source_id"] for value in values}),
+                    "sha256_values": hashes,
+                }
+            )
+        selected.append(chosen)
+    return selected, conflicts
+
+
+def latest_releases(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    identities: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        identities.setdefault(record["identity"], []).append(record)
+    return [dict(newest(values)) for _, values in sorted(identities.items())]
+
+
+def classify_changes(
+    latest: list[dict[str, Any]], state: dict[str, Any]
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, str]]]:
+    previous = state["packages"]
+    changes: list[dict[str, Any]] = []
+    # Preserve entries from temporarily unavailable feeds. Removing them would
+    # make an old release look new when that source recovers.
+    next_state: dict[str, dict[str, str]] = {
+        identity: dict(value) for identity, value in previous.items()
+    }
+    for record in latest:
+        identity = record["identity"]
+        old = previous.get(identity)
+        next_state[identity] = {
+            "version": record["version"],
+            "sha256": record["sha256"],
+            "source_id": record["source_id"],
+        }
+        change_type: str | None = None
+        if old is None:
+            change_type = "new"
+        else:
+            comparison = compare_versions(record["version"], str(old.get("version", "")))
+            if comparison > 0:
+                change_type = "updated"
+            elif comparison == 0 and record["sha256"] and old.get("sha256") and record["sha256"] != old["sha256"]:
+                change_type = "checksum_changed"
+                record["blockers"] = sorted(set(record["blockers"] + ["immutable_version_changed"]))
+        if change_type:
+            item = dict(record)
+            item["change_type"] = change_type
+            item["previous_version"] = old.get("version") if old else None
+            item["publish_eligible"] = not item["blockers"]
+            changes.append(item)
+    changes.sort(
+        key=lambda item: (
+            not item["publish_eligible"],
+            0 if item["change_type"] == "updated" else 1,
+            item["source_id"],
+            item["package"],
+        )
+    )
+    return changes, next_state
+
+
+def _markdown(report: dict[str, Any]) -> str:
+    stats = report["stats"]
+    lines = [
+        "# Tweak feed dry-run report",
+        "",
+        f"Generated: `{report['generated_at']}`",
+        "",
+        "## Result",
+        "",
+        f"- Sources attempted: **{stats['sources_attempted']}**",
+        f"- Sources successful: **{stats['sources_successful']}**",
+        f"- Verified sources successful: **{stats['verified_sources_successful']}**",
+        f"- Package records read: **{stats['package_records']}**",
+        f"- Unique current packages: **{stats['unique_current_packages']}**",
+        f"- Changes detected: **{stats['changes']}**",
+        f"- Eligible after safety gates: **{stats['publish_eligible']}**",
+        f"- Checksum conflicts: **{stats['checksum_conflicts']}**",
+        "",
+        "No website files, package binaries, links, or state were changed by this dry run.",
+        "",
+        "## Eligible changes (preview only)",
+        "",
+    ]
+    eligible = [item for item in report["changes"] if item["publish_eligible"]]
+    if not eligible:
+        lines.append("No change passed every publication gate.")
+    else:
+        lines.extend(["| Change | Tweak | Version | Architecture | Source |", "|---|---|---:|---|---|"])
+        for item in eligible[:30]:
+            name = item["name"].replace("|", "\\|")
+            lines.append(
+                f"| {item['change_type']} | {name} | {item['version']} | "
+                f"{item['architecture']} | {item['source_name']} |"
+            )
+    failed = [source for source in report["sources"] if source["status"] == "error"]
+    lines.extend(["", "## Source health", ""])
+    if failed:
+        lines.append(f"{len(failed)} source(s) failed. See `report.json` for bounded error details.")
+    else:
+        lines.append("Every attempted source returned a valid Packages index.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    registry = load_registry(args.sources)
+    state = load_state(args.state)
+    tiers = {value.strip() for value in args.tiers.split(",") if value.strip()}
+    invalid_tiers = tiers - {"verified", "observe"}
+    if invalid_tiers:
+        raise ValueError(f"unsupported scan tier(s): {', '.join(sorted(invalid_tiers))}")
+    sources = [source for source in registry["sources"] if source["tier"] in tiers]
+    if args.only:
+        requested = {value.strip() for value in args.only.split(",") if value.strip()}
+        known = {source["id"] for source in registry["sources"]}
+        missing = requested - known
+        if missing:
+            raise ValueError(f"unknown source id(s): {', '.join(sorted(missing))}")
+        sources = [source for source in sources if source["id"] in requested]
+    if not sources:
+        raise ValueError("no sources matched the selected tiers and ids")
+
+    results: list[SourceScan] = []
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {executor.submit(scan_source, source, args.timeout): source for source in sources}
+        for future in as_completed(futures):
+            results.append(future.result())
+    results.sort(key=lambda result: result.source["id"])
+
+    records = [package for result in results for package in result.packages]
+    unique_releases, conflicts = deduplicate(records)
+    latest = latest_releases(unique_releases)
+    changes, next_state = classify_changes(latest, state)
+    verified_successes = sum(
+        1 for result in results if result.error is None and result.source["tier"] == "verified"
+    )
+    if verified_successes < args.require_verified:
+        raise RuntimeError(
+            f"only {verified_successes} verified source(s) succeeded; required {args.require_verified}"
+        )
+
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    report = {
+        "schema_version": 1,
+        "mode": "dry-run" if not args.write_state else "state-update",
+        "generated_at": generated_at,
+        "policy": registry.get("policy", {}),
+        "stats": {
+            "sources_attempted": len(results),
+            "sources_successful": sum(result.error is None for result in results),
+            "verified_sources_successful": verified_successes,
+            "package_records": len(records),
+            "unique_releases": len(unique_releases),
+            "unique_current_packages": len(latest),
+            "changes": len(changes),
+            "publish_eligible": sum(item["publish_eligible"] for item in changes),
+            "checksum_conflicts": len(conflicts),
+        },
+        "sources": [
+            {
+                "id": result.source["id"],
+                "name": result.source["name"],
+                "tier": result.source["tier"],
+                "status": "ok" if result.error is None else "error",
+                "feed_url": result.feed_url,
+                "package_count": len(result.packages),
+                "error": result.error,
+                "attempts": result.attempts,
+            }
+            for result in results
+        ],
+        "conflicts": conflicts[: args.max_items],
+        "changes": changes[: args.max_items],
+        "truncated": len(changes) > args.max_items or len(conflicts) > args.max_items,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.summary.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.summary.write_text(_markdown(report), encoding="utf-8")
+    if args.write_state:
+        state_payload = {
+            "schema_version": 1,
+            "updated_at": generated_at,
+            "packages": next_state,
+        }
+        args.state.parent.mkdir(parents=True, exist_ok=True)
+        args.state.write_text(json.dumps(state_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sources", type=Path, default=Path("automation/sources.json"))
+    parser.add_argument("--state", type=Path, default=Path("automation/state/known-packages.json"))
+    parser.add_argument("--output", type=Path, default=Path("automation/out/report.json"))
+    parser.add_argument("--summary", type=Path, default=Path("automation/out/summary.md"))
+    parser.add_argument("--tiers", default="verified,observe")
+    parser.add_argument("--only", default="", help="Optional comma-separated source ids")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--workers", type=int, default=10)
+    parser.add_argument("--max-items", type=int, default=250)
+    parser.add_argument("--require-verified", type=int, default=1)
+    parser.add_argument(
+        "--write-state",
+        action="store_true",
+        help="Persist the current feed snapshot. Omit for a non-mutating dry run.",
+    )
+    args = parser.parse_args(argv)
+    if not 1 <= args.workers <= 20:
+        parser.error("--workers must be between 1 and 20")
+    if not 1 <= args.max_items <= 2000:
+        parser.error("--max-items must be between 1 and 2000")
+    if not 1 <= args.timeout <= 30:
+        parser.error("--timeout must be between 1 and 30 seconds")
+    if not 0 <= args.require_verified <= 100:
+        parser.error("--require-verified must be between 0 and 100")
+    return args
+
+
+def main() -> int:
+    try:
+        report = run(parse_args())
+    except (ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        print(f"scanner error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report["stats"], sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/automation/scanner.py
+++ b/automation/scanner.py
@@ -282,10 +282,13 @@ def load_registry(path: Path) -> dict[str, Any]:
 
 def load_state(path: Path) -> dict[str, Any]:
     if not path.exists():
-        return {"schema_version": 1, "packages": {}}
+        return {"schema_version": 1, "packages": {}, "sources": {}}
     data = json.loads(path.read_text(encoding="utf-8"))
     if data.get("schema_version") != 1 or not isinstance(data.get("packages"), dict):
         raise ValueError("state file must use schema_version 1 and contain packages{}")
+    if not isinstance(data.get("sources", {}), dict):
+        raise ValueError("state file sources must be an object")
+    data.setdefault("sources", {})
     return data
 
 
@@ -367,6 +370,20 @@ def classify_changes(
     return changes, next_state
 
 
+def suppress_first_seen_sources(
+    changes: list[dict[str, Any]], first_seen_sources: set[str]
+) -> tuple[list[dict[str, Any]], int]:
+    """Baseline a source on its first successful scan.
+
+    This prevents an existing catalog from becoming a publication queue when a
+    source is added, when the workflow runs for the first time, or when a source
+    recovers after being unavailable during the initial baseline.
+    """
+
+    retained = [item for item in changes if item["source_id"] not in first_seen_sources]
+    return retained, len(changes) - len(retained)
+
+
 def _markdown(report: dict[str, Any]) -> str:
     stats = report["stats"]
     lines = [
@@ -384,8 +401,9 @@ def _markdown(report: dict[str, Any]) -> str:
         f"- Changes detected: **{stats['changes']}**",
         f"- Eligible after safety gates: **{stats['publish_eligible']}**",
         f"- Checksum conflicts: **{stats['checksum_conflicts']}**",
+        f"- Historical changes baselined: **{stats['baseline_suppressed']}**",
         "",
-        "No website files, package binaries, links, or state were changed by this dry run.",
+        "The scanner never changes website files, package binaries, or links. Scanner state is written only when explicitly enabled.",
         "",
         "## Eligible changes (preview only)",
         "",
@@ -439,7 +457,17 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     records = [package for result in results for package in result.packages]
     unique_releases, conflicts = deduplicate(records)
     latest = latest_releases(unique_releases)
-    changes, next_state = classify_changes(latest, state)
+    raw_changes, next_state = classify_changes(latest, state)
+    successful_source_ids = {
+        result.source["id"] for result in results if result.error is None
+    }
+    known_source_ids = set(state.get("sources", {}))
+    first_seen_sources = (
+        successful_source_ids - known_source_ids if args.baseline_new_sources else set()
+    )
+    changes, baseline_suppressed = suppress_first_seen_sources(
+        raw_changes, first_seen_sources
+    )
     verified_successes = sum(
         1 for result in results if result.error is None and result.source["tier"] == "verified"
     )
@@ -449,11 +477,30 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         )
 
     generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    next_source_state = {
+        source_id: dict(value) for source_id, value in state.get("sources", {}).items()
+    }
+    for result in results:
+        if result.error is not None:
+            continue
+        entry = next_source_state.setdefault(
+            result.source["id"],
+            {
+                "initialized_at": generated_at,
+                "tier": result.source["tier"],
+            },
+        )
+        entry["last_success_at"] = generated_at
+        entry["tier"] = result.source["tier"]
     report = {
         "schema_version": 1,
-        "mode": "dry-run" if not args.write_state else "state-update",
+        "mode": "stateless-dry-run" if not args.write_state else "stateful-dry-run",
         "generated_at": generated_at,
         "policy": registry.get("policy", {}),
+        "baseline": {
+            "first_seen_sources": sorted(first_seen_sources),
+            "suppressed_changes": baseline_suppressed,
+        },
         "stats": {
             "sources_attempted": len(results),
             "sources_successful": sum(result.error is None for result in results),
@@ -464,6 +511,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             "changes": len(changes),
             "publish_eligible": sum(item["publish_eligible"] for item in changes),
             "checksum_conflicts": len(conflicts),
+            "baseline_suppressed": baseline_suppressed,
         },
         "sources": [
             {
@@ -492,6 +540,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             "schema_version": 1,
             "updated_at": generated_at,
             "packages": next_state,
+            "sources": next_source_state,
         }
         args.state.parent.mkdir(parents=True, exist_ok=True)
         args.state.write_text(json.dumps(state_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -510,6 +559,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--workers", type=int, default=10)
     parser.add_argument("--max-items", type=int, default=250)
     parser.add_argument("--require-verified", type=int, default=1)
+    parser.add_argument(
+        "--baseline-new-sources",
+        action="store_true",
+        help="Suppress changes when a source succeeds for the first time.",
+    )
     parser.add_argument(
         "--write-state",
         action="store_true",

--- a/automation/sources.json
+++ b/automation/sources.json
@@ -1,0 +1,454 @@
+{
+  "schema_version": 1,
+  "policy": {
+    "max_articles_per_day": 1,
+    "official_source_link_required": true,
+    "optional_ad_link_must_be_labelled": true,
+    "shortener_enabled": false,
+    "third_party_binaries_must_not_be_downloaded": true
+  },
+  "sources": [
+    {
+      "id": "0xkuj-yourepo",
+      "name": "0xkuj YouRepo",
+      "url": "https://0xkuj.yourepo.com/",
+      "tier": "observe"
+    },
+    {
+      "id": "akusio",
+      "name": "Akusio",
+      "url": "https://akusio.github.io/",
+      "tier": "observe"
+    },
+    {
+      "id": "alias20",
+      "name": "Alias20",
+      "url": "https://alias20.gitlab.io/apt/",
+      "tier": "observe"
+    },
+    {
+      "id": "alo-works",
+      "name": "Alo Works",
+      "url": "https://alo.works/",
+      "tier": "observe"
+    },
+    {
+      "id": "anthopak",
+      "name": "AnthoPak",
+      "url": "https://repo.anthopak.dev/",
+      "tier": "verified"
+    },
+    {
+      "id": "anubis-tweaks",
+      "name": "Anubis Tweaks",
+      "url": "https://anubistweaks.github.io/",
+      "tier": "observe"
+    },
+    {
+      "id": "arm64-debs-yourepo",
+      "name": "arm64-debs YouRepo",
+      "url": "https://arm64-debs.yourepo.com/",
+      "tier": "observe"
+    },
+    {
+      "id": "bigboss",
+      "name": "BigBoss",
+      "url": "http://apt.thebigboss.org/repofiles/cydia/",
+      "tier": "verified",
+      "feed_paths": [
+        "dists/stable/main/binary-iphoneos-arm/Packages.bz2",
+        "dists/stable/main/binary-iphoneos-arm/Packages.gz",
+        "dists/stable/main/binary-iphoneos-arm/Packages",
+        "Packages.bz2",
+        "Packages.gz",
+        "Packages"
+      ]
+    },
+    {
+      "id": "blatants",
+      "name": "Blatants",
+      "url": "https://repo.blatants.fyi/",
+      "tier": "observe"
+    },
+    {
+      "id": "brendonjkding",
+      "name": "Brendon JK Ding",
+      "url": "https://brendonjkding.github.io/",
+      "tier": "observe"
+    },
+    {
+      "id": "chariz",
+      "name": "Chariz",
+      "url": "https://repo.chariz.com/",
+      "tier": "verified"
+    },
+    {
+      "id": "codeymoore",
+      "name": "Codey Moore",
+      "url": "https://codeymoore.github.io/repo/",
+      "tier": "observe"
+    },
+    {
+      "id": "creaturecoding",
+      "name": "CreatureCoding",
+      "url": "https://creaturecoding.com/repo/",
+      "tier": "observe"
+    },
+    {
+      "id": "cydiageek-yourepo",
+      "name": "CydiaGeek YouRepo",
+      "url": "https://cydiageek.yourepo.com/",
+      "tier": "observe"
+    },
+    {
+      "id": "cypwn",
+      "name": "CyPwn",
+      "url": "https://repo.cypwn.xyz/",
+      "tier": "excluded",
+      "reason": "Provenance is not approved for unattended editorial publication."
+    },
+    {
+      "id": "dcsyhi1998",
+      "name": "DCSYHI 1998",
+      "url": "https://dcsyhi1998.github.io/",
+      "tier": "observe"
+    },
+    {
+      "id": "deno-io",
+      "name": "Deno iOS Repo",
+      "url": "https://6gr8.github.io/deno.io/",
+      "tier": "observe"
+    },
+    {
+      "id": "dhinakg",
+      "name": "Dhinak G",
+      "url": "https://dhinakg.github.io/repo/",
+      "tier": "observe"
+    },
+    {
+      "id": "dirtybeans",
+      "name": "DirtyBeans",
+      "url": "https://dirtybeans.github.io/",
+      "tier": "observe"
+    },
+    {
+      "id": "winaviation",
+      "name": "Win Aviation",
+      "url": "https://winaviation.github.io/repo/",
+      "tier": "observe"
+    },
+    {
+      "id": "nahtedetihw",
+      "name": "nahtedetihw",
+      "url": "https://nahtedetihw.github.io/",
+      "tier": "observe"
+    },
+    {
+      "id": "fouad-raheb",
+      "name": "Fouad Raheb",
+      "url": "https://apt.fouadraheb.com/",
+      "tier": "verified"
+    },
+    {
+      "id": "geometric",
+      "name": "Geometric Software",
+      "url": "https://apt.geometricsoftware.se/",
+      "tier": "verified"
+    },
+    {
+      "id": "havoc",
+      "name": "Havoc",
+      "url": "https://havoc.app/",
+      "tier": "verified"
+    },
+    {
+      "id": "i0s-tweak3r-betas",
+      "name": "i0s-tweak3r Betas",
+      "url": "https://i0s-tweak3r-betas.yourepo.com/",
+      "tier": "observe"
+    },
+    {
+      "id": "iarrays",
+      "name": "iArrays",
+      "url": "http://apt.iarrays.com/",
+      "tier": "observe"
+    },
+    {
+      "id": "ichitaso",
+      "name": "Ichitaso",
+      "url": "https://cydia.ichitaso.com/",
+      "tier": "verified"
+    },
+    {
+      "id": "idevicehacked",
+      "name": "iDeviceHacked",
+      "url": "https://idevicehacked.com/",
+      "tier": "excluded",
+      "reason": "Provenance is not approved for unattended editorial publication."
+    },
+    {
+      "id": "igg",
+      "name": "iGG",
+      "url": "http://aquawu.github.io/igg/",
+      "tier": "excluded",
+      "reason": "Game-mod content is outside the unattended editorial policy."
+    },
+    {
+      "id": "iosgods",
+      "name": "iOSGods",
+      "url": "https://iosgods.com/repo/",
+      "tier": "excluded",
+      "reason": "Game-mod content is outside the unattended editorial policy."
+    },
+    {
+      "id": "jjolano",
+      "name": "Julio Verne / jjolano",
+      "url": "https://ios.jjolano.me/",
+      "tier": "verified"
+    },
+    {
+      "id": "level3tjg",
+      "name": "Level3TJg",
+      "url": "https://level3tjg.me/repo/",
+      "tier": "observe"
+    },
+    {
+      "id": "limneos",
+      "name": "Limneos",
+      "url": "http://limneos.net/repo/",
+      "tier": "verified"
+    },
+    {
+      "id": "macthemes",
+      "name": "MacThemes",
+      "url": "https://macthemes.me/",
+      "tier": "observe"
+    },
+    {
+      "id": "repo-co-kr",
+      "name": "repo.co.kr",
+      "url": "https://repo.co.kr/",
+      "tier": "observe"
+    },
+    {
+      "id": "rpgfarm",
+      "name": "RPGFarm",
+      "url": "https://repo.rpgfarm.com/",
+      "tier": "excluded",
+      "reason": "Game-mod content is outside the unattended editorial policy."
+    },
+    {
+      "id": "miro92",
+      "name": "Miro92",
+      "url": "https://repo.miro92.com/",
+      "tier": "verified"
+    },
+    {
+      "id": "nathan4s",
+      "name": "Nathan4s",
+      "url": "https://nathan4s.lol/repo/",
+      "tier": "observe"
+    },
+    {
+      "id": "nextsolution",
+      "name": "Next Solution",
+      "url": "https://nextsolution.cc/",
+      "tier": "verified"
+    },
+    {
+      "id": "niceios",
+      "name": "NiceiOS",
+      "url": "http://repo.niceios.com/",
+      "tier": "observe"
+    },
+    {
+      "id": "niceios-global",
+      "name": "NiceiOS Global",
+      "url": "https://global.niceios.com/",
+      "tier": "observe"
+    },
+    {
+      "id": "nicho1as",
+      "name": "Nicho1as",
+      "url": "https://repo.nicho1as.dev/",
+      "tier": "observe"
+    },
+    {
+      "id": "nightwind",
+      "name": "Nightwind",
+      "url": "https://nightwinddev.github.io/",
+      "tier": "verified"
+    },
+    {
+      "id": "ellekit",
+      "name": "ElleKit",
+      "url": "https://ellekit.space/",
+      "tier": "verified"
+    },
+    {
+      "id": "opa334",
+      "name": "opa334",
+      "url": "https://opa334.github.io/",
+      "tier": "verified"
+    },
+    {
+      "id": "paisseon",
+      "name": "Paisseon",
+      "url": "https://paisseon.github.io/",
+      "tier": "observe"
+    },
+    {
+      "id": "pixelomer",
+      "name": "PixelOmer",
+      "url": "http://repo.pixelomer.com/",
+      "tier": "observe"
+    },
+    {
+      "id": "poomsmart",
+      "name": "PoomSmart",
+      "url": "https://poomsmart.github.io/repo/",
+      "tier": "verified"
+    },
+    {
+      "id": "procursus",
+      "name": "Procursus",
+      "url": "https://apt.procurs.us/",
+      "tier": "verified",
+      "feed_paths": [
+        "dists/1900/main/binary-iphoneos-arm64/Packages.xz",
+        "dists/1900/main/binary-iphoneos-arm64/Packages.gz",
+        "dists/1900/main/binary-iphoneos-arm64/Packages",
+        "dists/1900/main/binary-iphoneos-arm/Packages.xz",
+        "dists/1900/main/binary-iphoneos-arm/Packages.gz",
+        "dists/1900/main/binary-iphoneos-arm/Packages"
+      ]
+    },
+    {
+      "id": "roothide-procursus",
+      "name": "RootHide Procursus",
+      "url": "https://roothide.github.io/procursus/",
+      "tier": "verified",
+      "feed_paths": [
+        "dists/iphoneos-arm64e/1900/main/binary-iphoneos-arm64e/Packages.xz",
+        "dists/iphoneos-arm64e/1900/main/binary-iphoneos-arm64e/Packages.gz",
+        "dists/iphoneos-arm64e/1900/main/binary-iphoneos-arm64e/Packages",
+        "dists/iphoneos-arm64e/1900/main/binary-iphoneos-arm64/Packages.xz",
+        "dists/iphoneos-arm64e/1900/main/binary-iphoneos-arm64/Packages.gz",
+        "dists/iphoneos-arm64e/1900/main/binary-iphoneos-arm64/Packages"
+      ]
+    },
+    {
+      "id": "amgios",
+      "name": "AMG iOS",
+      "url": "http://apt.amgios.com/",
+      "tier": "observe"
+    },
+    {
+      "id": "rob311",
+      "name": "Rob311",
+      "url": "http://cydia.rob311.com/repo/",
+      "tier": "observe"
+    },
+    {
+      "id": "alfhaily",
+      "name": "Alfhaily",
+      "url": "https://apt.alfhaily.me/",
+      "tier": "observe"
+    },
+    {
+      "id": "roothide",
+      "name": "RootHide",
+      "url": "https://roothide.github.io/",
+      "tier": "verified"
+    },
+    {
+      "id": "skitty",
+      "name": "Skitty",
+      "url": "https://skitty.xyz/repo/",
+      "tier": "verified"
+    },
+    {
+      "id": "skypain",
+      "name": "SkyPain",
+      "url": "https://skypain.github.io/repo/",
+      "tier": "observe"
+    },
+    {
+      "id": "sparkdev",
+      "name": "SparkDev",
+      "url": "https://sparkdev.me/",
+      "tier": "verified"
+    },
+    {
+      "id": "tigisoftware",
+      "name": "Tigi Software",
+      "url": "http://tigisoftware.com/cydia/",
+      "tier": "verified"
+    },
+    {
+      "id": "tinyapps",
+      "name": "TinyApps",
+      "url": "https://apt.tinyapps.cn/",
+      "tier": "observe"
+    },
+    {
+      "id": "uckermark",
+      "name": "Uckermark",
+      "url": "https://repo.uckermark.dev/",
+      "tier": "observe"
+    },
+    {
+      "id": "udevsharold",
+      "name": "Udevs Harold",
+      "url": "https://udevsharold.github.io/repo/",
+      "tier": "observe"
+    },
+    {
+      "id": "uncore",
+      "name": "Uncore",
+      "url": "https://repo.uncore.me/",
+      "tier": "observe"
+    },
+    {
+      "id": "wilsonthewolf",
+      "name": "Wilson the Wolf",
+      "url": "https://wilsonthewolf.github.io/repo/",
+      "tier": "observe"
+    },
+    {
+      "id": "yourepo-directory",
+      "name": "YouRepo directory",
+      "url": "https://yourepo.com/",
+      "tier": "excluded",
+      "reason": "This is a repository directory, not one approved publisher feed."
+    },
+    {
+      "id": "yourepo-directory-www",
+      "name": "YouRepo directory (www)",
+      "url": "https://www.yourepo.com/",
+      "tier": "excluded",
+      "reason": "This is a duplicate repository directory URL."
+    },
+    {
+      "id": "zebra",
+      "name": "Zebra",
+      "url": "https://getzbra.com/repo/",
+      "tier": "verified",
+      "redirect_hosts": [
+        "repo.getzbra.com"
+      ]
+    },
+    {
+      "id": "zeroxjf",
+      "name": "ZeroXJF",
+      "url": "https://zeroxjf.github.io/",
+      "tier": "observe"
+    },
+    {
+      "id": "zsaaiq",
+      "name": "ZSAaiq Jailbreak Repo",
+      "url": "https://zsaaiq.github.io/jailbreakrepo/",
+      "tier": "observe"
+    }
+  ]
+}

--- a/automation/state/known-packages.json
+++ b/automation/state/known-packages.json
@@ -1,0 +1,5 @@
+{
+  "packages": {},
+  "schema_version": 1,
+  "updated_at": null
+}

--- a/automation/state/known-packages.json
+++ b/automation/state/known-packages.json
@@ -1,5 +1,6 @@
 {
   "packages": {},
   "schema_version": 1,
+  "sources": {},
   "updated_at": null
 }

--- a/automation/tests/fixtures/Packages
+++ b/automation/tests/fixtures/Packages
@@ -1,0 +1,28 @@
+Package: com.example.focuscards
+Name: Focus Cards
+Version: 1.2.0
+Architecture: iphoneos-arm64
+Description: Adds configurable cards to the iOS Home Screen.
+ Includes per-page spacing and color controls.
+ .
+ Settings are available through PreferenceLoader.
+Author: Example Developer <developer@example.com>
+Section: Tweaks
+Depends: mobilesubstrate, preferenceloader
+Filename: ./debs/com.example.focuscards_1.2.0_iphoneos-arm64.deb
+SHA256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+Depiction: https://example.com/depictions/focuscards
+
+Package: invalid-no-version
+Architecture: iphoneos-arm64
+Description: This paragraph must be ignored by normalization.
+
+Package: com.example.focuscards
+Name: Focus Cards
+Version: 1.1.0~beta1
+Architecture: iphoneos-arm64
+Description: An earlier beta package retained in the feed for testing.
+Author: Example Developer
+Section: Tweaks
+Filename: ./debs/old.deb
+SHA256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/automation/tests/test_debian.py
+++ b/automation/tests/test_debian.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import unittest
+
+from automation.debian import compare_versions, newest, parse_control
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "Packages"
+
+
+class ControlParserTests(unittest.TestCase):
+    def test_parses_paragraphs_and_continuations(self) -> None:
+        records = parse_control(FIXTURE.read_text(encoding="utf-8"))
+        self.assertEqual(len(records), 3)
+        self.assertEqual(records[0]["package"], "com.example.focuscards")
+        self.assertIn("per-page spacing", records[0]["description"])
+        self.assertIn("\n\nSettings", records[0]["description"])
+
+    def test_debian_version_ordering(self) -> None:
+        ordered = ["1.0~beta1", "1.0", "1.0-1", "1.0-2", "1:0.1"]
+        for lower, higher in zip(ordered, ordered[1:]):
+            self.assertLess(compare_versions(lower, higher), 0)
+            self.assertGreater(compare_versions(higher, lower), 0)
+        self.assertEqual(compare_versions("1.02", "1.2"), 0)
+
+    def test_selects_newest(self) -> None:
+        record = newest([{"version": "1.0~rc1"}, {"version": "1.0"}, {"version": "0.9"}])
+        self.assertEqual(record["version"], "1.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/automation/tests/test_scanner.py
+++ b/automation/tests/test_scanner.py
@@ -9,6 +9,7 @@ from automation.scanner import (
     load_registry,
     normalize_package,
     scan_source,
+    suppress_first_seen_sources,
 )
 
 
@@ -111,6 +112,30 @@ class ScannerPolicyTests(unittest.TestCase):
         }
         _, next_state = classify_changes([], state)
         self.assertIn("com.example.unavailable|iphoneos-arm64", next_state)
+
+    def test_first_successful_source_is_baselined(self) -> None:
+        record = package()
+        changes, _ = classify_changes([record], {"packages": {}})
+        retained, suppressed = suppress_first_seen_sources(changes, {"example"})
+        self.assertEqual(retained, [])
+        self.assertEqual(suppressed, 1)
+
+    def test_initialized_source_can_emit_a_future_update(self) -> None:
+        record = package(version="1.1")
+        state = {
+            "packages": {
+                record["identity"]: {
+                    "version": "1.0",
+                    "sha256": "a" * 64,
+                    "source_id": "example",
+                }
+            }
+        }
+        changes, _ = classify_changes([record], state)
+        retained, suppressed = suppress_first_seen_sources(changes, set())
+        self.assertEqual(len(retained), 1)
+        self.assertEqual(retained[0]["change_type"], "updated")
+        self.assertEqual(suppressed, 0)
 
 
 if __name__ == "__main__":

--- a/automation/tests/test_scanner.py
+++ b/automation/tests/test_scanner.py
@@ -1,0 +1,117 @@
+import gzip
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+from automation.scanner import (
+    classify_changes,
+    deduplicate,
+    load_registry,
+    normalize_package,
+    scan_source,
+)
+
+
+VERIFIED_SOURCE = {
+    "id": "example",
+    "name": "Example Repo",
+    "url": "https://example.com/repo/",
+    "tier": "verified",
+}
+
+
+def package(version: str = "1.0", sha: str = "a" * 64):
+    return normalize_package(
+        {
+            "package": "com.example.cards",
+            "name": "Example Cards",
+            "version": version,
+            "architecture": "iphoneos-arm64",
+            "description": "Adds useful configurable cards to the Home Screen.",
+            "author": "Example Developer",
+            "section": "Tweaks",
+            "sha256": sha,
+        },
+        VERIFIED_SOURCE,
+    )
+
+
+class ScannerPolicyTests(unittest.TestCase):
+    def test_committed_registry_is_valid_and_complete(self) -> None:
+        registry = load_registry(Path("automation/sources.json"))
+        self.assertEqual(len(registry["sources"]), 68)
+        self.assertGreaterEqual(
+            sum(source["tier"] == "verified" for source in registry["sources"]), 1
+        )
+
+    def test_verified_complete_metadata_is_eligible(self) -> None:
+        record = package()
+        self.assertIsNotNone(record)
+        self.assertEqual(record["blockers"], [])
+
+    def test_scans_a_compressed_packages_index(self) -> None:
+        payload = gzip.compress(
+            (Path(__file__).parent / "fixtures" / "Packages").read_bytes()
+        )
+        source = dict(VERIFIED_SOURCE, feed_paths=["Packages.gz"])
+        with patch("automation.scanner._fetch", return_value=payload):
+            result = scan_source(source, timeout=1)
+        self.assertIsNone(result.error)
+        self.assertEqual(result.feed_url, "https://example.com/repo/Packages.gz")
+        self.assertEqual(len(result.packages), 2)
+
+    def test_risky_language_is_blocked(self) -> None:
+        record = normalize_package(
+            {
+                "package": "com.example.menu",
+                "version": "1.0",
+                "architecture": "iphoneos-arm64",
+                "name": "Unlimited Gems Mod Menu",
+                "description": "A game cheat package with configurable controls.",
+                "author": "Unknown",
+                "sha256": "c" * 64,
+            },
+            VERIFIED_SOURCE,
+        )
+        self.assertIn("game_cheat_language", record["blockers"])
+
+    def test_conflicting_checksums_are_never_eligible(self) -> None:
+        first = package(sha="a" * 64)
+        second = package(sha="b" * 64)
+        second["source_id"] = "mirror"
+        selected, conflicts = deduplicate([first, second])
+        self.assertEqual(len(conflicts), 1)
+        self.assertIn("checksum_conflict", selected[0]["blockers"])
+
+    def test_same_version_checksum_change_is_blocked(self) -> None:
+        record = package(sha="b" * 64)
+        state = {
+            "packages": {
+                record["identity"]: {
+                    "version": "1.0",
+                    "sha256": "a" * 64,
+                    "source_id": "example",
+                }
+            }
+        }
+        changes, _ = classify_changes([record], state)
+        self.assertEqual(changes[0]["change_type"], "checksum_changed")
+        self.assertFalse(changes[0]["publish_eligible"])
+        self.assertIn("immutable_version_changed", changes[0]["blockers"])
+
+    def test_missing_source_does_not_disappear_from_next_state(self) -> None:
+        state = {
+            "packages": {
+                "com.example.unavailable|iphoneos-arm64": {
+                    "version": "2.0",
+                    "sha256": "d" * 64,
+                    "source_id": "temporarily-down",
+                }
+            }
+        }
+        _, next_state = classify_changes([], state)
+        self.assertIn("com.example.unavailable|iphoneos-arm64", next_state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Added a dependency-free Python scanner for Debian/APT `Packages` metadata.
- Registered all 68 repository URLs supplied for the project: 22 verified, 39 observe-only, and 7 excluded from unattended publication.
- Added Debian version-aware deduplication, checksum-conflict detection, metadata completeness checks, and piracy/game-cheat language blockers.
- Added safe first-seen baselining and persistent scanner state through GitHub Actions cache.
- Added a scheduled six-hour GitHub Actions dry run with `contents: read` permission.
- Added 12 deterministic tests and documented staged rollout gates.

## Why

This establishes the safe first stage of the Next Solution content automation. It identifies factual release candidates without downloading third-party package binaries, changing website files, publishing articles, creating links, or generating engagement.

## Impact

- The live website content remains unchanged.
- The workflow only updates an isolated scanner-state cache and uploads a report artifact.
- Each feed is baselined on its first successful scan, so historical packages and recovering feeds cannot flood the future content queue.
- If cached state is lost, the workflow safely re-baselines and emits no candidates from that gap.
- Automatic writing, ShrinkMe links, and publishing remain disabled.

## Validation

- `python3 -m unittest discover -s automation/tests -v` — 12 tests passed.
- Python compilation passed.
- Workflow YAML parsed successfully and declares read-only contents permission.
- `git diff --check` passed.
- No credential-like values were found in the added files.
- GitHub Actions run `31598633590` passed in 16 seconds: 56/61 feeds succeeded, 20/22 verified feeds succeeded, 16,368 historical packages were baselined, and zero candidates were queued.