### PR TITLE
Add reliable three-hour publisher trigger

### DIFF
--- a/.github/workflows/tweak-draft-generator.yml
+++ b/.github/workflows/tweak-draft-generator.yml
@@ -2,6 +2,11 @@ name: Verified tweak article publisher
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "automation/publisher-trigger.json"
   schedule:
     # 03:00 UTC is 06:00 in Qatar (UTC+3, no daylight-saving changes).
     - cron: "0 3 * * *"

--- a/automation/publisher-trigger.json
+++ b/automation/publisher-trigger.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "purpose": "Request a gated publisher run through the connected GitHub app",
+  "last_trigger_requested_at": "2026-08-13T08:40:00Z",
+  "reason": "Install the reliable three-hour launch-boost trigger"
+}


### PR DESCRIPTION
Adds a narrow push trigger for `automation/publisher-trigger.json` so the launch boost can be invoked every three hours through the connected GitHub app even when GitHub's scheduled-event queue is delayed.

All existing protections remain in force before API use:

- three-hour minimum interval
- eight-publication Qatar-day limit during the boost
- independent factual verifier
- compatibility and source checks
- kill switch
- no URL shortener
- daily limit after the boost ends

The workflow still keeps both GitHub cron schedules as a redundant path. The trigger file is internal and never appears in reader-facing pages.