### PR TITLE
Redesign Next Solution as an informative jailbreak blog

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1,37 +1,35 @@
 :root {
-  color-scheme: dark;
-  --bg: #05070d;
-  --bg-elevated: #090e19;
-  --panel: rgba(15, 23, 41, .78);
-  --panel-solid: #10182a;
-  --panel-soft: rgba(255, 255, 255, .045);
-  --text: #f6f8ff;
-  --muted: #a8b3c9;
-  --quiet: #758199;
-  --line: rgba(255, 255, 255, .105);
-  --line-strong: rgba(124, 147, 255, .32);
-  --violet: #8b5cf6;
-  --blue: #3b82f6;
-  --cyan: #22d3ee;
-  --green: #3ddc97;
-  --yellow: #f7c75e;
-  --red: #ff6b7d;
-  --gradient: linear-gradient(135deg, #8b5cf6 0%, #3b82f6 56%, #22d3ee 115%);
-  --gradient-soft: linear-gradient(135deg, rgba(139, 92, 246, .16), rgba(59, 130, 246, .12));
-  --shadow: 0 28px 80px rgba(0, 0, 0, .38);
-  --shadow-soft: 0 18px 48px rgba(0, 0, 0, .22);
-  --radius-xl: 32px;
+  color-scheme: light;
+  --bg: #f2f4f5;
+  --surface: #ffffff;
+  --surface-soft: #e8edef;
+  --ink: #0b0d10;
+  --muted: #58616b;
+  --quiet: #7d858d;
+  --line: #d8dde0;
+  --line-dark: #b8c0c5;
+  --coral: #ff5573;
+  --coral-soft: #ffe3e9;
+  --blue: #5776ff;
+  --blue-soft: #dce4ff;
+  --mint: #8be0c3;
+  --yellow: #f5cf65;
+  --green: #13a36f;
+  --red: #df304f;
+  --shadow: 0 24px 70px rgba(24, 31, 36, .12);
+  --shadow-soft: 0 12px 38px rgba(24, 31, 36, .07);
+  --radius-xl: 34px;
   --radius-lg: 22px;
-  --radius-md: 15px;
-  --container: 1180px;
-  --header-height: 76px;
+  --radius-md: 14px;
+  --container: 1220px;
+  --header-height: 84px;
 }
 
 * { box-sizing: border-box; }
 
 html {
   scroll-behavior: smooth;
-  scroll-padding-top: calc(var(--header-height) + 18px);
+  scroll-padding-top: calc(var(--header-height) + 28px);
   scrollbar-gutter: stable;
 }
 
@@ -40,483 +38,607 @@ body {
   min-width: 320px;
   min-height: 100vh;
   overflow-x: clip;
-  color: var(--text);
-  background:
-    radial-gradient(circle at 9% 2%, rgba(89, 66, 255, .20), transparent 32rem),
-    radial-gradient(circle at 92% 16%, rgba(22, 141, 255, .16), transparent 34rem),
-    linear-gradient(160deg, #04060b 0%, #07101e 52%, #0d0920 100%);
-  font: 16px/1.68 -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, Arial, sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+  font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
-}
-
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  opacity: .26;
-  background-image:
-    linear-gradient(rgba(255, 255, 255, .028) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, .028) 1px, transparent 1px);
-  background-size: 52px 52px;
-  mask-image: linear-gradient(to bottom, #000 0%, transparent 86%);
 }
 
 img { display: block; max-width: 100%; }
 a { color: inherit; }
 button, a { -webkit-tap-highlight-color: transparent; }
 a:focus-visible, button:focus-visible, summary:focus-visible {
-  outline: 3px solid var(--cyan);
+  outline: 3px solid var(--blue);
   outline-offset: 3px;
+}
+
+.container { width: min(var(--container), calc(100% - 40px)); margin-inline: auto; }
+.narrow { width: min(820px, 100%); margin-inline: auto; }
+
+.topline {
+  color: #fff;
+  background: var(--ink);
+  font-size: .72rem;
+  font-weight: 720;
+  letter-spacing: .045em;
+  text-transform: uppercase;
+}
+.topline-inner {
+  width: min(var(--container), calc(100% - 40px));
+  min-height: 34px;
+  margin-inline: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 22px;
+}
+.topline-status { display: inline-flex; align-items: center; gap: 8px; color: #d5d9dc; }
+.topline-status i, .status-line i {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #50dfa9;
+  box-shadow: 0 0 0 4px rgba(80, 223, 169, .14);
 }
 
 .site-header {
   position: sticky;
   top: 0;
   z-index: 1000;
-  border-bottom: 1px solid var(--line);
-  background: rgba(5, 7, 13, .78);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, .22);
-  backdrop-filter: blur(22px) saturate(145%);
-  -webkit-backdrop-filter: blur(22px) saturate(145%);
+  border-bottom: 1px solid rgba(184, 192, 197, .7);
+  background: rgba(247, 249, 249, .92);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
 }
-
 .nav-shell {
-  width: min(var(--container), calc(100% - 32px));
+  width: min(var(--container), calc(100% - 40px));
   min-height: var(--header-height);
-  margin: 0 auto;
+  margin-inline: auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 20px;
+  gap: 32px;
 }
-
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 11px;
-  color: #fff;
+  gap: 12px;
+  color: var(--ink);
   text-decoration: none;
-  font-size: 1.12rem;
-  font-weight: 900;
-  letter-spacing: -.025em;
   white-space: nowrap;
 }
-
 .brand-mark {
-  width: 42px;
-  height: 42px;
+  width: 58px;
+  height: 58px;
   display: grid;
   place-items: center;
-  border: 1px solid rgba(255, 255, 255, .22);
-  border-radius: 14px;
-  color: #fff;
-  background: var(--gradient);
-  box-shadow: 0 10px 30px rgba(70, 73, 230, .34), inset 0 1px rgba(255, 255, 255, .35);
-  font-size: 1.05rem;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  background: transparent;
+  font-size: 1.25rem;
   font-weight: 950;
+  letter-spacing: -.06em;
 }
-
+.brand-copy { display: flex; align-items: baseline; gap: 5px; line-height: 1; }
+.brand-copy strong { font-size: 1.12rem; font-weight: 950; letter-spacing: -.045em; text-transform: uppercase; }
+.brand-copy small { font-size: .93rem; font-weight: 760; letter-spacing: -.02em; }
 .nav-links {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: clamp(12px, 3vw, 42px);
   margin: 0;
   padding: 0;
   overflow-x: auto;
   list-style: none;
   scrollbar-width: none;
 }
