### PR TITLE
Archive obsolete Next Home Torch patch workflows

### DIFF
--- a/.github/workflows/patch-nexthometorch-tutorial-pages.yml
+++ b/.github/workflows/patch-nexthometorch-tutorial-pages.yml
@@ -1,81 +1,15 @@
-name: Patch Next Home Torch Tutorial Pages
+# Archived after the Next Home Torch article and cards were published.
+name: Archived Next Home Torch tutorial patch
 
 on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  patch:
+  archived:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: tutorial/nexthometorch-1.0.0
-          fetch-depth: 0
-      - name: Add homepage card, Tutorials card and sitemap entry
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          from pathlib import Path
-
-          index = Path('index.html')
-          text = index.read_text()
-          text = text.replace(
-              'The newest Next Solution guides, with PhoneAura permanently pinned for quick access.',
-              'The newest Next Solution guides, with PhoneAura and Next Home Torch permanently pinned for quick access.'
-          )
-          card = '''
-        <!-- NEXTHOMETORCH_RECENT_CARD_START -->
-        <article class="card">
-          <div class="icon"><i class="fas fa-bolt" aria-hidden="true"></i></div>
-          <h3>Next Home Torch 1.0.0 — Two-Finger Flashlight</h3>
-          <p>Toggle the flashlight from empty Home Screen space with one simultaneous two-finger tap. RootHide and rootless builds for iOS 15+.</p>
-          <a class="more" href="next-home-torch-ios15-ios16.html">Read guide &amp; download <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
-        </article>
-        <!-- NEXTHOMETORCH_RECENT_CARD_END -->
-'''
-          marker = '        <!-- PHONEAURA_RECENT_CARD_END -->\n'
-          if 'NEXTHOMETORCH_RECENT_CARD_START' not in text:
-              assert marker in text
-              text = text.replace(marker, marker + card, 1)
-          index.write_text(text)
-
-          tutorials = Path('tutorials.html')
-          text = tutorials.read_text()
-          card = '''
-      <article class="card">
-        <div class="icon"><i class="fas fa-bolt" aria-hidden="true"></i></div>
-        <h3>Next Home Torch 1.0.0</h3>
-        <p>Use a two-finger tap on empty Home Screen wallpaper to toggle the flashlight. Includes direct RootHide and rootless downloads.</p>
-        <a href="next-home-torch-ios15-ios16.html">Read guide &amp; download</a>
-      </article>
-'''
-          if 'href="next-home-torch-ios15-ios16.html"' not in text:
-              start = text.index('<section class="grid" aria-label="Tutorial guides">')
-              end = text.index('</section>', start)
-              text = text[:end] + card + '\n' + text[end:]
-          tutorials.write_text(text)
-
-          sitemap = Path('sitemap.xml')
-          text = sitemap.read_text()
-          entry = '  <url><loc>https://nextsolution.cc/next-home-torch-ios15-ios16.html</loc><lastmod>2026-07-31</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>\n'
-          if 'next-home-torch-ios15-ios16.html' not in text:
-              marker = '  <url><loc>https://nextsolution.cc/privacy.html</loc>'
-              assert marker in text
-              text = text.replace(marker, entry + marker, 1)
-          sitemap.write_text(text)
-          PY
-          python3 .github/scripts/publish-nexthometorch-blog.py
-      - name: Commit tutorial-page updates
-        shell: bash
-        run: |
-          set -euo pipefail
-          git config user.name 'Next Solution Website Bot'
-          git config user.email actions@users.noreply.github.com
-          git add index.html tutorials.html sitemap.xml
-          git diff --cached --check
-          git commit -m 'Complete Next Home Torch tutorial draft pages'
-          git push origin HEAD:tutorial/nexthometorch-1.0.0
+      - name: Explain archived workflow
+        run: echo "This one-time tutorial patch is archived; the published site is maintained by current workflows."

--- a/.github/workflows/run-nht-page-patch-pr.yml
+++ b/.github/workflows/run-nht-page-patch-pr.yml
@@ -1,73 +1,15 @@
-name: Run Next Home Torch Page Patch from PR
+# Archived after the Next Home Torch article and cards were published.
+name: Archived Next Home Torch PR page patch
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - "DailyTweaks/2026-07-31-NextHomeTorch/TUTORIAL_TRIGGER"
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  patch:
+  archived:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: tutorial/nexthometorch-1.0.0
-          fetch-depth: 0
-      - name: Add cards and sitemap
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          from pathlib import Path
-          index=Path('index.html'); text=index.read_text()
-          text=text.replace('The newest Next Solution guides, with PhoneAura permanently pinned for quick access.','The newest Next Solution guides, with PhoneAura and Next Home Torch permanently pinned for quick access.')
-          card='''
-        <!-- NEXTHOMETORCH_RECENT_CARD_START -->
-        <article class="card">
-          <div class="icon"><i class="fas fa-bolt" aria-hidden="true"></i></div>
-          <h3>Next Home Torch 1.0.0 — Two-Finger Flashlight</h3>
-          <p>Toggle the flashlight from empty Home Screen space with one simultaneous two-finger tap. RootHide and rootless builds for iOS 15+.</p>
-          <a class="more" href="next-home-torch-ios15-ios16.html">Read guide &amp; download <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
-        </article>
-        <!-- NEXTHOMETORCH_RECENT_CARD_END -->
-'''
-          marker='        <!-- PHONEAURA_RECENT_CARD_END -->\n'
-          if 'NEXTHOMETORCH_RECENT_CARD_START' not in text:
-              assert marker in text
-              text=text.replace(marker,marker+card,1)
-          index.write_text(text)
-          tutorials=Path('tutorials.html'); text=tutorials.read_text()
-          card='''
-      <article class="card">
-        <div class="icon"><i class="fas fa-bolt" aria-hidden="true"></i></div>
-        <h3>Next Home Torch 1.0.0</h3>
-        <p>Use a two-finger tap on empty Home Screen wallpaper to toggle the flashlight. Includes direct RootHide and rootless downloads.</p>
-        <a href="next-home-torch-ios15-ios16.html">Read guide &amp; download</a>
-      </article>
-'''
-          if 'href="next-home-torch-ios15-ios16.html"' not in text:
-              start=text.index('<section class="grid" aria-label="Tutorial guides">')
-              end=text.index('</section>',start)
-              text=text[:end]+card+'\n'+text[end:]
-          tutorials.write_text(text)
-          sitemap=Path('sitemap.xml'); text=sitemap.read_text()
-          entry='  <url><loc>https://nextsolution.cc/next-home-torch-ios15-ios16.html</loc><lastmod>2026-07-31</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>\n'
-          if 'next-home-torch-ios15-ios16.html' not in text:
-              marker='  <url><loc>https://nextsolution.cc/privacy.html</loc>'
-              assert marker in text
-              text=text.replace(marker,entry+marker,1)
-          sitemap.write_text(text)
-          PY
-          python3 .github/scripts/publish-nexthometorch-blog.py
-      - name: Commit branch changes
-        run: |
-          git config user.name 'Next Solution Website Bot'
-          git config user.email actions@users.noreply.github.com
-          git add index.html tutorials.html sitemap.xml
-          git diff --cached --check
-          git commit -m 'Complete Next Home Torch tutorial draft pages'
-          git push origin HEAD:tutorial/nexthometorch-1.0.0
+      - name: Explain archived workflow
+        run: echo "This one-time page patch is archived; the published site is maintained by current workflows."

