### PR TITLE
Keep homepage hero glow inside the viewport

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -164,9 +164,9 @@ a:focus-visible, button:focus-visible, summary:focus-visible {
 .home-hero::after {
   content: "";
   position: absolute;
-  width: 560px;
-  height: 560px;
-  right: -240px;
+  width: min(560px, 100%);
+  aspect-ratio: 1;
+  right: 0;
   top: 16px;
   z-index: -1;
   border-radius: 50%;


### PR DESCRIPTION
Live browser validation found the decorative homepage glow increased the document scroll width beyond the desktop viewport. This keeps the effect within the hero container and makes it responsive, preventing horizontal overflow without changing content.