### PR TITLE
Trigger Next Ledger App Store build

### DIFF
--- a/.github/workflows/build-nextledger-appstore.yml
+++ b/.github/workflows/build-nextledger-appstore.yml
@@ -1,3 +1,4 @@
+# Trigger App Store base build 2026-08-18
 name: Build Next Ledger App Store IPA
 
 on:


### PR DESCRIPTION
Triggers the Xcode 26+ App Store base IPA build for Next Ledger 1.3.76.