--- a/.github/workflows/run-nht-page-patch.yml
+++ b/.github/workflows/run-nht-page-patch.yml
@@ -1,84 +1,15 @@
-name: Run Next Home Torch Tutorial Page Patch
+# Archived after the Next Home Torch article and cards were published.
+name: Archived Next Home Torch page patch
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - ".github/workflows/run-nht-page-patch.yml"
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  patch:
+  archived:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: tutorial/nexthometorch-1.0.0
-          fetch-depth: 0
-      - name: Add homepage card, Tutorials card and sitemap entry
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          from pathlib import Path
-
-          index = Path('index.html')
-          text = index.read_text()
-          text = text.replace(
-              'The newest Next Solution guides, with PhoneAura permanently pinned for quick access.',
-              'The newest Next Solution guides, with PhoneAura and Next Home Torch permanently pinned for quick access.'
-          )
-          card = '''
-        <!-- NEXTHOMETORCH_RECENT_CARD_START -->
-        <article class="card">
-          <div class="icon"><i class="fas fa-bolt" aria-hidden="true"></i></div>
-          <h3>Next Home Torch 1.0.0 — Two-Finger Flashlight</h3>
-          <p>Toggle the flashlight from empty Home Screen space with one simultaneous two-finger tap. RootHide and rootless builds for iOS 15+.</p>
-          <a class="more" href="next-home-torch-ios15-ios16.html">Read guide &amp; download <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
-        </article>
-        <!-- NEXTHOMETORCH_RECENT_CARD_END -->
-'''
-          marker = '        <!-- PHONEAURA_RECENT_CARD_END -->\n'
-          if 'NEXTHOMETORCH_RECENT_CARD_START' not in text:
-              assert marker in text
-              text = text.replace(marker, marker + card, 1)
-          index.write_text(text)
-
-          tutorials = Path('tutorials.html')
-          text = tutorials.read_text()
-          card = '''
-      <article class="card">
-        <div class="icon"><i class="fas fa-bolt" aria-hidden="true"></i></div>
-        <h3>Next Home Torch 1.0.0</h3>
-        <p>Use a two-finger tap on empty Home Screen wallpaper to toggle the flashlight. Includes direct RootHide and rootless downloads.</p>
-        <a href="next-home-torch-ios15-ios16.html">Read guide &amp; download</a>
-      </article>
-'''
-          if 'href="next-home-torch-ios15-ios16.html"' not in text:
-              start = text.index('<section class="grid" aria-label="Tutorial guides">')
-              end = text.index('</section>', start)
-              text = text[:end] + card + '\n' + text[end:]
-          tutorials.write_text(text)
-
-          sitemap = Path('sitemap.xml')
-          text = sitemap.read_text()
-          entry = '  <url><loc>https://nextsolution.cc/next-home-torch-ios15-ios16.html</loc><lastmod>2026-07-31</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>\n'
-          if 'next-home-torch-ios15-ios16.html' not in text:
-              marker = '  <url><loc>https://nextsolution.cc/privacy.html</loc>'
-              assert marker in text
-              text = text.replace(marker, entry + marker, 1)
-          sitemap.write_text(text)
-          PY
-          python3 .github/scripts/publish-nexthometorch-blog.py
-      - name: Commit tutorial-page updates
-        shell: bash
-        run: |
-          set -euo pipefail
-          git config user.name 'Next Solution Website Bot'
-          git config user.email actions@users.noreply.github.com
-          git add index.html tutorials.html sitemap.xml
-          git diff --cached --check
-          git commit -m 'Complete Next Home Torch tutorial draft pages'
-          git push origin HEAD:tutorial/nexthometorch-1.0.0
+      - name: Explain archived workflow
+        run: echo "This one-time page patch is archived; the published site is maintained by current workflows."


### PR DESCRIPTION
Three completed one-time page-patch workflows contained invalid YAML and produced configuration failures on unrelated pushes. This replaces them with valid, read-only, manual archive stubs. The current Next Home Lock validation workflow remains active and already passes.