### PR TITLE
Run the daily publisher at 06:00 Qatar time

### DIFF
--- a/.github/workflows/tweak-draft-generator.yml
+++ b/.github/workflows/tweak-draft-generator.yml
@@ -3,8 +3,8 @@ name: Verified tweak article publisher
 on:
   workflow_dispatch:
   schedule:
-    # 01:00 UTC is 04:00 in Qatar (UTC+3, no daylight-saving changes).
-    - cron: "0 1 * * *"
+    # 03:00 UTC is 06:00 in Qatar (UTC+3, no daylight-saving changes).
+    - cron: "0 3 * * *"
   pull_request:
     paths:
       - "automation/**"

--- a/.github/workflows/tweak-draft-generator.yml
+++ b/.github/workflows/tweak-draft-generator.yml
@@ -3,7 +3,8 @@ name: Verified tweak article publisher
 on:
   workflow_dispatch:
   schedule:
-    - cron: "37 4 * * *"
+    # 01:00 UTC is 04:00 in Qatar (UTC+3, no daylight-saving changes).
+    - cron: "0 1 * * *"
   pull_request:
     paths:
       - "automation/**"

--- a/automation/README.md
+++ b/automation/README.md
@@ -5,7 +5,7 @@ jailbreak repositories. The first workflow is intentionally a dry run: it reads
 APT `Packages` indexes, produces a report artifact, and cannot modify the live
 website.
 
-The publisher workflow runs once per day at 04:00 Qatar time. It first checks a
+The publisher workflow runs once per day at 06:00 Qatar time. It first checks a
 committed kill switch and the one-per-day audit log, before making any billable
 request. It can then generate one article from a new eligible release or, when
 that queue is empty, one undrafted package from the verified-source evergreen

--- a/automation/README.md
+++ b/automation/README.md
@@ -5,7 +5,7 @@ jailbreak repositories. The first workflow is intentionally a dry run: it reads
 APT `Packages` indexes, produces a report artifact, and cannot modify the live
 website.
 
-The publisher workflow runs once per day at 07:37 Qatar time. It first checks a
+The publisher workflow runs once per day at 04:00 Qatar time. It first checks a
 committed kill switch and the one-per-day audit log, before making any billable
 request. It can then generate one article from a new eligible release or, when
 that queue is empty, one undrafted package from the verified-source evergreen

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://nextsolution.cc/sitemap.xml


### PR DESCRIPTION
## What changed
- schedule the guarded daily publisher for 06:00 Qatar time (03:00 UTC)
- document the Qatar-time schedule
- add a public `robots.txt` that points search engines to the sitemap

## Safety
- the existing kill switch remains enabled
- the existing one-article-per-Qatar-day limit remains unchanged
- API calls still happen only after preflight checks pass