-
 .nav-links::-webkit-scrollbar { display: none; }
 .nav-links a {
-  display: block;
-  padding: 9px 13px;
-  border-radius: 12px;
-  color: var(--muted);
-  text-decoration: none;
-  font-size: .9rem;
-  font-weight: 760;
-  white-space: nowrap;
-  transition: color .18s ease, background .18s ease;
-}
-.nav-links a:hover, .nav-links a[aria-current="page"] {
-  color: #fff;
-  background: rgba(255, 255, 255, .075);
-}
-
-.container { width: min(var(--container), calc(100% - 32px)); margin-inline: auto; }
-.narrow { width: min(820px, 100%); margin-inline: auto; }
-
-.home-hero {
   position: relative;
-  isolation: isolate;
-  display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(320px, .92fr);
-  align-items: center;
-  gap: clamp(34px, 7vw, 86px);
-  min-height: min(760px, calc(100svh - var(--header-height)));
-  padding-block: clamp(58px, 9vw, 108px);
+  display: block;
+  padding: 15px 0;
+  color: #15181a;
+  text-decoration: none;
+  font-size: .84rem;
+  font-weight: 880;
+  letter-spacing: .035em;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
-
-.home-hero::after {
+.nav-links a::after {
   content: "";
   position: absolute;
-  width: min(560px, 100%);
-  aspect-ratio: 1;
-  right: 0;
-  top: 16px;
-  z-index: -1;
-  border-radius: 50%;
-  background: rgba(38, 134, 255, .10);
-  filter: blur(12px);
+  left: 0;
+  right: 100%;
+  bottom: 9px;
+  height: 3px;
+  background: var(--coral);
+  transition: right .2s ease;
 }
+.nav-links a:hover::after, .nav-links a[aria-current="page"]::after { right: 0; }
 
-.kicker, .article-kicker {
+.editorial-hero {
+  min-height: 650px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(360px, .92fr);
+  align-items: center;
+  gap: clamp(30px, 6vw, 86px);
+  margin-block: 30px 0;
+  padding: clamp(48px, 7vw, 86px);
+  overflow: hidden;
+  border: 1px solid #d5dbde;
+  border-radius: var(--radius-xl);
+  background:
+    radial-gradient(circle at 88% 18%, rgba(255, 255, 255, .86), transparent 28%),
+    linear-gradient(120deg, #f5f7f7 0%, #d9e2e7 58%, #c8d5dc 100%);
+}
+.eyebrow, .kicker, .article-kicker {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 18px;
-  padding: 7px 11px;
-  border: 1px solid rgba(120, 129, 255, .32);
-  border-radius: 999px;
-  color: #d9ddff;
-  background: rgba(94, 71, 233, .12);
-  font-size: .75rem;
-  font-weight: 850;
-  letter-spacing: .08em;
+  margin-bottom: 15px;
+  color: #4d565d;
+  font-size: .74rem;
+  font-weight: 900;
+  letter-spacing: .095em;
   text-transform: uppercase;
 }
-
-.kicker::before, .article-kicker::before {
+.eyebrow::before, .kicker::before, .article-kicker::before {
   content: "";
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--cyan);
-  box-shadow: 0 0 14px var(--cyan);
+  width: 20px;
+  height: 3px;
+  background: var(--coral);
 }
-
-.hero-copy h1, .page-hero h1, .article-hero h1 {
+.hero-copy h1 {
+  max-width: 760px;
   margin: 0;
-  line-height: 1.01;
-  letter-spacing: -.055em;
-}
-
-.hero-copy h1 { max-width: 790px; font-size: clamp(3.15rem, 7.4vw, 6.5rem); }
-.gradient-text {
-  color: transparent;
-  background: linear-gradient(100deg, #fff 3%, #cbd7ff 40%, #72dcff 100%);
-  background-clip: text;
-  -webkit-background-clip: text;
+  font-size: clamp(3.3rem, 6.5vw, 6.1rem);
+  line-height: .98;
+  letter-spacing: -.065em;
 }
 .hero-copy > p {
-  max-width: 670px;
-  margin: 24px 0 0;
-  color: var(--muted);
-  font-size: clamp(1.05rem, 2vw, 1.24rem);
+  max-width: 680px;
+  margin: 27px 0 0;
+  color: #4c565e;
+  font-size: clamp(1.05rem, 1.7vw, 1.23rem);
+  line-height: 1.6;
 }
-
-.hero-actions { display: flex; flex-wrap: wrap; gap: 11px; margin-top: 30px; }
+.hero-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 29px; }
 .button {
-  min-height: 48px;
+  min-height: 49px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 11px 17px;
+  gap: 9px;
+  padding: 11px 18px;
   border: 1px solid transparent;
-  border-radius: 14px;
+  border-radius: 999px;
   text-decoration: none;
+  font-size: .89rem;
   font-weight: 850;
-  transition: transform .18s ease, border-color .18s ease, background .18s ease;
+  transition: transform .18s ease, box-shadow .18s ease, background .18s ease;
 }
 .button:hover { transform: translateY(-2px); }
-.button-primary { color: #fff; background: var(--gradient); box-shadow: 0 14px 34px rgba(58, 74, 222, .30); }
-.button-secondary { color: #eef2ff; border-color: var(--line); background: rgba(255, 255, 255, .045); }
-.button-secondary:hover { border-color: var(--line-strong); background: rgba(255, 255, 255, .075); }
-.button-youtube { color: #fff; background: #e62b32; box-shadow: 0 14px 34px rgba(230, 43, 50, .22); }
-
-.trust-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 22px;
-  margin-top: 30px;
-  color: var(--quiet);
-  font-size: .88rem;
-  font-weight: 700;
-}
+.button-primary { color: #fff; background: var(--ink); box-shadow: 0 12px 28px rgba(11, 13, 16, .18); }
+.button-primary:hover { background: #25292d; }
+.button-secondary { color: var(--ink); border-color: var(--line-dark); background: rgba(255, 255, 255, .75); }
+.button-secondary:hover { background: #fff; box-shadow: var(--shadow-soft); }
+.button-youtube { color: #fff; background: #ec2d3b; box-shadow: 0 12px 28px rgba(236, 45, 59, .2); }
+.trust-row { display: flex; flex-wrap: wrap; gap: 9px 22px; margin-top: 28px; color: #626b72; font-size: .8rem; font-weight: 760; }
 .trust-row span { display: inline-flex; align-items: center; gap: 7px; }
 .trust-row span::before { content: "✓"; color: var(--green); font-weight: 950; }
 
-.hero-visual {
-  position: relative;
-  justify-self: center;
-  width: min(100%, 440px);
-  min-height: 470px;
-  display: grid;
-  place-items: center;
-}
-.hero-orbit {
-  position: absolute;
-  inset: 7%;
-  border: 1px solid rgba(119, 136, 255, .18);
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(84, 116, 255, .16), transparent 66%);
-  box-shadow: 0 0 90px rgba(79, 99, 255, .12);
-}
-.device-card {
-  position: relative;
-  width: min(82%, 350px);
-  padding: 18px;
-  border: 1px solid rgba(255, 255, 255, .17);
-  border-radius: 38px;
-  background: linear-gradient(145deg, rgba(21, 31, 55, .92), rgba(11, 16, 31, .88));
-  box-shadow: var(--shadow);
+.hero-stage { position: relative; min-height: 500px; display: grid; place-items: center; }
+.hero-image-wrap {
+  width: min(100%, 420px);
+  padding: 28px;
+  border: 1px solid rgba(11, 13, 16, .1);
+  border-radius: 44px;
+  background: rgba(255, 255, 255, .54);
+  box-shadow: 0 35px 80px rgba(49, 62, 70, .17);
   transform: rotate(2deg);
-  backdrop-filter: blur(18px);
 }
-.device-card img { width: 100%; border-radius: 26px; }
-.float-chip {
+.hero-image-wrap img { width: 100%; border-radius: 28px; }
+.hero-story-card {
   position: absolute;
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  padding: 11px 13px;
-  border: 1px solid rgba(255, 255, 255, .14);
-  border-radius: 15px;
-  color: #f2f5ff;
-  background: rgba(12, 18, 34, .88);
-  box-shadow: var(--shadow-soft);
-  font-size: .82rem;
-  font-weight: 800;
-  backdrop-filter: blur(16px);
-}
-.float-chip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--green); box-shadow: 0 0 11px var(--green); }
-.float-chip.one { left: -1%; top: 24%; }
-.float-chip.two { right: -2%; bottom: 22%; }
-.float-chip.two::before { background: var(--cyan); box-shadow: 0 0 11px var(--cyan); }
-
-.section { padding-block: clamp(64px, 9vw, 108px); }
-.section + .section { border-top: 1px solid var(--line); }
-.section-heading { display: flex; align-items: end; justify-content: space-between; gap: 26px; margin-bottom: 30px; }
-.section-heading > div { max-width: 720px; }
-.section-heading.center { display: block; max-width: 760px; margin-inline: auto; text-align: center; }
-.section-heading h2 { margin: 0; font-size: clamp(2rem, 4.5vw, 3.5rem); line-height: 1.08; letter-spacing: -.045em; }
-.section-heading p { margin: 11px 0 0; color: var(--muted); font-size: 1.02rem; }
-.text-link { color: #8fdcff; text-decoration: none; font-size: .92rem; font-weight: 850; white-space: nowrap; }
-.text-link:hover { text-decoration: underline; }
-
-.content-grid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 16px; }
-.content-card {
-  grid-column: span 4;
-  min-height: 250px;
+  left: -7%;
+  bottom: 7%;
+  width: min(290px, 78%);
   display: flex;
   flex-direction: column;
+  padding: 19px 20px;
+  border: 1px solid rgba(11, 13, 16, .1);
+  border-radius: 18px;
+  color: var(--ink);
+  background: #fff;
+  box-shadow: var(--shadow);
+  text-decoration: none;
+  transform: rotate(-2deg);
+  transition: transform .2s ease;
+}
+.hero-story-card:hover { transform: rotate(-2deg) translateY(-4px); }
+.hero-story-card span { color: var(--coral); font-size: .67rem; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
+.hero-story-card strong { margin-top: 4px; font-size: 1.3rem; line-height: 1.25; }
+.hero-story-card small { margin-top: 5px; color: var(--muted); font-size: .78rem; }
+
+.category-rail { border-block: 1px solid var(--line); background: #fff; }
+.category-rail-inner { min-height: 66px; display: flex; align-items: center; gap: 10px 26px; overflow-x: auto; scrollbar-width: none; }
+.category-rail-inner::-webkit-scrollbar { display: none; }
+.category-rail-inner span { color: var(--coral); font-size: .69rem; font-weight: 900; letter-spacing: .1em; text-transform: uppercase; }
+.category-rail-inner a { color: #293036; text-decoration: none; font-size: .83rem; font-weight: 780; white-space: nowrap; }
+.category-rail-inner a:hover { color: var(--coral); }
+
+.section { padding-block: clamp(68px, 8vw, 106px); }
+.section + .section { border-top: 1px solid var(--line); }
+.section-heading { display: flex; align-items: end; justify-content: space-between; gap: 28px; margin-bottom: 34px; }
+.section-heading > div { max-width: 780px; }
+.section-heading.center { display: block; max-width: 760px; margin-inline: auto; text-align: center; }
+.section-heading h2, .faq-intro h2 {
+  margin: 0;
+  font-size: clamp(2.3rem, 4.5vw, 4.2rem);
+  line-height: 1.02;
+  letter-spacing: -.055em;
+}
+.section-heading p, .faq-intro p { margin: 13px 0 0; color: var(--muted); font-size: 1rem; }
+.text-link { color: var(--ink); text-decoration: none; font-size: .83rem; font-weight: 900; white-space: nowrap; }
+.text-link:hover { color: var(--coral); }
+
+.blog-layout { display: grid; grid-template-columns: minmax(0, 1fr) 330px; align-items: start; gap: 28px; }
+.news-feed { display: grid; gap: 15px; }
+.content-card {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 66px minmax(0, 1fr);
+  grid-template-areas: "icon meta" "icon title" "icon copy" "icon link";
+  column-gap: 20px;
+  padding: 27px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-soft);
+  transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+.content-card:hover { transform: translateY(-3px); border-color: var(--line-dark); box-shadow: var(--shadow); }
+.news-feed > .content-card:first-of-type {
+  padding: clamp(28px, 4vw, 42px);
+  border-top: 5px solid var(--coral);
+  background: linear-gradient(135deg, #fff 30%, #fff0f3 100%);
+}
+.news-feed > .content-card:first-of-type h3 { font-size: clamp(1.7rem, 3vw, 2.55rem); line-height: 1.08; }
+.card-icon {
+  grid-area: icon;
+  width: 58px;
+  height: 58px;
+  display: grid;
+  place-items: center;
+  border: 1px solid #c6ccd0;
+  border-radius: 17px;
+  color: #fff;
+  background: var(--ink);
+  font-size: 1.02rem;
+  font-weight: 950;
+  letter-spacing: -.03em;
+}
+.card-meta, .tags { grid-area: meta; display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 11px; }
+.tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 25px;
+  padding: 4px 9px;
+  border: 1px solid #d4d9dc;
+  border-radius: 999px;
+  color: #566068;
+  background: #f7f8f8;
+  font-size: .66rem;
+  font-weight: 850;
+  letter-spacing: .025em;
+}
+.content-card h3 { grid-area: title; margin: 0; font-size: 1.28rem; line-height: 1.25; letter-spacing: -.025em; }
+.content-card p { grid-area: copy; margin: 8px 0 17px; color: var(--muted); font-size: .93rem; }
+.content-card .card-link { grid-area: link; justify-self: start; color: var(--ink); text-decoration: none; font-size: .82rem; font-weight: 900; }
+.content-card .card-link:hover { color: var(--coral); }
+
+.blog-sidebar { position: sticky; top: calc(var(--header-height) + 20px); display: grid; gap: 14px; }
+.sidebar-card {
+  display: block;
   padding: 24px;
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
-  background: linear-gradient(145deg, rgba(17, 26, 47, .88), rgba(10, 16, 30, .82));
+  color: var(--ink);
+  background: #fff;
   box-shadow: var(--shadow-soft);
-  transition: transform .2s ease, border-color .2s ease;
+  text-decoration: none;
 }
-.content-card:hover { transform: translateY(-4px); border-color: var(--line-strong); }
-.content-card.featured { grid-column: span 6; min-height: 300px; }
-.card-icon {
-  width: 48px;
-  height: 48px;
-  display: grid;
-  place-items: center;
-  border: 1px solid rgba(255, 255, 255, .16);
-  border-radius: 15px;
-  color: #fff;
-  background: var(--gradient);
-  box-shadow: 0 12px 28px rgba(72, 76, 220, .25);
-  font-size: 1.2rem;
-  font-weight: 950;
-}
-.content-card h3 { margin: 20px 0 8px; font-size: 1.22rem; line-height: 1.3; letter-spacing: -.02em; }
-.content-card p { margin: 0 0 20px; color: var(--muted); }
-.content-card .card-link { align-self: flex-start; margin-top: auto; color: #8edcff; text-decoration: none; font-weight: 850; }
-.content-card .card-link:hover { text-decoration: underline; }
-.card-meta, .tags { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 12px; }
-.tag {
-  display: inline-flex;
-  padding: 5px 9px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  color: #c3cce0;
-  background: rgba(255, 255, 255, .035);
-  font-size: .72rem;
-  font-weight: 800;
-}
+.sidebar-label { display: block; margin-bottom: 11px; color: var(--coral); font-size: .68rem; font-weight: 900; letter-spacing: .09em; text-transform: uppercase; }
+.sidebar-card > strong { display: block; font-size: 1.25rem; line-height: 1.25; letter-spacing: -.025em; }
+.sidebar-card > p { margin: 9px 0 0; color: var(--muted); font-size: .86rem; }
+.schedule-card { color: #fff; border-color: #0b0d10; background: var(--ink); }
+.schedule-card .sidebar-label { color: #ff8ca1; }
+.schedule-card > p { color: #b9c0c5; }
+.status-line { display: inline-flex; align-items: center; gap: 9px; margin-top: 17px; color: #dfe3e6; font-size: .72rem; font-weight: 800; }
+.category-list { margin: 0; padding: 0; list-style: none; }
+.category-list li + li { border-top: 1px solid var(--line); }
+.category-list a { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 11px 0; text-decoration: none; font-size: .84rem; font-weight: 780; }
+.category-list b { color: var(--coral); }
+.category-list a:hover span { text-decoration: underline; text-decoration-color: var(--coral); text-underline-offset: 3px; }
+.check-list { counter-reset: checks; display: grid; gap: 10px; margin: 0; padding: 0; list-style: none; }
+.check-list li { counter-increment: checks; display: grid; grid-template-columns: 24px 1fr; gap: 9px; color: #4f5860; font-size: .82rem; }
+.check-list li::before { content: counter(checks); width: 22px; height: 22px; display: grid; place-items: center; border-radius: 50%; color: #fff; background: var(--blue); font-size: .65rem; font-weight: 900; }
+.youtube-card { border-color: #f4a8b3; background: var(--coral-soft); }
+.youtube-card .sidebar-link { display: block; margin-top: 15px; font-size: .81rem; font-weight: 900; }
+.youtube-card:hover .sidebar-link { color: var(--red); }
 
-.principles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin: 0; padding: 0; list-style: none; }
-.principles li { padding: 22px; border: 1px solid var(--line); border-radius: var(--radius-lg); background: var(--panel-soft); }
-.principles strong { display: block; margin-bottom: 6px; color: #fff; }
-.principles span { color: var(--muted); font-size: .93rem; }
+.topic-section { color: #fff; background: var(--ink); }
+.topic-section .section-heading p, .topic-section .eyebrow { color: #aeb6bb; }
+.topic-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 13px; }
+.topic-card { min-height: 310px; display: flex; flex-direction: column; padding: 25px; border-radius: var(--radius-lg); color: var(--ink); text-decoration: none; transition: transform .2s ease; }
+.topic-card:hover { transform: translateY(-5px); }
+.topic-card.coral { background: #ff8ba0; }
+.topic-card.blue { background: #8ca4ff; }
+.topic-card.mint { background: var(--mint); }
+.topic-card.yellow { background: var(--yellow); }
+.topic-card > span { align-self: flex-start; padding: 4px 8px; border: 1px solid rgba(11, 13, 16, .28); border-radius: 999px; font-size: .66rem; font-weight: 900; }
+.topic-card h3 { margin: auto 0 8px; font-size: 1.45rem; line-height: 1.12; letter-spacing: -.035em; }
+.topic-card p { margin: 0 0 18px; color: rgba(11, 13, 16, .72); font-size: .86rem; }
+.topic-card b { font-size: .78rem; }
 
-.cta-panel {
-  position: relative;
-  overflow: hidden;
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: center;
-  gap: 24px;
-  padding: clamp(28px, 5vw, 48px);
-  border: 1px solid rgba(126, 136, 255, .28);
-  border-radius: var(--radius-xl);
-  background: linear-gradient(135deg, rgba(92, 61, 220, .24), rgba(29, 111, 212, .19));
-  box-shadow: var(--shadow-soft);
-}
-.cta-panel::after { content: ""; position: absolute; width: 300px; height: 300px; right: -110px; top: -150px; border-radius: 50%; background: rgba(34, 211, 238, .11); }
-.cta-panel h2 { position: relative; margin: 0; font-size: clamp(1.75rem, 3.8vw, 2.8rem); letter-spacing: -.035em; }
-.cta-panel p { position: relative; margin: 8px 0 0; color: #bdc7dd; }
-.cta-panel .button { position: relative; z-index: 1; }
+.editorial-note-section { background: #dfe5e8; }
+.editorial-note { display: grid; grid-template-columns: minmax(0, .9fr) minmax(0, 1.1fr); gap: clamp(34px, 8vw, 100px); align-items: start; }
+.editorial-note h2 { max-width: 560px; margin: 0; font-size: clamp(2.3rem, 4.6vw, 4.4rem); line-height: 1.02; letter-spacing: -.058em; }
+.editorial-note-copy p { margin: 0 0 16px; color: #505a61; font-size: 1.05rem; }
+.editorial-note-copy .text-link { display: inline-block; margin-top: 8px; }
 
+.faq-layout { display: grid; grid-template-columns: minmax(250px, .72fr) minmax(0, 1.28fr); align-items: start; gap: clamp(34px, 7vw, 88px); }
+.faq-intro { position: sticky; top: calc(var(--header-height) + 22px); }
 .faq-list { display: grid; gap: 10px; }
-.faq-list details { border: 1px solid var(--line); border-radius: var(--radius-md); background: rgba(255, 255, 255, .035); overflow: hidden; }
-.faq-list summary { display: flex; justify-content: space-between; gap: 18px; padding: 17px 19px; cursor: pointer; font-weight: 820; list-style: none; }
+.faq-list details { overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius-md); background: #fff; }
+.faq-list summary { display: flex; justify-content: space-between; gap: 18px; padding: 19px 20px; cursor: pointer; font-weight: 850; list-style: none; }
 .faq-list summary::-webkit-details-marker { display: none; }
-.faq-list summary::after { content: "+"; color: var(--cyan); font-size: 1.28rem; line-height: 1; }
+.faq-list summary::after { content: "+"; color: var(--coral); font-size: 1.35rem; line-height: 1; }
 .faq-list details[open] summary::after { content: "−"; }
-.faq-list details p { margin: 0; padding: 0 19px 19px; color: var(--muted); }
+.faq-list details p { margin: 0; padding: 0 20px 20px; color: var(--muted); }
 
-.page-hero { padding-block: clamp(70px, 10vw, 120px) clamp(54px, 8vw, 90px); text-align: center; }
-.page-hero h1 { font-size: clamp(3rem, 7vw, 5.6rem); }
-.page-hero p { max-width: 760px; margin: 19px auto 0; color: var(--muted); font-size: clamp(1.03rem, 2vw, 1.22rem); }
+.archive-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(300px, .95fr);
+  align-items: end;
+  gap: clamp(30px, 7vw, 100px);
+  padding-block: clamp(70px, 10vw, 130px);
+}
+.archive-hero h1, .page-hero h1, .article-hero h1 {
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(3.2rem, 7.2vw, 6.8rem);
+  line-height: .97;
+  letter-spacing: -.068em;
+}
+.archive-hero > p { margin: 0 0 8px; color: var(--muted); font-size: clamp(1.02rem, 1.8vw, 1.2rem); }
+.archive-section { background: #e7ecee; }
 
+.content-grid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 16px; }
+.content-grid .content-card {
+  grid-column: span 4;
+  min-height: 285px;
+  display: flex;
+  flex-direction: column;
+}
+.content-grid .content-card .card-meta { margin-bottom: 14px; }
+.content-grid .content-card h3 { margin: 20px 0 0; }
+.content-grid .content-card p { margin: 9px 0 20px; }
+.content-grid .content-card .card-link { align-self: flex-start; margin-top: auto; }
 .featured-guide {
   grid-column: 1 / -1;
   display: grid;
-  grid-template-columns: minmax(290px, .9fr) minmax(0, 1.1fr);
-  min-height: 390px;
+  grid-template-columns: minmax(310px, .92fr) minmax(0, 1.08fr);
+  min-height: 420px;
   overflow: hidden;
-  border: 1px solid var(--line-strong);
+  border: 1px solid var(--line-dark);
   border-radius: var(--radius-xl);
-  background: linear-gradient(145deg, rgba(19, 31, 56, .94), rgba(16, 12, 36, .90));
+  background: #fff;
   box-shadow: var(--shadow);
 }
-.featured-media { min-height: 320px; overflow: hidden; background: #060b14; }
+.featured-media { min-height: 320px; overflow: hidden; background: #10151a; }
 .featured-media img { width: 100%; height: 100%; object-fit: cover; }
-.featured-body { display: flex; flex-direction: column; justify-content: center; padding: clamp(28px, 5vw, 52px); }
-.featured-body h3 { margin: 16px 0 10px; font-size: clamp(1.8rem, 4vw, 3rem); line-height: 1.1; letter-spacing: -.035em; }
-.featured-body p { color: var(--muted); }
+.featured-body { display: flex; flex-direction: column; justify-content: center; align-items: flex-start; padding: clamp(30px, 5vw, 58px); }
+.featured-body h3 { margin: 18px 0 7px; font-size: clamp(2rem, 4vw, 3.5rem); line-height: 1.05; letter-spacing: -.05em; }
+.featured-body p { margin: 0 0 22px; color: var(--muted); }
+.featured-body .tags { grid-area: auto; }
+.archive-layout { display: grid; grid-template-columns: minmax(0, 1fr) 330px; align-items: start; gap: 28px; }
+.archive-cards .content-card { grid-column: 1 / -1; }
+.archive-aside { padding: 27px; border: 1px solid #cbd2d6; border-radius: var(--radius-lg); background: #fff; }
+.archive-aside h3 { margin: 0; font-size: 1.5rem; line-height: 1.2; letter-spacing: -.035em; }
+.archive-aside p { color: var(--muted); font-size: .89rem; }
+.plain-checks { display: grid; gap: 9px; margin: 19px 0 0; padding: 0; list-style: none; color: #4f585f; font-size: .82rem; }
+.plain-checks li { display: flex; gap: 9px; }
+.plain-checks li::before { content: "✓"; color: var(--green); font-weight: 950; }
+.guide-card-grid .content-card { grid-column: span 3; }
 
-.video-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 20px; margin-bottom: 28px; }
-.video-toolbar h2 { margin: 0; font-size: clamp(2rem, 4vw, 3.2rem); letter-spacing: -.04em; }
+.cta-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 28px;
+  padding: clamp(34px, 6vw, 68px);
+  border-radius: var(--radius-xl);
+  color: #fff;
+  background: var(--ink);
+  box-shadow: var(--shadow);
+}
+.cta-panel .eyebrow { color: #bac1c6; }
+.cta-panel h2 { margin: 0; font-size: clamp(2rem, 4vw, 3.7rem); line-height: 1.05; letter-spacing: -.05em; }
+.cta-panel p { margin: 10px 0 0; color: #aeb6bb; }
+.cta-panel .button-secondary { color: #fff; border-color: #555d63; background: #25292d; }
+
+.page-hero { padding-block: clamp(72px, 10vw, 130px) clamp(55px, 8vw, 95px); text-align: center; }
+.page-hero p { max-width: 770px; margin: 20px auto 0; color: var(--muted); font-size: clamp(1.02rem, 2vw, 1.2rem); }
+.gradient-text { color: var(--ink); background: none; }
+.video-toolbar { display: flex; justify-content: space-between; align-items: end; gap: 22px; margin-bottom: 30px; }
+.video-toolbar h2 { margin: 0; font-size: clamp(2.3rem, 4.5vw, 4.1rem); line-height: 1.04; letter-spacing: -.055em; }
 .video-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
-.video-card { overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius-lg); background: var(--panel); box-shadow: var(--shadow-soft); transition: transform .2s ease, border-color .2s ease; }
-.video-card:hover { transform: translateY(-4px); border-color: var(--line-strong); }
-.playlist-card { grid-column: 1 / -1; width: min(100%, 1000px); justify-self: center; }
-.video-frame { position: relative; aspect-ratio: 16 / 9; background: #03050a; }
+.video-card { overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius-xl); background: #fff; box-shadow: var(--shadow); }
+.playlist-card { grid-column: 1 / -1; width: min(100%, 1050px); justify-self: center; }
+.video-frame { position: relative; aspect-ratio: 16 / 9; background: #080a0c; }
 .video-frame iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
-.video-info { padding: 18px; }
-.video-info h3 { margin: 0; font-size: 1.05rem; line-height: 1.4; }
+.video-info { padding: 23px; }
+.video-info h3 { margin: 0; font-size: 1.2rem; }
 .video-info p { margin: 8px 0 0; color: var(--muted); font-size: .9rem; }
-.video-meta { display: flex; justify-content: space-between; gap: 12px; margin-top: 14px; color: var(--quiet); font-size: .78rem; }
-.video-meta a { color: #8edcff; text-decoration: none; font-weight: 800; }
-.status-panel { padding: 18px; border: 1px solid var(--line); border-radius: var(--radius-md); color: var(--muted); background: var(--panel-soft); text-align: center; }
+.video-meta { display: flex; justify-content: space-between; gap: 14px; margin-top: 16px; color: var(--quiet); font-size: .78rem; }
+.video-meta a { color: var(--red); text-decoration: none; font-weight: 850; }
+.status-panel { padding: 18px; border: 1px solid var(--line); border-radius: var(--radius-md); color: var(--muted); background: #fff; text-align: center; }
 .status-panel[hidden], .load-more[hidden] { display: none; }
 .load-row { display: flex; justify-content: center; margin-top: 28px; }
 .load-more { border: 0; cursor: pointer; font: inherit; }
-.load-more:disabled { cursor: wait; opacity: .55; }
 
-.article-main { padding-block: clamp(42px, 7vw, 82px); }
-.breadcrumbs { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 22px; color: var(--quiet); font-size: .82rem; }
-.breadcrumbs a { color: #9edfff; text-decoration: none; }
+.article-main { padding-block: clamp(42px, 7vw, 84px); }
+.breadcrumbs { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 22px; color: var(--quiet); font-size: .8rem; }
+.breadcrumbs a { color: var(--ink); text-decoration: none; font-weight: 780; }
+.breadcrumbs a:hover { color: var(--coral); }
 .article-hero {
-  position: relative;
+  padding: clamp(34px, 6vw, 70px);
   overflow: hidden;
-  padding: clamp(30px, 6vw, 64px);
-  border: 1px solid var(--line-strong);
+  border: 1px solid #c9d2d7;
   border-radius: var(--radius-xl);
-  background: linear-gradient(145deg, rgba(19, 31, 57, .96), rgba(17, 10, 39, .91));
+  background: linear-gradient(130deg, #fff 0%, #dce7ec 100%);
   box-shadow: var(--shadow);
 }
-.article-hero::after { content: ""; position: absolute; width: 430px; height: 430px; right: -190px; top: -220px; border-radius: 50%; background: rgba(37, 142, 255, .13); }
-.article-hero > * { position: relative; z-index: 1; }
-.article-hero h1 { max-width: 900px; font-size: clamp(2.5rem, 6vw, 5rem); }
-.article-summary { max-width: 850px; margin: 20px 0 0; color: #c0c9dc; font-size: clamp(1.03rem, 2vw, 1.2rem); }
+.article-hero h1 { max-width: 1000px; font-size: clamp(2.7rem, 6vw, 5.7rem); }
+.article-summary { max-width: 900px; margin: 22px 0 0; color: #4e5961; font-size: clamp(1.02rem, 1.8vw, 1.16rem); }
 .fact-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-top: 30px; }
-.fact-box { padding: 14px; border: 1px solid var(--line); border-radius: var(--radius-md); background: rgba(255, 255, 255, .045); }
-.fact-box span { display: block; color: var(--quiet); font-size: .7rem; font-weight: 850; letter-spacing: .07em; text-transform: uppercase; }
-.fact-box strong { display: block; margin-top: 3px; overflow-wrap: anywhere; }
-
-.article-layout { display: grid; grid-template-columns: minmax(0, 1fr) 280px; align-items: start; gap: 26px; margin-top: 28px; }
-.article-content, .article-sidebar { border: 1px solid var(--line); border-radius: var(--radius-lg); background: rgba(12, 19, 35, .76); box-shadow: var(--shadow-soft); }
-.article-content { padding: clamp(25px, 5vw, 48px); }
-.article-content h2 { margin: 2.4rem 0 .8rem; font-size: clamp(1.55rem, 3vw, 2.15rem); letter-spacing: -.03em; }
+.fact-box { padding: 15px; border: 1px solid #ccd3d7; border-radius: var(--radius-md); background: rgba(255, 255, 255, .66); }
+.fact-box span { display: block; color: var(--quiet); font-size: .65rem; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
+.fact-box strong { display: block; margin-top: 4px; overflow-wrap: anywhere; }
+.article-layout { display: grid; grid-template-columns: minmax(0, 1fr) 290px; align-items: start; gap: 26px; margin-top: 28px; }
+.article-content, .article-sidebar { border: 1px solid var(--line); border-radius: var(--radius-lg); background: #fff; box-shadow: var(--shadow-soft); }
+.article-content { padding: clamp(27px, 5vw, 52px); }
+.article-content h2 { margin: 2.45rem 0 .8rem; font-size: clamp(1.6rem, 3vw, 2.3rem); line-height: 1.12; letter-spacing: -.04em; }
 .article-content h2:first-child { margin-top: 0; }
-.article-content p, .article-content li { color: #bdc6d9; }
-.article-content ul, .article-content ol { padding-left: 1.3rem; }
-.article-content li + li { margin-top: .55rem; }
-.article-content code { padding: 2px 6px; border: 1px solid var(--line); border-radius: 7px; background: rgba(255, 255, 255, .055); color: #dce6ff; overflow-wrap: anywhere; }
-.article-sidebar { position: sticky; top: calc(var(--header-height) + 20px); padding: 20px; }
-.article-sidebar h2 { margin: 0 0 8px; font-size: 1rem; }
-.article-sidebar p { margin: 0; color: var(--muted); font-size: .88rem; }
-.article-sidebar .button { width: 100%; margin-top: 16px; }
-.source-note { margin-top: 13px !important; color: var(--quiet) !important; font-size: .77rem !important; }
-.article-disclaimer { margin-top: 22px; padding: 16px; border: 1px solid rgba(247, 199, 94, .22); border-radius: var(--radius-md); color: #d9ccaa; background: rgba(247, 199, 94, .07); font-size: .88rem; }
-.article-footnote { margin-top: 24px; color: var(--quiet); font-size: .78rem; }
+.article-content p, .article-content li { color: #4f5961; }
+.article-content ul, .article-content ol { padding-left: 1.35rem; }
+.article-content li + li { margin-top: .58rem; }
+.article-content code { padding: 2px 6px; border: 1px solid var(--line); border-radius: 7px; background: #f2f4f5; color: #263039; overflow-wrap: anywhere; }
+.article-sidebar { position: sticky; top: calc(var(--header-height) + 20px); padding: 22px; color: #fff; border-color: var(--ink); background: var(--ink); }
+.article-sidebar h2 { margin: 0 0 8px; font-size: 1.1rem; }
+.article-sidebar p { margin: 0; color: #b7bec3; font-size: .86rem; }
+.article-sidebar .button { width: 100%; margin-top: 17px; color: var(--ink); background: #fff; }
+.source-note { margin-top: 13px !important; color: #8f989f !important; font-size: .75rem !important; }
+.article-disclaimer { margin-top: 24px; padding: 17px; border: 1px solid #e8c75e; border-radius: var(--radius-md); color: #67551d; background: #fff8dc; font-size: .88rem; }
+.article-footnote { margin-top: 25px; color: var(--quiet) !important; font-size: .77rem; }
 
-.site-footer { margin-top: 50px; border-top: 1px solid var(--line); background: rgba(3, 5, 10, .66); }
-.footer-shell { width: min(var(--container), calc(100% - 32px)); margin: 0 auto; padding: 42px 0 calc(42px + env(safe-area-inset-bottom)); display: grid; grid-template-columns: 1fr auto; gap: 28px; align-items: end; }
-.footer-shell strong { font-size: 1.05rem; }
-.footer-shell p { max-width: 620px; margin: 7px 0 0; color: var(--quiet); font-size: .88rem; }
+.site-footer { color: #fff; background: var(--ink); }
+.footer-shell {
+  width: min(var(--container), calc(100% - 40px));
+  margin-inline: auto;
+  padding: 66px 0 54px;
+  display: grid;
+  grid-template-columns: minmax(280px, 1.8fr) repeat(3, minmax(110px, .55fr));
+  gap: 36px;
+}
+.site-footer .brand { color: #fff; }
+.site-footer .brand-mark { border-color: #fff; }
+.footer-brand p { max-width: 480px; margin: 17px 0 0; color: #9fa8ae; font-size: .87rem; }
+.footer-column { display: flex; flex-direction: column; align-items: flex-start; gap: 9px; }
+.footer-column > strong { margin-bottom: 6px; color: #fff; font-size: .72rem; letter-spacing: .09em; text-transform: uppercase; }
+.footer-column a { color: #aeb6bb; text-decoration: none; font-size: .82rem; }
+.footer-column a:hover { color: #fff; }
+.footer-bottom { border-top: 1px solid #303438; color: #7f898f; font-size: .7rem; letter-spacing: .035em; text-transform: uppercase; }
+.footer-bottom .container { min-height: 58px; display: flex; align-items: center; justify-content: space-between; gap: 20px; }
 .footer-links { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 10px 18px; }
-.footer-links a { color: var(--muted); text-decoration: none; font-size: .85rem; font-weight: 750; }
-.footer-links a:hover { color: #fff; }
+.footer-links a { color: #aeb6bb; text-decoration: none; font-size: .82rem; }
 
-@media (max-width: 960px) {
-  .home-hero { grid-template-columns: 1fr; text-align: center; }
-  .hero-copy { display: flex; flex-direction: column; align-items: center; }
+@media (max-width: 1020px) {
+  .editorial-hero { grid-template-columns: minmax(0, 1fr) 360px; padding-inline: 44px; }
+  .hero-copy h1 { font-size: clamp(3.2rem, 7vw, 5.2rem); }
+  .blog-layout, .archive-layout { grid-template-columns: minmax(0, 1fr) 290px; }
+  .topic-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .topic-card { min-height: 265px; }
+  .guide-card-grid .content-card { grid-column: span 6; }
+  .footer-shell { grid-template-columns: minmax(280px, 1.5fr) repeat(3, minmax(100px, .5fr)); }
+}
+
+@media (max-width: 820px) {
+  :root { --header-height: 120px; }
+  .topline-inner > span:first-child { display: none; }
+  .topline-inner { justify-content: center; }
+  .nav-shell { min-height: var(--header-height); flex-direction: column; align-items: stretch; justify-content: center; gap: 5px; padding-block: 10px; }
+  .brand { align-self: flex-start; }
+  .brand-mark { width: 45px; height: 45px; font-size: 1rem; }
+  .nav-links { width: 100%; gap: 25px; }
+  .nav-links a { padding-block: 9px; }
+  .nav-links a::after { bottom: 4px; }
+  .editorial-hero { grid-template-columns: 1fr; min-height: 0; padding: 50px 34px; }
+  .hero-copy { text-align: center; }
   .hero-copy > p { margin-inline: auto; }
   .hero-actions, .trust-row { justify-content: center; }
-  .hero-visual { min-height: 390px; }
-  .content-card { grid-column: span 6; }
-  .principles { grid-template-columns: 1fr; }
-  .video-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .hero-stage { min-height: 390px; }
+  .hero-image-wrap { width: min(78%, 360px); }
+  .hero-story-card { left: 3%; }
+  .blog-layout, .archive-layout, .faq-layout, .editorial-note { grid-template-columns: 1fr; }
+  .blog-sidebar { position: static; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .faq-intro { position: static; }
+  .archive-hero { grid-template-columns: 1fr; padding-block: 75px; }
+  .archive-hero > p { max-width: 680px; }
+  .featured-guide { grid-template-columns: 1fr; }
+  .featured-media { min-height: 280px; max-height: 430px; }
+  .content-grid .content-card { grid-column: span 6; }
+  .archive-cards .content-card { grid-column: 1 / -1; }
+  .cta-panel { grid-template-columns: 1fr; text-align: center; }
+  .cta-panel .eyebrow { justify-content: center; }
+  .cta-panel .button { justify-self: center; }
   .article-layout { grid-template-columns: 1fr; }
   .article-sidebar { position: static; }
+  .footer-shell { grid-template-columns: 1.5fr 1fr 1fr; }
+  .footer-brand { grid-column: 1 / -1; }
 }
 
-@media (max-width: 720px) {
-  :root { --header-height: 118px; }
-  .nav-shell { min-height: var(--header-height); flex-direction: column; align-items: stretch; justify-content: center; gap: 7px; padding-block: 10px; }
-  .brand { padding-inline: 4px; }
-  .nav-links { width: 100%; }
-  .home-hero { min-height: 0; padding-top: 56px; }
-  .hero-copy h1 { font-size: clamp(2.75rem, 14vw, 4.6rem); }
-  .float-chip.one { left: 0; }
-  .float-chip.two { right: 0; }
-  .section-heading, .video-toolbar { align-items: flex-start; flex-direction: column; }
-  .content-card, .content-card.featured { grid-column: 1 / -1; }
-  .featured-guide { grid-template-columns: 1fr; }
-  .featured-media { min-height: 230px; }
-  .cta-panel { grid-template-columns: 1fr; text-align: center; }
-  .cta-panel .button { justify-self: center; }
-  .fact-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .footer-shell { grid-template-columns: 1fr; }
-  .footer-links { justify-content: flex-start; }
-}
-
-@media (max-width: 520px) {
-  .container, .nav-shell, .footer-shell { width: min(100% - 22px, var(--container)); }
+@media (max-width: 600px) {
+  .container, .topline-inner, .nav-shell, .footer-shell { width: min(100% - 24px, var(--container)); }
+  .topline { font-size: .63rem; }
+  .topline-status { text-align: center; }
+  .brand-copy strong { font-size: 1rem; }
+  .brand-copy small { font-size: .83rem; }
+  .nav-links { gap: 19px; }
+  .nav-links a { font-size: .73rem; }
+  .editorial-hero { width: 100%; margin-top: 0; padding: 45px 18px 36px; border-inline: 0; border-radius: 0; }
+  .hero-copy h1 { font-size: clamp(2.75rem, 15vw, 4.25rem); }
   .hero-actions .button { width: 100%; }
-  .hero-visual { min-height: 340px; }
-  .device-card { width: 76%; padding: 12px; border-radius: 30px; }
-  .float-chip { padding: 9px 10px; font-size: .7rem; }
-  .video-grid { grid-template-columns: 1fr; }
+  .trust-row { flex-direction: column; align-items: center; }
+  .hero-stage { min-height: 330px; }
+  .hero-image-wrap { width: 72%; padding: 16px; border-radius: 32px; }
+  .hero-image-wrap img { border-radius: 22px; }
+  .hero-story-card { left: 2%; bottom: 1%; padding: 15px; }
+  .category-rail-inner { gap: 18px; }
+  .section { padding-block: 65px; }
+  .section-heading, .video-toolbar { align-items: flex-start; flex-direction: column; }
+  .blog-sidebar { grid-template-columns: 1fr; }
+  .content-card { grid-template-columns: 46px minmax(0, 1fr); column-gap: 14px; padding: 20px; }
+  .card-icon { width: 44px; height: 44px; border-radius: 13px; font-size: .82rem; }
+  .news-feed > .content-card:first-of-type { padding: 21px; }
+  .news-feed > .content-card:first-of-type h3 { font-size: 1.55rem; }
+  .topic-grid { grid-template-columns: 1fr; }
+  .topic-card { min-height: 250px; }
+  .content-grid .content-card, .guide-card-grid .content-card { grid-column: 1 / -1; }
+  .featured-media { min-height: 215px; }
+  .featured-body { padding: 26px 22px 30px; }
+  .archive-hero h1, .page-hero h1, .article-hero h1 { font-size: clamp(2.65rem, 14vw, 4.25rem); }
+  .fact-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .video-meta { flex-direction: column; }
+  .article-hero { padding: 27px 21px; border-radius: 24px; }
+  .article-content { padding-inline: 21px; }
+  .footer-shell { grid-template-columns: repeat(2, 1fr); }
+  .footer-brand { grid-column: 1 / -1; }
+  .footer-bottom .container { align-items: flex-start; flex-direction: column; justify-content: center; padding-block: 16px; }
+}
+
+@media (max-width: 390px) {
+  .nav-links { gap: 14px; }
+  .nav-links a { font-size: .68rem; }
   .fact-grid { grid-template-columns: 1fr; }
-  .article-hero { border-radius: 24px; }
-  .article-content { padding-inline: 20px; }
 }
 
 @media (hover: none) {
-  .button:hover, .content-card:hover, .video-card:hover { transform: none; }
+  .button:hover, .content-card:hover, .topic-card:hover, .hero-story-card:hover { transform: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/automation/draft_pipeline.py
+++ b/automation/draft_pipeline.py
@@ -249,17 +249,18 @@ def render_article(article: dict[str, Any], candidate: dict[str, Any], site: dic
         for item in article["faq"]
     )
     architectures = ", ".join(candidate["architectures"])
-    return f"""<!doctype html>
+    return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#05070d">
+  <meta name="theme-color" content="#f3f5f6">
   <title>{esc(article['title'])} | {esc(site['site_name'])}</title>
   <meta name="description" content="{esc(article['meta_description'])}">
+  <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="{esc(canonical)}">
   <link rel="alternate" type="application/rss+xml" title="{esc(site['site_name'])} articles" href="/feed.xml">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" href="/NextSolutionRepoIcon.png">
   <link rel="stylesheet" href="/assets/site.css">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="{esc(site['site_name'])}">
@@ -273,10 +274,13 @@ def render_article(article: dict[str, Any], candidate: dict[str, Any], site: dic
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={esc(site['adsense_client'])}" crossorigin="anonymous"></script>
 </head>
 <body>
+  <div class="topline">
+    <div class="topline-inner"><span>Independent iPhone jailbreak publication</span><span class="topline-status"><i aria-hidden="true"></i> New verified article daily at 06:00 Qatar time</span></div>
+  </div>
   <header class="site-header">
     <div class="nav-shell">
-      <a class="brand" href="/" aria-label="{esc(site['site_name'])} home"><span class="brand-mark" aria-hidden="true">N</span><span>{esc(site['site_name'])}</span></a>
-      <nav aria-label="Primary navigation"><ul class="nav-links"><li><a href="/">Home</a></li><li><a href="/tutorials.html" aria-current="page">Guides</a></li><li><a href="/videos.html">Videos</a></li><li><a href="/#faq">FAQ</a></li></ul></nav>
+      <a class="brand" href="/" aria-label="{esc(site['site_name'])} home"><span class="brand-mark" aria-hidden="true">N</span><span class="brand-copy"><strong>Next</strong><small>solution</small></span></a>
+      <nav aria-label="Primary navigation"><ul class="nav-links"><li><a href="/">Blog</a></li><li><a href="/tutorials.html#verified-articles" aria-current="page">Cydia Tweaks</a></li><li><a href="/tutorials.html#jailbreak-guides">Jailbreak</a></li><li><a href="/videos.html">Videos</a></li></ul></nav>
     </div>
   </header>
   <main class="container article-main">
@@ -312,7 +316,15 @@ def render_article(article: dict[str, Any], candidate: dict[str, Any], site: dic
       </div>
     </article>
   </main>
-  <footer class="site-footer"><div class="footer-shell"><div><strong>{esc(site['site_name'])}</strong><p>Independent jailbreak tutorials, verified tweak information, and original iPhone customization videos by {esc(site['author_name'])}.</p></div><div class="footer-links"><a href="/">Home</a><a href="/tutorials.html">Guides</a><a href="/videos.html">Videos</a><a href="/feed.xml">RSS</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div></div></footer>
+  <footer class="site-footer">
+    <div class="footer-shell">
+      <div class="footer-brand"><a class="brand" href="/" aria-label="{esc(site['site_name'])} home"><span class="brand-mark" aria-hidden="true">N</span><span class="brand-copy"><strong>Next</strong><small>solution</small></span></a><p>Independent jailbreak news, verified tweak information, practical guides, and original videos by {esc(site['author_name'])}.</p></div>
+      <div class="footer-column"><strong>Read</strong><a href="/#latest">Latest articles</a><a href="/tutorials.html#verified-articles">Cydia tweaks</a><a href="/tutorials.html#jailbreak-guides">Jailbreak guides</a><a href="/videos.html">Videos</a></div>
+      <div class="footer-column"><strong>Follow</strong><a href="/feed.xml">RSS feed</a><a href="https://youtube.com/@zeshan0727" rel="noopener noreferrer">YouTube</a></div>
+      <div class="footer-column"><strong>Legal</strong><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div>
+    </div>
+    <div class="footer-bottom"><div class="container"><span>© 2026 {esc(site['site_name'])}</span><span>Articles publish daily at 06:00 Qatar time</span></div></div>
+  </footer>
 </body>
 </html>
 """

--- a/index.html
+++ b/index.html
@@ -1,16 +1,16 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#05070d">
-  <title>Next Solution | iPhone Jailbreak Guides & Tweak Reviews</title>
-  <meta name="description" content="Clear iPhone jailbreak tutorials, verified tweak information, rootless package guides, and original Next Solution videos.">
+  <meta name="theme-color" content="#f3f5f6">
+  <title>Next Solution | Jailbreak News, iPhone Tweaks &amp; Guides</title>
+  <meta name="description" content="Latest jailbreak tweak releases, practical iPhone tutorials, rootless package guides, and verified source information from Next Solution.">
+  <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://nextsolution.cc/">
   <link rel="alternate" type="application/rss+xml" title="Next Solution articles" href="feed.xml">
-  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
+  <link rel="apple-touch-icon" href="NextSolutionRepoIcon.png">
+  <link rel="icon" type="image/png" href="NextSolutionRepoIcon.png">
   <link rel="preload" href="assets/site.css" as="style">
   <link rel="preload" href="nextsolution-iphone-customization-showcase.png" as="image">
   <link rel="stylesheet" href="assets/site.css">
@@ -18,164 +18,228 @@
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Next Solution">
   <meta property="og:url" content="https://nextsolution.cc/">
-  <meta property="og:title" content="Next Solution | iPhone Jailbreak Guides & Tweak Reviews">
-  <meta property="og:description" content="Useful jailbreak tutorials and fact-checked tweak information with direct source links.">
+  <meta property="og:title" content="Next Solution | Jailbreak News, iPhone Tweaks & Guides">
+  <meta property="og:description" content="New tweak releases, practical jailbreak guides, and verified source information—published every morning.">
   <meta property="og:image" content="https://nextsolution.cc/nextsolution-iphone-customization-showcase.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@nextsoluti0n">
-  <meta name="twitter:title" content="Next Solution | iPhone Jailbreak Guides">
-  <meta name="twitter:description" content="Useful jailbreak tutorials and fact-checked tweak information.">
+  <meta name="twitter:title" content="Next Solution | Jailbreak News & Tweak Guides">
+  <meta name="twitter:description" content="New tweak releases, practical jailbreak guides, and verified source information.">
   <meta name="twitter:image" content="https://nextsolution.cc/nextsolution-iphone-customization-showcase.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    "name": "Next Solution",
+    "url": "https://nextsolution.cc/",
+    "description": "Jailbreak news, tweak release information, rootless package guides, and practical iPhone tutorials.",
+    "inLanguage": "en",
+    "publisher": {"@type": "Organization", "name": "Next Solution", "url": "https://nextsolution.cc/"},
+    "blogPost": [
+      {"@type": "BlogPosting", "headline": "Phonehub 1.1.3: Caller ID, Auto Redial, and Phone App Features", "url": "https://nextsolution.cc/phonehub-tweak.html", "datePublished": "2026-08-12"},
+      {"@type": "BlogPosting", "headline": "Next Home Lock 1.0.5 — Double-Tap to Lock", "url": "https://nextsolution.cc/next-home-lock-tweak-ios16.html", "datePublished": "2026-07-30"},
+      {"@type": "BlogPosting", "headline": "PhoneAura 0.4.16 — Stable Phone App Redesign", "url": "https://nextsolution.cc/phoneaura-tweak-ios16.html", "datePublished": "2026-07-30"}
+    ]
+  }
+  </script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4770123899731214" crossorigin="anonymous"></script>
 </head>
 <body>
+  <div class="topline">
+    <div class="topline-inner">
+      <span>Independent iPhone jailbreak publication</span>
+      <span class="topline-status"><i aria-hidden="true"></i> New verified article daily at 06:00 Qatar time</span>
+    </div>
+  </div>
+
   <header class="site-header">
     <div class="nav-shell">
-      <a class="brand" href="./" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span>Next Solution</span></a>
+      <a class="brand" href="./" aria-label="Next Solution home">
+        <span class="brand-mark" aria-hidden="true">N</span>
+        <span class="brand-copy"><strong>Next</strong><small>solution</small></span>
+      </a>
       <nav aria-label="Primary navigation">
         <ul class="nav-links">
-          <li><a href="./" aria-current="page">Home</a></li>
-          <li><a href="tutorials.html">Guides</a></li>
+          <li><a href="./" aria-current="page">Blog</a></li>
+          <li><a href="tutorials.html#verified-articles">Cydia Tweaks</a></li>
+          <li><a href="tutorials.html#jailbreak-guides">Jailbreak</a></li>
           <li><a href="videos.html">Videos</a></li>
-          <li><a href="#faq">FAQ</a></li>
         </ul>
       </nav>
     </div>
   </header>
 
   <main>
-    <section class="container home-hero" aria-labelledby="home-title">
+    <section class="container editorial-hero" aria-labelledby="home-title">
       <div class="hero-copy">
-        <span class="kicker">Independent iPhone customization guides</span>
-        <h1 id="home-title" class="gradient-text">Make your iPhone feel like yours.</h1>
-        <p>Practical jailbreak tutorials, clear package information, and original video walkthroughs—written to help you understand what is confirmed before you install.</p>
+        <span class="eyebrow">Jailbreak blog · Verified sources</span>
+        <h1 id="home-title">Jailbreak news, tweak releases &amp; guides.</h1>
+        <p>Discover useful iPhone tweaks, understand rootless compatibility, and follow practical tutorials with direct links to the original source.</p>
         <div class="hero-actions">
-          <a class="button button-primary" href="tutorials.html">Explore the guides <span aria-hidden="true">→</span></a>
-          <a class="button button-secondary" href="videos.html">Watch on Next Solution</a>
+          <a class="button button-primary" href="#latest">Read the latest <span aria-hidden="true">↓</span></a>
+          <a class="button button-secondary" href="tutorials.html">Browse all guides</a>
         </div>
-        <div class="trust-row" aria-label="Editorial commitments">
-          <span>Direct source links</span>
-          <span>Compatibility cautions</span>
-          <span>No mirrored packages</span>
+        <div class="trust-row" role="group" aria-label="Editorial commitments">
+          <span>Source checked</span>
+          <span>Compatibility explained</span>
+          <span>No mirrored third-party packages</span>
         </div>
       </div>
-      <div class="hero-visual" aria-label="Next Solution iPhone customization showcase">
-        <div class="hero-orbit" aria-hidden="true"></div>
-        <div class="device-card"><img src="nextsolution-iphone-customization-showcase.png" alt="Customized iPhone interface with jailbreak themes and tweaks" width="320" height="320" fetchpriority="high"></div>
-        <div class="float-chip one">Verified metadata</div>
-        <div class="float-chip two">Rootless guides</div>
+      <div class="hero-stage" role="group" aria-label="Customized iPhone featured by Next Solution">
+        <div class="hero-image-wrap">
+          <img src="nextsolution-iphone-customization-showcase.png" alt="Customized iPhone interface with jailbreak themes and tweaks" width="640" height="640" fetchpriority="high">
+        </div>
+        <a class="hero-story-card" href="phonehub-tweak.html">
+          <span>Latest release guide</span>
+          <strong>Phonehub 1.1.3</strong>
+          <small>Caller ID, Auto Redial &amp; more →</small>
+        </a>
       </div>
     </section>
 
-    <section class="section">
-      <div class="container">
-        <div class="section-heading">
-          <div><span class="kicker">Start here</span><h2>Choose what you want to do</h2><p>Use a focused written guide, then switch to video when seeing the process is more useful.</p></div>
-        </div>
-        <div class="content-grid">
-          <article class="content-card">
-            <div class="card-icon" aria-hidden="true">JB</div>
-            <h3>Jailbreak tutorials</h3>
-            <p>Step-by-step preparation, installation, and troubleshooting for supported devices and versions.</p>
-            <a class="card-link" href="how-to-jailbreak.html">Open jailbreak guide →</a>
-          </article>
-          <article class="content-card">
-            <div class="card-icon" aria-hidden="true">TW</div>
-            <h3>Tweak information</h3>
-            <p>Understand features, architecture, dependencies, and what still needs confirmation before installing.</p>
-            <a class="card-link" href="tutorials.html">Browse tweak guides →</a>
-          </article>
-          <article class="content-card">
-            <div class="card-icon" aria-hidden="true">RL</div>
-            <h3>Rootless packages</h3>
-            <p>Learn the difference between package environments and work through rootful-to-rootless conversion.</p>
-            <a class="card-link" href="convert-rootful-to-rootless.html">Read conversion guide →</a>
-          </article>
-        </div>
+    <nav class="category-rail" aria-label="Browse article topics">
+      <div class="container category-rail-inner">
+        <span>Explore</span>
+        <a href="tutorials.html#verified-articles">Latest tweaks</a>
+        <a href="tutorials.html#original-releases">Next Solution releases</a>
+        <a href="tutorials.html#jailbreak-guides">Jailbreak guides</a>
+        <a href="ios16-rootless-tweaks.html">Rootless tweaks</a>
+        <a href="convert-rootful-to-rootless.html">Package conversion</a>
       </div>
-    </section>
+    </nav>
 
     <section class="section" id="latest">
       <div class="container">
-        <div class="section-heading">
-          <div><span class="kicker">Recently published</span><h2>Latest guides</h2><p>New verified-source articles appear here automatically after factual and quality checks pass.</p></div>
-          <a class="text-link" href="tutorials.html">View all guides →</a>
+        <div class="section-heading editorial-heading">
+          <div>
+            <span class="eyebrow">Fresh from the blog</span>
+            <h2>Latest articles</h2>
+            <p>Release details and guides organized so you can quickly see what a tweak does, where it comes from, and what to verify.</p>
+          </div>
+          <a class="text-link" href="feed.xml">Follow via RSS <span aria-hidden="true">↗</span></a>
         </div>
-        <div class="content-grid">
-          <!-- AUTO_ARTICLES_HOME_START -->
-          <article class="content-card">
-            <div class="card-meta"><span class="tag">Messages &amp; Phone</span><span class="tag">Havoc</span></div>
-            <div class="card-icon" aria-hidden="true">PH</div>
-            <h3>Phonehub 1.1.3: Caller ID, Auto Redial, and Phone App Features</h3>
-            <p>Phonehub 1.1.3 is a package for the iOS Phone app with listed Caller ID engines, Auto Redial, Smart Loudspeaker, dual-SIM selection, and interface refinements.</p>
-            <a class="card-link" href="phonehub-tweak.html">Read verified guide →</a>
-          </article>
-          <!-- AUTO_ARTICLES_HOME_END -->
 
-          <!-- NEXT_HOME_LOCK_RECENT_CARD_START -->
-          <article class="content-card featured">
-            <div class="card-meta"><span class="tag">Next Solution release</span><span class="tag">iOS 16+</span></div>
-            <div class="card-icon" aria-hidden="true">NL</div>
-            <h3>Next Home Lock 1.0.5 — Double-Tap to Lock</h3>
-            <p>Double-tap empty Home Screen space to lock your iPhone, with one clean enable switch for the verified runtime.</p>
-            <a class="card-link" href="next-home-lock-tweak-ios16.html">Read guide and download →</a>
-          </article>
-          <!-- NEXT_HOME_LOCK_RECENT_CARD_END -->
+        <div class="blog-layout">
+          <div class="news-feed">
+            <!-- AUTO_ARTICLES_HOME_START -->
+            <article class="content-card">
+              <div class="card-meta"><span class="tag">Messages &amp; Phone</span><span class="tag">Havoc</span></div>
+              <div class="card-icon" aria-hidden="true">PH</div>
+              <h3>Phonehub 1.1.3: Caller ID, Auto Redial, and Phone App Features</h3>
+              <p>Phonehub 1.1.3 is a package for the iOS Phone app with listed Caller ID engines, Auto Redial, Smart Loudspeaker, dual-SIM selection, and interface refinements.</p>
+              <a class="card-link" href="phonehub-tweak.html">Read verified guide →</a>
+            </article>
+            <!-- AUTO_ARTICLES_HOME_END -->
 
-          <!-- PHONEAURA_RECENT_CARD_START -->
-          <article class="content-card featured">
-            <div class="card-meta"><span class="tag">Next Solution release</span><span class="tag">Phone app</span></div>
-            <div class="card-icon" aria-hidden="true">PA</div>
-            <h3>PhoneAura 0.4.16 — Stable Phone App Redesign</h3>
-            <p>Redesigned Favorites, Recents, Contacts, and Keypad with the 0.4.16 stability rollback for RootHide and rootless setups.</p>
-            <a class="card-link" href="phoneaura-tweak-ios16.html">Read guide and download →</a>
-          </article>
-          <!-- PHONEAURA_RECENT_CARD_END -->
+            <!-- NEXT_HOME_LOCK_RECENT_CARD_START -->
+            <article class="content-card featured">
+              <div class="card-meta"><span class="tag">Next Solution release</span><span class="tag">iOS 16+</span></div>
+              <div class="card-icon" aria-hidden="true">NL</div>
+              <h3>Next Home Lock 1.0.5 — Double-Tap to Lock</h3>
+              <p>Double-tap empty Home Screen space to lock your iPhone, with one clean enable switch for the verified runtime.</p>
+              <a class="card-link" href="next-home-lock-tweak-ios16.html">Read guide and download →</a>
+            </article>
+            <!-- NEXT_HOME_LOCK_RECENT_CARD_END -->
 
-          <article class="content-card">
-            <div class="card-meta"><span class="tag">Tutorial</span></div>
-            <div class="card-icon" aria-hidden="true">16</div>
-            <h3>Complete iOS 16 Jailbreak Guide</h3>
-            <p>Review requirements, follow the palera1n process, and work through common problems carefully.</p>
-            <a class="card-link" href="how-to-jailbreak.html">Read the tutorial →</a>
-          </article>
-          <article class="content-card">
-            <div class="card-meta"><span class="tag">Collection</span></div>
-            <div class="card-icon" aria-hidden="true">25</div>
-            <h3>25+ Free iOS 16 Rootless Tweaks</h3>
-            <p>A categorized collection of rootless tweaks with repository and installation information.</p>
-            <a class="card-link" href="ios16-rootless-tweaks.html">Browse the collection →</a>
-          </article>
+            <!-- PHONEAURA_RECENT_CARD_START -->
+            <article class="content-card featured">
+              <div class="card-meta"><span class="tag">Next Solution release</span><span class="tag">Phone app</span></div>
+              <div class="card-icon" aria-hidden="true">PA</div>
+              <h3>PhoneAura 0.4.16 — Stable Phone App Redesign</h3>
+              <p>Redesigned Favorites, Recents, Contacts, and Keypad with the 0.4.16 stability rollback for RootHide and rootless setups.</p>
+              <a class="card-link" href="phoneaura-tweak-ios16.html">Read guide and download →</a>
+            </article>
+            <!-- PHONEAURA_RECENT_CARD_END -->
+
+            <article class="content-card">
+              <div class="card-meta"><span class="tag">Jailbreak tutorial</span><span class="tag">iOS 16</span></div>
+              <div class="card-icon" aria-hidden="true">16</div>
+              <h3>Complete iOS 16 Jailbreak Guide</h3>
+              <p>Review supported hardware, preparation, the palera1n process, and common troubleshooting steps before you begin.</p>
+              <a class="card-link" href="how-to-jailbreak.html">Read the tutorial →</a>
+            </article>
+
+            <article class="content-card">
+              <div class="card-meta"><span class="tag">Tweak collection</span><span class="tag">Rootless</span></div>
+              <div class="card-icon" aria-hidden="true">25</div>
+              <h3>25+ Free iOS 16 Rootless Tweaks</h3>
+              <p>Browse useful packages by category, with repository and installation details gathered in one place.</p>
+              <a class="card-link" href="ios16-rootless-tweaks.html">Browse the collection →</a>
+            </article>
+          </div>
+
+          <aside class="blog-sidebar" aria-label="Blog navigation and useful links">
+            <section class="sidebar-card schedule-card">
+              <span class="sidebar-label">Publishing schedule</span>
+              <strong>One useful article every morning.</strong>
+              <p>The automated editor checks eligible repositories, verifies the source facts, and publishes at 06:00 Qatar time.</p>
+              <span class="status-line"><i aria-hidden="true"></i> Daily automation active</span>
+            </section>
+
+            <section class="sidebar-card">
+              <span class="sidebar-label">Browse categories</span>
+              <ul class="category-list">
+                <li><a href="tutorials.html#verified-articles"><span>Cydia tweak releases</span><b>→</b></a></li>
+                <li><a href="tutorials.html#original-releases"><span>Original tweaks</span><b>→</b></a></li>
+                <li><a href="tutorials.html#jailbreak-guides"><span>Jailbreak tutorials</span><b>→</b></a></li>
+                <li><a href="ios16-rootless-tweaks.html"><span>Rootless packages</span><b>→</b></a></li>
+              </ul>
+            </section>
+
+            <section class="sidebar-card start-card">
+              <span class="sidebar-label">Before installing</span>
+              <ol class="check-list">
+                <li>Confirm your exact iOS version.</li>
+                <li>Check rootless or RootHide support.</li>
+                <li>Read dependencies and source notes.</li>
+                <li>Back up important device data.</li>
+              </ol>
+            </section>
+
+            <a class="sidebar-card youtube-card" href="videos.html">
+              <span class="sidebar-label">Next Solution on YouTube</span>
+              <strong>Prefer to watch the process?</strong>
+              <p>Open the official upload playlist and follow along.</p>
+              <span class="sidebar-link">Watch videos →</span>
+            </a>
+          </aside>
         </div>
       </div>
     </section>
 
-    <section class="section">
+    <section class="section topic-section">
       <div class="container">
-        <div class="section-heading center"><span class="kicker">Editorial standard</span><h2>Useful information without false certainty</h2><p>Package metadata is often incomplete. Next Solution separates documented facts from details that still require confirmation.</p></div>
-        <ul class="principles">
-          <li><strong>Facts before claims</strong><span>Versions, architecture, dependencies, and features are tied to available source metadata.</span></li>
-          <li><strong>Compatibility stays honest</strong><span>An architecture label or dependency is not treated as a complete device and iOS support matrix.</span></li>
-          <li><strong>The direct source remains available</strong><span>Articles point readers to the source page and do not mirror third-party package files.</span></li>
-        </ul>
+        <div class="section-heading editorial-heading">
+          <div><span class="eyebrow">Find the right answer</span><h2>Browse by topic</h2><p>Go straight to the type of jailbreak information you need.</p></div>
+        </div>
+        <div class="topic-grid">
+          <a class="topic-card coral" href="tutorials.html#verified-articles"><span>01</span><h3>Latest tweak releases</h3><p>Features, package metadata, source links, and honest compatibility notes.</p><b>Explore tweaks →</b></a>
+          <a class="topic-card blue" href="tutorials.html#jailbreak-guides"><span>02</span><h3>Jailbreak guides</h3><p>Preparation, supported devices, installation steps, and troubleshooting.</p><b>Open tutorials →</b></a>
+          <a class="topic-card mint" href="ios16-rootless-tweaks.html"><span>03</span><h3>Rootless setup</h3><p>Collections and package information for modern rootless environments.</p><b>Browse rootless →</b></a>
+          <a class="topic-card yellow" href="videos.html"><span>04</span><h3>Video walkthroughs</h3><p>Original Next Solution videos when seeing each step is more useful.</p><b>Watch videos →</b></a>
+        </div>
       </div>
     </section>
 
-    <section class="section">
-      <div class="container cta-panel">
-        <div><h2>Prefer the full process on screen?</h2><p>Watch original jailbreak tutorials and iPhone customization videos from the Next Solution channel.</p></div>
-        <a class="button button-youtube" href="https://youtube.com/@zeshan0727" target="_blank" rel="noopener noreferrer">Open YouTube channel</a>
+    <section class="section editorial-note-section">
+      <div class="container editorial-note">
+        <div><span class="eyebrow">How we publish</span><h2>Clear about what is known—and what is not.</h2></div>
+        <div class="editorial-note-copy">
+          <p>Repository metadata can confirm a package name, version, architecture, dependencies, and developer notes. It cannot always confirm every iOS version or device combination.</p>
+          <p>Next Solution keeps those limits visible, links to the original source, and does not mirror third-party tweak packages in automated articles.</p>
+          <a class="text-link" href="tutorials.html">See the guide library →</a>
+        </div>
       </div>
     </section>
 
     <section class="section" id="faq">
-      <div class="container narrow">
-        <div class="section-heading center"><span class="kicker">Before you begin</span><h2>Frequently asked questions</h2><p>Four important checks before modifying an iPhone.</p></div>
+      <div class="container faq-layout">
+        <div class="faq-intro"><span class="eyebrow">Quick answers</span><h2>Before you modify an iPhone</h2><p>Important checks that apply to every jailbreak and package guide.</p></div>
         <div class="faq-list">
           <details><summary>Is jailbreaking completely risk-free?</summary><p>No. Modifying system software can cause instability, security issues, data loss, or compatibility problems. Back up important data and use instructions confirmed for your exact device and software version.</p></details>
-          <details><summary>Does a package architecture confirm full compatibility?</summary><p>No. Architecture is one compatibility fact. Device model, operating-system release, bootstrap, dependencies, and developer notes may also matter.</p></details>
-          <details><summary>Does Next Solution host third-party tweak files?</summary><p>Automated information pages do not mirror third-party package files. They retain a direct link to the source page so readers can verify current details there.</p></details>
-          <details><summary>Why might a tweak fail after installation?</summary><p>Common causes include an unsupported iOS version, the wrong architecture, missing dependencies, conflicts with another tweak, or a package built for a different environment.</p></details>
+          <details><summary>Does package architecture confirm full compatibility?</summary><p>No. Architecture is one compatibility fact. Device model, iOS release, bootstrap, dependencies, and developer notes may also matter.</p></details>
+          <details><summary>Where do automated articles get their facts?</summary><p>The system reads eligible public repository metadata and source pages, then runs factual and editorial checks before an article can be published.</p></details>
+          <details><summary>Does Next Solution host third-party tweak files?</summary><p>Automated information pages do not mirror third-party package files. They retain a direct link to the original source so you can verify current details there.</p></details>
         </div>
       </div>
     </section>
@@ -183,9 +247,15 @@
 
   <footer class="site-footer">
     <div class="footer-shell">
-      <div><strong>Next Solution</strong><p>Independent jailbreak tutorials, verified tweak information, and original iPhone customization videos by Zeeshan Barvi.</p></div>
-      <div class="footer-links"><a href="tutorials.html">Guides</a><a href="videos.html">Videos</a><a href="feed.xml">RSS</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a><a href="mailto:NextSolution@zeshanbarvi.uk">Contact</a></div>
+      <div class="footer-brand">
+        <a class="brand" href="./" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span class="brand-copy"><strong>Next</strong><small>solution</small></span></a>
+        <p>Independent jailbreak news, verified tweak information, practical guides, and original videos by Zeeshan Barvi.</p>
+      </div>
+      <div class="footer-column"><strong>Read</strong><a href="#latest">Latest articles</a><a href="tutorials.html#verified-articles">Cydia tweaks</a><a href="tutorials.html#jailbreak-guides">Jailbreak guides</a><a href="videos.html">Videos</a></div>
+      <div class="footer-column"><strong>Follow</strong><a href="feed.xml">RSS feed</a><a href="https://youtube.com/@zeshan0727" target="_blank" rel="noopener noreferrer">YouTube</a><a href="mailto:NextSolution@zeshanbarvi.uk">Contact</a></div>
+      <div class="footer-column"><strong>Legal</strong><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></div>
     </div>
+    <div class="footer-bottom"><div class="container"><span>© 2026 Next Solution</span><span>Articles publish daily at 06:00 Qatar time</span></div></div>
   </footer>
 </body>
 </html>

--- a/phonehub-tweak.html
+++ b/phonehub-tweak.html
@@ -1,14 +1,15 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#05070d">
-  <title>Phonehub 1.1.3: Caller ID, Auto Redial, and Phone App Features | Next Solution</title>
+  <meta name="theme-color" content="#f3f5f6">
+  <title>Phonehub 1.1.3: Caller ID &amp; Auto Redial | Next Solution</title>
   <meta name="description" content="Phonehub 1.1.3 is a package for the iOS Phone app with listed Caller ID engines, Auto Redial, Smart Loudspeaker, dual-SIM selection, and interface refinements.">
+  <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://nextsolution.cc/phonehub-tweak.html">
   <link rel="alternate" type="application/rss+xml" title="Next Solution articles" href="/feed.xml">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" href="/NextSolutionRepoIcon.png">
   <link rel="stylesheet" href="/assets/site.css">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="Next Solution">
@@ -22,10 +23,13 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4770123899731214" crossorigin="anonymous"></script>
 </head>
 <body>
+  <div class="topline">
+    <div class="topline-inner"><span>Independent iPhone jailbreak publication</span><span class="topline-status"><i aria-hidden="true"></i> New verified article daily at 06:00 Qatar time</span></div>
+  </div>
   <header class="site-header">
     <div class="nav-shell">
-      <a class="brand" href="/" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span>Next Solution</span></a>
-      <nav aria-label="Primary navigation"><ul class="nav-links"><li><a href="/">Home</a></li><li><a href="/tutorials.html" aria-current="page">Guides</a></li><li><a href="/videos.html">Videos</a></li><li><a href="/#faq">FAQ</a></li></ul></nav>
+      <a class="brand" href="/" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span class="brand-copy"><strong>Next</strong><small>solution</small></span></a>
+      <nav aria-label="Primary navigation"><ul class="nav-links"><li><a href="/">Blog</a></li><li><a href="/tutorials.html#verified-articles" aria-current="page">Cydia Tweaks</a></li><li><a href="/tutorials.html#jailbreak-guides">Jailbreak</a></li><li><a href="/videos.html">Videos</a></li></ul></nav>
     </div>
   </header>
   <main class="container article-main">
@@ -61,6 +65,14 @@
       </div>
     </article>
   </main>
-  <footer class="site-footer"><div class="footer-shell"><div><strong>Next Solution</strong><p>Independent jailbreak tutorials, verified tweak information, and original iPhone customization videos by Zeeshan Barvi.</p></div><div class="footer-links"><a href="/">Home</a><a href="/tutorials.html">Guides</a><a href="/videos.html">Videos</a><a href="/feed.xml">RSS</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div></div></footer>
+  <footer class="site-footer">
+    <div class="footer-shell">
+      <div class="footer-brand"><a class="brand" href="/" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span class="brand-copy"><strong>Next</strong><small>solution</small></span></a><p>Independent jailbreak news, verified tweak information, practical guides, and original videos by Zeeshan Barvi.</p></div>
+      <div class="footer-column"><strong>Read</strong><a href="/#latest">Latest articles</a><a href="/tutorials.html#verified-articles">Cydia tweaks</a><a href="/tutorials.html#jailbreak-guides">Jailbreak guides</a><a href="/videos.html">Videos</a></div>
+      <div class="footer-column"><strong>Follow</strong><a href="/feed.xml">RSS feed</a><a href="https://youtube.com/@zeshan0727" rel="noopener noreferrer">YouTube</a></div>
+      <div class="footer-column"><strong>Legal</strong><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div>
+    </div>
+    <div class="footer-bottom"><div class="container"><span>© 2026 Next Solution</span><span>Articles publish daily at 06:00 Qatar time</span></div></div>
+  </footer>
 </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,16 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nextsolution.cc/</loc>
+    <lastmod>2026-08-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://nextsolution.cc/tutorials.html</loc>
+    <lastmod>2026-08-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextsolution.cc/videos.html</loc>
+    <lastmod>2026-08-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/tutorials.html
+++ b/tutorials.html
@@ -1,45 +1,67 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#05070d">
-  <title>Jailbreak & Tweak Guides | Next Solution</title>
-  <meta name="description" content="Browse Next Solution jailbreak tutorials, verified tweak information, rootless package guides, and original tweak releases.">
+  <meta name="theme-color" content="#f3f5f6">
+  <title>Jailbreak &amp; Tweak Guides | Next Solution</title>
+  <meta name="description" content="Browse jailbreak tutorials, verified Cydia tweak information, rootless package guides, and original Next Solution releases.">
+  <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://nextsolution.cc/tutorials.html">
   <link rel="alternate" type="application/rss+xml" title="Next Solution articles" href="feed.xml">
-  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+  <link rel="icon" type="image/png" href="NextSolutionRepoIcon.png">
   <link rel="stylesheet" href="assets/site.css">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Next Solution">
+  <meta property="og:title" content="Jailbreak & Tweak Guides | Next Solution">
+  <meta property="og:description" content="Verified tweak release information, jailbreak tutorials, and original Next Solution packages.">
+  <meta property="og:url" content="https://nextsolution.cc/tutorials.html">
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4770123899731214" crossorigin="anonymous"></script>
 </head>
 <body>
+  <div class="topline">
+    <div class="topline-inner"><span>Independent iPhone jailbreak publication</span><span class="topline-status"><i aria-hidden="true"></i> New verified article daily at 06:00 Qatar time</span></div>
+  </div>
+
   <header class="site-header">
     <div class="nav-shell">
-      <a class="brand" href="./" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span>Next Solution</span></a>
+      <a class="brand" href="./" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span class="brand-copy"><strong>Next</strong><small>solution</small></span></a>
       <nav aria-label="Primary navigation">
         <ul class="nav-links">
-          <li><a href="./">Home</a></li>
-          <li><a href="tutorials.html" aria-current="page">Guides</a></li>
+          <li><a href="./">Blog</a></li>
+          <li><a href="#verified-articles" aria-current="page">Cydia Tweaks</a></li>
+          <li><a href="#jailbreak-guides">Jailbreak</a></li>
           <li><a href="videos.html">Videos</a></li>
-          <li><a href="./#faq">FAQ</a></li>
         </ul>
       </nav>
     </div>
   </header>
 
   <main>
-    <section class="container page-hero">
-      <span class="kicker">Next Solution knowledge base</span>
-      <h1 class="gradient-text">Guides that explain the details.</h1>
-      <p>From complete jailbreak walkthroughs to verified package summaries, each page separates documented facts from compatibility details you still need to confirm.</p>
+    <section class="container archive-hero">
+      <div>
+        <span class="eyebrow">Next Solution guide library</span>
+        <h1>Jailbreak &amp; tweak guides.</h1>
+      </div>
+      <p>Find original releases, verified package summaries, complete tutorials, and rootless setup information. Every automated article keeps a direct link to its source.</p>
     </section>
 
-    <section class="section">
+    <nav class="category-rail" aria-label="Guide categories">
+      <div class="container category-rail-inner">
+        <span>Jump to</span>
+        <a href="#verified-articles">Latest tweak information</a>
+        <a href="#original-releases">Original releases</a>
+        <a href="#jailbreak-guides">Jailbreak tutorials</a>
+        <a href="ios16-rootless-tweaks.html">Rootless collection</a>
+      </div>
+    </nav>
+
+    <section class="section" id="original-releases">
       <div class="container">
-        <div class="section-heading">
-          <div><span class="kicker">Original releases</span><h2>Next Solution tweaks</h2><p>Detailed guides and downloads for packages created and maintained by Next Solution.</p></div>
+        <div class="section-heading editorial-heading">
+          <div><span class="eyebrow">Built by Next Solution</span><h2>Original tweak releases</h2><p>Detailed feature notes, compatibility guidance, and downloads for packages created and maintained by Next Solution.</p></div>
         </div>
-        <div class="content-grid">
+        <div class="content-grid releases-grid">
           <!-- NEXT_HOME_LOCK_TUTORIAL_CARD_START -->
           <article class="featured-guide">
             <a class="featured-media" href="next-home-lock-tweak-ios16.html" aria-label="Open the Next Home Lock 1.0.5 guide"><img src="assets/next-home-lock/next-home-lock-hero.svg" alt="Next Home Lock double-tap Home Screen lock concept" width="1600" height="900" loading="eager"></a>
@@ -67,55 +89,63 @@
       </div>
     </section>
 
-    <section class="section" id="verified-articles">
+    <section class="section archive-section" id="verified-articles">
       <div class="container">
-        <div class="section-heading">
-          <div><span class="kicker">Verified-source articles</span><h2>Tweak information</h2><p>Automatically prepared articles appear only after structured factual checks and an independent verifier both approve them.</p></div>
-          <a class="text-link" href="feed.xml">Follow the RSS feed →</a>
+        <div class="section-heading editorial-heading">
+          <div><span class="eyebrow">Checked before publication</span><h2>Latest tweak information</h2><p>Source-based package articles explaining features, architecture, dependencies, and which compatibility details still need confirmation.</p></div>
+          <a class="text-link" href="feed.xml">Follow the RSS feed ↗</a>
         </div>
-        <div class="content-grid">
-          <!-- AUTO_ARTICLES_TUTORIALS_START -->
-          <article class="content-card">
-            <div class="card-meta"><span class="tag">Messages &amp; Phone</span><span class="tag">Havoc</span></div>
-            <div class="card-icon" aria-hidden="true">PH</div>
-            <h3>Phonehub 1.1.3: Caller ID, Auto Redial, and Phone App Features</h3>
-            <p>Phonehub 1.1.3 is a package for the iOS Phone app with listed Caller ID engines, Auto Redial, Smart Loudspeaker, dual-SIM selection, and interface refinements.</p>
-            <a class="card-link" href="phonehub-tweak.html">Read verified guide →</a>
-          </article>
-          <!-- AUTO_ARTICLES_TUTORIALS_END -->
+        <div class="archive-layout">
+          <div class="content-grid archive-cards">
+            <!-- AUTO_ARTICLES_TUTORIALS_START -->
+            <article class="content-card">
+              <div class="card-meta"><span class="tag">Messages &amp; Phone</span><span class="tag">Havoc</span></div>
+              <div class="card-icon" aria-hidden="true">PH</div>
+              <h3>Phonehub 1.1.3: Caller ID, Auto Redial, and Phone App Features</h3>
+              <p>Phonehub 1.1.3 is a package for the iOS Phone app with listed Caller ID engines, Auto Redial, Smart Loudspeaker, dual-SIM selection, and interface refinements.</p>
+              <a class="card-link" href="phonehub-tweak.html">Read verified guide →</a>
+            </article>
+            <!-- AUTO_ARTICLES_TUTORIALS_END -->
+          </div>
+          <aside class="archive-aside">
+            <span class="sidebar-label">What “verified source” means</span>
+            <h3>Facts stay tied to public package information.</h3>
+            <p>Automated drafts must pass structured factual checks and an independent verifier before publication. Unsupported compatibility claims are not added.</p>
+            <ul class="plain-checks"><li>Version and package ID checked</li><li>Architecture and dependencies shown</li><li>Original source retained</li><li>No third-party package mirroring</li></ul>
+          </aside>
         </div>
       </div>
     </section>
 
-    <section class="section">
+    <section class="section" id="jailbreak-guides">
       <div class="container">
-        <div class="section-heading"><div><span class="kicker">Core tutorials</span><h2>Jailbreak and package guides</h2><p>Long-form instructions for common setup, conversion, and troubleshooting work.</p></div></div>
-        <div class="content-grid">
+        <div class="section-heading editorial-heading">
+          <div><span class="eyebrow">Learn step by step</span><h2>Jailbreak &amp; package tutorials</h2><p>Long-form instructions for preparation, setup, package conversion, and troubleshooting.</p></div>
+        </div>
+        <div class="content-grid guide-card-grid">
           <article class="content-card">
+            <div class="card-meta"><span class="tag">Complete guide</span><span class="tag">iOS 16</span></div>
             <div class="card-icon" aria-hidden="true">16</div>
             <h3>Complete iOS 16 Jailbreak Guide</h3>
             <p>Follow the palera1n process with device requirements, preparation, installation, and troubleshooting.</p>
             <a class="card-link" href="how-to-jailbreak.html">Read tutorial →</a>
           </article>
           <article class="content-card">
+            <div class="card-meta"><span class="tag">Collection</span><span class="tag">Rootless</span></div>
             <div class="card-icon" aria-hidden="true">25</div>
             <h3>Free iOS 16 Rootless Tweaks</h3>
             <p>Browse a categorized collection of useful rootless packages with repositories and installation information.</p>
             <a class="card-link" href="ios16-rootless-tweaks.html">View the collection →</a>
           </article>
           <article class="content-card">
+            <div class="card-meta"><span class="tag">Package guide</span></div>
             <div class="card-icon" aria-hidden="true">RL</div>
             <h3>Convert Rootful Tweaks to Rootless</h3>
             <p>Understand package layouts and convert older packages for modern rootless environments.</p>
             <a class="card-link" href="convert-rootful-to-rootless.html">Open conversion guide →</a>
           </article>
           <article class="content-card">
-            <div class="card-icon" aria-hidden="true">BH</div>
-            <h3>Remove the Battery Service Message</h3>
-            <p>Review the process for restoring battery-health information and the checks to complete first.</p>
-            <a class="card-link" href="remove-service-message-iphone.html">Read battery guide →</a>
-          </article>
-          <article class="content-card">
+            <div class="card-meta"><span class="tag">Tweak review</span></div>
             <div class="card-icon" aria-hidden="true">LX</div>
             <h3>Lynx 2 Tweak Review</h3>
             <p>Explore the customization areas covered by Lynx 2 and the compatibility points worth checking.</p>
@@ -127,7 +157,7 @@
 
     <section class="section">
       <div class="container cta-panel">
-        <div><h2>Want a visual walkthrough?</h2><p>Pair the written steps with original videos from the Next Solution YouTube channel.</p></div>
+        <div><span class="eyebrow">Next Solution videos</span><h2>Want a visual walkthrough?</h2><p>Pair the written instructions with original videos from the official channel.</p></div>
         <a class="button button-youtube" href="videos.html">Browse video tutorials</a>
       </div>
     </section>
@@ -135,9 +165,12 @@
 
   <footer class="site-footer">
     <div class="footer-shell">
-      <div><strong>Next Solution</strong><p>Independent jailbreak tutorials, verified tweak information, and original iPhone customization videos by Zeeshan Barvi.</p></div>
-      <div class="footer-links"><a href="./">Home</a><a href="videos.html">Videos</a><a href="feed.xml">RSS</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a><a href="mailto:NextSolution@zeshanbarvi.uk">Contact</a></div>
+      <div class="footer-brand"><a class="brand" href="./" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span class="brand-copy"><strong>Next</strong><small>solution</small></span></a><p>Independent jailbreak news, verified tweak information, practical guides, and original videos by Zeeshan Barvi.</p></div>
+      <div class="footer-column"><strong>Read</strong><a href="./#latest">Latest articles</a><a href="#verified-articles">Cydia tweaks</a><a href="#jailbreak-guides">Jailbreak guides</a><a href="videos.html">Videos</a></div>
+      <div class="footer-column"><strong>Follow</strong><a href="feed.xml">RSS feed</a><a href="https://youtube.com/@zeshan0727" target="_blank" rel="noopener noreferrer">YouTube</a><a href="mailto:NextSolution@zeshanbarvi.uk">Contact</a></div>
+      <div class="footer-column"><strong>Legal</strong><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></div>
     </div>
+    <div class="footer-bottom"><div class="container"><span>© 2026 Next Solution</span><span>Articles publish daily at 06:00 Qatar time</span></div></div>
   </footer>
 </body>
 </html>

--- a/videos.html
+++ b/videos.html
@@ -1,27 +1,31 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#05070d">
+  <meta name="theme-color" content="#f3f5f6">
   <title>iPhone Jailbreak Videos | Next Solution</title>
   <meta name="description" content="Watch Next Solution jailbreak tutorials, rootless tweak reviews, and original iPhone customization videos.">
+  <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://nextsolution.cc/videos.html">
-  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+  <link rel="icon" type="image/png" href="NextSolutionRepoIcon.png">
   <link rel="preconnect" href="https://www.youtube.com">
   <link rel="stylesheet" href="assets/site.css">
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4770123899731214" crossorigin="anonymous"></script>
 </head>
 <body>
+  <div class="topline">
+    <div class="topline-inner"><span>Independent iPhone jailbreak publication</span><span class="topline-status"><i aria-hidden="true"></i> New verified article daily at 06:00 Qatar time</span></div>
+  </div>
   <header class="site-header">
     <div class="nav-shell">
-      <a class="brand" href="./" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span>Next Solution</span></a>
+      <a class="brand" href="./" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span class="brand-copy"><strong>Next</strong><small>solution</small></span></a>
       <nav aria-label="Primary navigation">
         <ul class="nav-links">
-          <li><a href="./">Home</a></li>
-          <li><a href="tutorials.html">Guides</a></li>
+          <li><a href="./">Blog</a></li>
+          <li><a href="tutorials.html#verified-articles">Cydia Tweaks</a></li>
+          <li><a href="tutorials.html#jailbreak-guides">Jailbreak</a></li>
           <li><a href="videos.html" aria-current="page">Videos</a></li>
-          <li><a href="./#faq">FAQ</a></li>
         </ul>
       </nav>
     </div>
@@ -66,9 +70,12 @@
 
   <footer class="site-footer">
     <div class="footer-shell">
-      <div><strong>Next Solution</strong><p>Independent jailbreak tutorials, verified tweak information, and original iPhone customization videos by Zeeshan Barvi.</p></div>
-      <div class="footer-links"><a href="./">Home</a><a href="tutorials.html">Guides</a><a href="feed.xml">RSS</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a><a href="mailto:NextSolution@zeshanbarvi.uk">Contact</a></div>
+      <div class="footer-brand"><a class="brand" href="./" aria-label="Next Solution home"><span class="brand-mark" aria-hidden="true">N</span><span class="brand-copy"><strong>Next</strong><small>solution</small></span></a><p>Independent jailbreak news, verified tweak information, practical guides, and original videos by Zeeshan Barvi.</p></div>
+      <div class="footer-column"><strong>Read</strong><a href="./#latest">Latest articles</a><a href="tutorials.html#verified-articles">Cydia tweaks</a><a href="tutorials.html#jailbreak-guides">Jailbreak guides</a><a href="videos.html">Videos</a></div>
+      <div class="footer-column"><strong>Follow</strong><a href="feed.xml">RSS feed</a><a href="https://youtube.com/@zeshan0727" target="_blank" rel="noopener noreferrer">YouTube</a><a href="mailto:NextSolution@zeshanbarvi.uk">Contact</a></div>
+      <div class="footer-column"><strong>Legal</strong><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></div>
     </div>
+    <div class="footer-bottom"><div class="container"><span>© 2026 Next Solution</span><span>Articles publish daily at 06:00 Qatar time</span></div></div>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## What changed
- replace the promotional landing-page look with a light editorial blog design inspired by the reference layout
- put latest tweak articles, release information, categories, compatibility guidance, and useful links directly on the homepage
- redesign the guide archive, video page, and Phonehub article to use the same visual system
- update the generated-article template so every future automated article matches the new design
- add Blog structured data, index directives, working site icons, and updated sitemap dates
- display the daily 06:00 Qatar publishing schedule throughout the site

## Automation safety
- all existing article insertion markers are preserved exactly once
- the one-article-per-Qatar-day guard remains unchanged
- source verification and no-mirroring rules remain visible

## Validation
- 53 automation unit tests pass
- HTML and CSS validation pass
- sitemap and RSS XML parse successfully
- responsive browser checks pass at 1440px, 820px, and 390px for all four redesigned pages
- no horizontal overflow, page errors, missing alt text, or empty links