### PR TITLE
Add Next Signer TIPA and one-tap private app publishing

### DIFF
--- a/.github/workflows/build-nextsigner-tipa.yml
+++ b/.github/workflows/build-nextsigner-tipa.yml
@@ -8,6 +8,13 @@ on:
     paths:
       - 'NextSigner/**'
       - '.github/workflows/build-nextsigner-tipa.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'NextSigner/**'
+      - '.github/workflows/build-nextsigner-tipa.yml'
+      - '.github/workflows/nextsigner-sign-publish.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/build-nextsigner-tipa.yml
+++ b/.github/workflows/build-nextsigner-tipa.yml
@@ -1,0 +1,65 @@
+name: Build Next Signer TIPA
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - feature/nextsigner-1.0
+    paths:
+      - 'NextSigner/**'
+      - '.github/workflows/build-nextsigner-tipa.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-15
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate project
+        working-directory: NextSigner
+        run: xcodegen generate
+
+      - name: Build unsigned iPhone app
+        working-directory: NextSigner
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project NextSigner.xcodeproj \
+            -scheme NextSigner \
+            -configuration Release \
+            -sdk iphoneos \
+            -derivedDataPath "$RUNNER_TEMP/NextSignerDerived" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
+
+      - name: Package IPA and TIPA
+        run: |
+          set -euo pipefail
+          APP_PATH="$(find "$RUNNER_TEMP/NextSignerDerived/Build/Products/Release-iphoneos" -maxdepth 1 -type d -name '*.app' | head -n1)"
+          test -n "$APP_PATH" || { echo 'Built .app not found'; exit 1; }
+          mkdir -p "$RUNNER_TEMP/package/Payload"
+          cp -R "$APP_PATH" "$RUNNER_TEMP/package/Payload/NextSigner.app"
+          cd "$RUNNER_TEMP/package"
+          /usr/bin/zip -qry "$RUNNER_TEMP/NextSigner-1.0.ipa" Payload
+          cp "$RUNNER_TEMP/NextSigner-1.0.ipa" "$RUNNER_TEMP/NextSigner-1.0.tipa"
+          shasum -a 256 "$RUNNER_TEMP/NextSigner-1.0.ipa" "$RUNNER_TEMP/NextSigner-1.0.tipa"
+
+      - name: Upload TIPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NextSigner-1.0-TIPA
+          path: |
+            ${{ runner.temp }}/NextSigner-1.0.tipa
+            ${{ runner.temp }}/NextSigner-1.0.ipa
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/nextsigner-sign-publish.yml
+++ b/.github/workflows/nextsigner-sign-publish.yml
@@ -1,0 +1,257 @@
+name: Next Signer - Sign and Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      staging_asset:
+        description: Unsigned IPA asset in the Next Signer inbox release
+        required: true
+        type: string
+      requested_name:
+        description: Display name to use for the signed app
+        required: true
+        type: string
+      requested_bundle_id:
+        description: Bundle identifier to use for the signed app
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: nextsigner-publish
+  cancel-in-progress: false
+
+jobs:
+  sign-and-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      ZSIGN_COMMIT: e803f870dc686e6161d00d9b22c425b8acdfacee
+      INBOX_TAG: nextsigner-inbox
+      PUBLISH_TAG: private-apps
+      P12_PASSWORD: ${{ secrets.NEXTSIGNER_P12_PASSWORD }}
+    steps:
+      - name: Check out website
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate signing secrets
+        shell: bash
+        env:
+          P12_B64: ${{ secrets.NEXTSIGNER_P12_BASE64 }}
+          PROVISION_B64: ${{ secrets.NEXTSIGNER_MOBILEPROVISION_BASE64 }}
+        run: |
+          set -euo pipefail
+          test -n "$P12_B64" || { echo "NEXTSIGNER_P12_BASE64 is missing"; exit 1; }
+          test -n "$P12_PASSWORD" || { echo "NEXTSIGNER_P12_PASSWORD is missing"; exit 1; }
+          test -n "$PROVISION_B64" || { echo "NEXTSIGNER_MOBILEPROVISION_BASE64 is missing"; exit 1; }
+          printf '%s' "$P12_B64" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          printf '%s' "$PROVISION_B64" | base64 --decode > "$RUNNER_TEMP/profile.mobileprovision"
+          chmod 600 "$RUNNER_TEMP/certificate.p12" "$RUNNER_TEMP/profile.mobileprovision"
+
+      - name: Download staged IPA
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STAGING_ASSET: ${{ inputs.staging_asset }}
+        run: |
+          set -euo pipefail
+          RELEASES_JSON="$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100")"
+          RELEASE_ID="$(printf '%s' "$RELEASES_JSON" | jq -r --arg tag "$INBOX_TAG" '.[] | select(.tag_name==$tag) | .id' | head -n1)"
+          test -n "$RELEASE_ID" && test "$RELEASE_ID" != "null" || { echo "Signing inbox release not found"; exit 1; }
+          ASSETS_JSON="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets")"
+          ASSET_ID="$(printf '%s' "$ASSETS_JSON" | jq -r --arg name "$STAGING_ASSET" '.[] | select(.name==$name) | .id' | head -n1)"
+          test -n "$ASSET_ID" && test "$ASSET_ID" != "null" || { echo "Staged IPA asset not found: $STAGING_ASSET"; exit 1; }
+          gh api -H 'Accept: application/octet-stream' "repos/$GITHUB_REPOSITORY/releases/assets/$ASSET_ID" > "$RUNNER_TEMP/input.ipa"
+          echo "INBOX_RELEASE_ID=$RELEASE_ID" >> "$GITHUB_ENV"
+          echo "INBOX_ASSET_ID=$ASSET_ID" >> "$GITHUB_ENV"
+          test -s "$RUNNER_TEMP/input.ipa"
+
+      - name: Build pinned zsign
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y g++ pkg-config libssl-dev jq
+          git clone --filter=blob:none https://github.com/zhlynn/zsign.git "$RUNNER_TEMP/zsign"
+          git -C "$RUNNER_TEMP/zsign" checkout "$ZSIGN_COMMIT"
+          make -C "$RUNNER_TEMP/zsign/build/linux" clean
+          make -C "$RUNNER_TEMP/zsign/build/linux" -j"$(nproc)"
+          "$RUNNER_TEMP/zsign/bin/zsign" --version
+
+      - name: Sign IPA
+        shell: bash
+        env:
+          REQUESTED_NAME: ${{ inputs.requested_name }}
+          REQUESTED_BUNDLE_ID: ${{ inputs.requested_bundle_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/metadata"
+          "$RUNNER_TEMP/zsign/bin/zsign" \
+            -f \
+            -k "$RUNNER_TEMP/certificate.p12" \
+            -p "$P12_PASSWORD" \
+            -m "$RUNNER_TEMP/profile.mobileprovision" \
+            -b "$REQUESTED_BUNDLE_ID" \
+            -n "$REQUESTED_NAME" \
+            -x "$RUNNER_TEMP/metadata" \
+            -o "$RUNNER_TEMP/signed.ipa" \
+            "$RUNNER_TEMP/input.ipa"
+          test -s "$RUNNER_TEMP/signed.ipa"
+
+      - name: Read signed app metadata
+        shell: bash
+        env:
+          REQUESTED_NAME: ${{ inputs.requested_name }}
+          REQUESTED_BUNDLE_ID: ${{ inputs.requested_bundle_id }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, plistlib, re, zipfile
+          ipa = os.path.join(os.environ['RUNNER_TEMP'], 'signed.ipa')
+          with zipfile.ZipFile(ipa) as z:
+              infos = [n for n in z.namelist() if re.fullmatch(r'Payload/[^/]+\.app/Info\.plist', n)]
+              if not infos:
+                  raise SystemExit('Main app Info.plist not found')
+              info = plistlib.loads(z.read(infos[0]))
+          name = info.get('CFBundleDisplayName') or info.get('CFBundleName') or os.environ['REQUESTED_NAME']
+          bundle_id = info.get('CFBundleIdentifier') or os.environ['REQUESTED_BUNDLE_ID']
+          version = str(info.get('CFBundleShortVersionString') or '1.0')
+          build = str(info.get('CFBundleVersion') or '1')
+          minimum = str(info.get('MinimumOSVersion') or 'Unknown')
+          slug = re.sub(r'[^a-z0-9]+', '-', bundle_id.lower()).strip('-')[-70:] or 'signed-app'
+          values = {
+              'APP_NAME': name,
+              'APP_BUNDLE_ID': bundle_id,
+              'APP_VERSION': version,
+              'APP_BUILD': build,
+              'APP_MINIMUM_OS': minimum,
+              'APP_SLUG': slug,
+              'SIGNED_FILENAME': f'{slug}.ipa',
+          }
+          with open(os.environ['GITHUB_ENV'], 'a') as f:
+              for k, v in values.items():
+                  print(f'{k}={v}', file=f)
+          PY
+
+      - name: Publish signed IPA release asset
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$PUBLISH_TAG" >/dev/null 2>&1; then
+            gh release create "$PUBLISH_TAG" --title "Next Solution Private Apps" --notes "Signed builds published by Next Signer." --latest=false
+          fi
+          cp "$RUNNER_TEMP/signed.ipa" "$RUNNER_TEMP/$SIGNED_FILENAME"
+          gh release upload "$PUBLISH_TAG" "$RUNNER_TEMP/$SIGNED_FILENAME" --clobber
+          echo "SIGNED_URL=https://github.com/$GITHUB_REPOSITORY/releases/download/$PUBLISH_TAG/$SIGNED_FILENAME" >> "$GITHUB_ENV"
+
+      - name: Publish icon, manifest and catalog entry
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p install/icons
+          ICON_PATH=""
+          while IFS= read -r -d '' candidate; do
+            ICON_PATH="$candidate"
+            break
+          done < <(find "$RUNNER_TEMP/metadata" -type f -iname '*.png' -print0)
+          if [ -n "$ICON_PATH" ]; then
+            cp "$ICON_PATH" "install/icons/$APP_SLUG.png"
+            ICON_URL="/install/icons/$APP_SLUG.png"
+          else
+            ICON_URL="/apple-touch-icon.png"
+          fi
+          export ICON_URL
+          python3 - <<'PY'
+          import json, os, pathlib, plistlib
+          root = pathlib.Path('install')
+          app = {
+              'id': os.environ['APP_SLUG'],
+              'name': os.environ['APP_NAME'],
+              'version': os.environ['APP_VERSION'],
+              'build': os.environ['APP_BUILD'],
+              'platform': 'iPhone',
+              'minimumOS': ('iOS ' + os.environ['APP_MINIMUM_OS'] + '+') if os.environ['APP_MINIMUM_OS'] != 'Unknown' else 'iOS',
+              'bundleId': os.environ['APP_BUNDLE_ID'],
+              'icon': os.environ['ICON_URL'],
+              'manifest': f"/install/{os.environ['APP_SLUG']}.plist",
+              'available': True,
+              'status': 'Ready to install'
+          }
+          catalog_path = root / 'apps.json'
+          if catalog_path.exists():
+              catalog = json.loads(catalog_path.read_text())
+          else:
+              catalog = {'catalog': 'Next Solution Private Apps', 'updated': '', 'apps': []}
+          apps = [x for x in catalog.get('apps', []) if x.get('id') != app['id']]
+          apps.insert(0, app)
+          catalog['apps'] = apps
+          from datetime import date
+          catalog['updated'] = date.today().isoformat()
+          catalog_path.write_text(json.dumps(catalog, indent=2) + '\n')
+
+          icon_absolute = 'https://nextsolution.cc' + os.environ['ICON_URL']
+          manifest = {
+              'items': [{
+                  'assets': [
+                      {'kind': 'software-package', 'url': os.environ['SIGNED_URL']},
+                      {'kind': 'display-image', 'needs-shine': False, 'url': icon_absolute},
+                      {'kind': 'full-size-image', 'needs-shine': False, 'url': icon_absolute},
+                  ],
+                  'metadata': {
+                      'bundle-identifier': os.environ['APP_BUNDLE_ID'],
+                      'bundle-version': os.environ['APP_BUILD'],
+                      'kind': 'software',
+                      'title': os.environ['APP_NAME'],
+                  }
+              }]
+          }
+          with open(root / f"{os.environ['APP_SLUG']}.plist", 'wb') as f:
+              plistlib.dump(manifest, f, fmt=plistlib.FMT_XML, sort_keys=False)
+          PY
+
+      - name: Commit catalog update
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add install/apps.json "install/$APP_SLUG.plist" install/icons || true
+          if git diff --cached --quiet; then
+            echo "No website changes to commit"
+          else
+            git commit -m "Publish $APP_NAME via Next Signer"
+            git push origin main
+          fi
+
+      - name: Remove staged IPA after success
+        if: success()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api -X DELETE "repos/$GITHUB_REPOSITORY/releases/assets/$INBOX_ASSET_ID"
+
+      - name: Signing summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Next Signer"
+            echo
+            echo "App: ${APP_NAME:-${{ inputs.requested_name }}}"
+            echo "Bundle ID: ${APP_BUNDLE_ID:-${{ inputs.requested_bundle_id }}}"
+            if [ "${{ job.status }}" = "success" ]; then
+              echo "Status: Signed and published"
+              echo "Installer: https://nextsolution.cc/install/"
+            else
+              echo "Status: Failed — inspect the signing log above"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/NextSigner/NextSigner/ContentView.swift
+++ b/NextSigner/NextSigner/ContentView.swift
@@ -138,7 +138,7 @@ private struct SignView: View {
 
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: store.request.isValidBundleID ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                        .foregroundStyle(store.request.isValidBundleID ? .green : .orange)
+                        .foregroundColor(store.request.isValidBundleID ? .green : .orange)
                     Text(store.request.isValidBundleID
                          ? "The bundle identifier format is valid. Keep it under com.nextsolution.* when using your wildcard Ad Hoc profile."
                          : "Enter a valid reverse-DNS bundle identifier, for example com.nextsolution.myapp.")
@@ -165,7 +165,7 @@ private struct SignView: View {
                 if let success = store.successMessage {
                     Label(success, systemImage: "checkmark.circle.fill")
                         .font(.caption)
-                        .foregroundStyle(.green)
+                        .foregroundColor(.green)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
@@ -218,11 +218,21 @@ private struct ActivityView: View {
                         .padding(.vertical, 4)
                     }
                 } else {
-                    ContentUnavailableView(
-                        "No signing jobs yet",
-                        systemImage: "signature",
-                        description: Text("Your latest Sign & Publish job will appear here.")
-                    )
+                    Section {
+                        VStack(spacing: 10) {
+                            Image(systemName: "signature")
+                                .font(.system(size: 34))
+                                .foregroundStyle(.secondary)
+                            Text("No signing jobs yet")
+                                .font(.headline)
+                            Text("Your latest Sign & Publish job will appear here.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.center)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 24)
+                    }
                 }
 
                 Section("Installer") {
@@ -282,7 +292,7 @@ private struct SettingsView: View {
                     Label(store.tokenIsStored ? "Token stored on this device" : "Token not configured",
                           systemImage: store.tokenIsStored ? "lock.fill" : "lock.open")
                         .font(.caption)
-                        .foregroundStyle(store.tokenIsStored ? .green : .secondary)
+                        .foregroundColor(store.tokenIsStored ? .green : .gray)
                 }
 
                 Section("Required token permissions") {

--- a/NextSigner/NextSigner/ContentView.swift
+++ b/NextSigner/NextSigner/ContentView.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ContentView: View {
+    @StateObject private var store = SignerStore()
+
+    var body: some View {
+        TabView {
+            SignView(store: store)
+                .tabItem { Label("Sign", systemImage: "signature") }
+
+            ActivityView(store: store)
+                .tabItem { Label("Activity", systemImage: "clock.arrow.circlepath") }
+
+            SettingsView(store: store)
+                .tabItem { Label("Settings", systemImage: "gearshape") }
+        }
+        .tint(.accentColor)
+    }
+}
+
+private struct SignView: View {
+    @ObservedObject var store: SignerStore
+    @State private var showsImporter = false
+
+    private var ipaType: UTType {
+        UTType(filenameExtension: "ipa") ?? .data
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 18) {
+                    header
+                    ipaCard
+                    detailsCard
+                    actionCard
+                }
+                .padding()
+            }
+            .navigationTitle("Next Signer")
+            .fileImporter(
+                isPresented: $showsImporter,
+                allowedContentTypes: [ipaType],
+                allowsMultipleSelection: false
+            ) { result in
+                switch result {
+                case let .success(urls):
+                    if let url = urls.first { store.importIPA(from: url) }
+                case let .failure(error):
+                    store.errorMessage = error.localizedDescription
+                }
+            }
+            .alert("Next Signer", isPresented: Binding(
+                get: { store.errorMessage != nil },
+                set: { if !$0 { store.errorMessage = nil } }
+            )) {
+                Button("OK", role: .cancel) { store.errorMessage = nil }
+            } message: {
+                Text(store.errorMessage ?? "Unknown error")
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Pick. Sign. Publish.", systemImage: "checkmark.seal.fill")
+                .font(.title2.bold())
+            Text("Choose an IPA, assign a Next Solution bundle ID, then send it to your signing workflow. The signed build is published automatically to nextsolution.cc/install/ for registered devices.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var ipaCard: some View {
+        GroupBox {
+            VStack(spacing: 12) {
+                if let url = store.request.ipaURL {
+                    HStack(spacing: 12) {
+                        Image(systemName: "shippingbox.fill")
+                            .font(.title2)
+                            .frame(width: 42, height: 42)
+                            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(url.lastPathComponent)
+                                .font(.headline)
+                                .lineLimit(2)
+                            Text(fileSizeText(url))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Button(role: .destructive) { store.clearSelectedIPA() } label: {
+                            Image(systemName: "trash")
+                        }
+                    }
+                } else {
+                    VStack(spacing: 10) {
+                        Image(systemName: "square.and.arrow.down")
+                            .font(.system(size: 34))
+                        Text("No IPA selected")
+                            .font(.headline)
+                        Text("Import an IPA from Files.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                }
+
+                Button {
+                    showsImporter = true
+                } label: {
+                    Label(store.request.ipaURL == nil ? "Choose IPA" : "Choose Another IPA", systemImage: "folder")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        } label: {
+            Label("App", systemImage: "app.dashed")
+        }
+    }
+
+    private var detailsCard: some View {
+        GroupBox {
+            VStack(spacing: 12) {
+                TextField("App name", text: $store.request.appName)
+                    .textInputAutocapitalization(.words)
+                    .autocorrectionDisabled()
+                    .textFieldStyle(.roundedBorder)
+
+                TextField("Bundle ID", text: $store.request.bundleID)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.asciiCapable)
+                    .textFieldStyle(.roundedBorder)
+
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: store.request.isValidBundleID ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                        .foregroundStyle(store.request.isValidBundleID ? .green : .orange)
+                    Text(store.request.isValidBundleID
+                         ? "The bundle identifier format is valid. Keep it under com.nextsolution.* when using your wildcard Ad Hoc profile."
+                         : "Enter a valid reverse-DNS bundle identifier, for example com.nextsolution.myapp.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } label: {
+            Label("Signing identity", systemImage: "number")
+        }
+    }
+
+    private var actionCard: some View {
+        GroupBox {
+            VStack(spacing: 12) {
+                if store.isWorking {
+                    ProgressView(value: store.progress)
+                    Text(store.activeJob?.detail ?? "Working…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                if let success = store.successMessage {
+                    Label(success, systemImage: "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                Button {
+                    store.signAndPublish()
+                } label: {
+                    Label(store.isWorking ? "Signing & Publishing…" : "Sign & Publish", systemImage: "paperplane.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(!store.request.isReady || store.isWorking || !store.tokenIsStored)
+
+                if !store.tokenIsStored {
+                    Text("Add your GitHub token once in Settings before the first use.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } label: {
+            Label("Publish", systemImage: "arrow.up.circle")
+        }
+    }
+
+    private func fileSizeText(_ url: URL) -> String {
+        guard let values = try? url.resourceValues(forKeys: [.fileSizeKey]), let bytes = values.fileSize else { return "IPA" }
+        return ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+    }
+}
+
+private struct ActivityView: View {
+    @ObservedObject var store: SignerStore
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if let job = store.activeJob {
+                    Section("Current job") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Image(systemName: icon(for: job.stage))
+                                Text(job.requestedAppName).font(.headline)
+                                Spacer()
+                                Text(job.stage.rawValue).font(.caption.bold())
+                            }
+                            Text(job.sourceName).font(.caption).foregroundStyle(.secondary)
+                            Text(job.requestedBundleID).font(.caption2).foregroundStyle(.secondary)
+                            Text(job.detail).font(.footnote)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                } else {
+                    ContentUnavailableView(
+                        "No signing jobs yet",
+                        systemImage: "signature",
+                        description: Text("Your latest Sign & Publish job will appear here.")
+                    )
+                }
+
+                Section("Installer") {
+                    Link(destination: URL(string: "https://nextsolution.cc/install/")!) {
+                        Label("Open Next Solution Private Apps", systemImage: "safari")
+                    }
+                }
+            }
+            .navigationTitle("Activity")
+        }
+    }
+
+    private func icon(for stage: SigningJob.Stage) -> String {
+        switch stage {
+        case .preparing: return "gearshape.2"
+        case .uploading: return "arrow.up.circle"
+        case .queued: return "checkmark.circle.fill"
+        case .failed: return "xmark.octagon.fill"
+        }
+    }
+}
+
+private struct SettingsView: View {
+    @ObservedObject var store: SignerStore
+    @State private var revealToken = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("GitHub") {
+                    TextField("Owner", text: $store.configuration.owner)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                    TextField("Repository", text: $store.configuration.repository)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                    TextField("Branch", text: $store.configuration.branch)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                    TextField("Workflow file", text: $store.configuration.workflowFile)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+
+                Section("Fine-grained token") {
+                    if revealToken {
+                        TextField("github_pat_…", text: $store.token)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                    } else {
+                        SecureField("github_pat_…", text: $store.token)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                    }
+                    Toggle("Show token", isOn: $revealToken)
+                    Button("Save Token to Keychain") { store.saveToken() }
+                    Label(store.tokenIsStored ? "Token stored on this device" : "Token not configured",
+                          systemImage: store.tokenIsStored ? "lock.fill" : "lock.open")
+                        .font(.caption)
+                        .foregroundStyle(store.tokenIsStored ? .green : .secondary)
+                }
+
+                Section("Required token permissions") {
+                    Label("Contents: Read and write", systemImage: "doc.badge.gearshape")
+                    Label("Actions: Read and write", systemImage: "bolt.horizontal.circle")
+                    Text("Scope the token only to the NextSolution repository. The token is saved in the iOS Keychain, not UserDefaults.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Signing certificate") {
+                    Text("The P12 certificate, password and provisioning profile are intentionally not stored in this app. Add them once as encrypted GitHub Actions secrets. After that, Sign & Publish needs only the IPA.")
+                        .font(.footnote)
+                }
+            }
+            .navigationTitle("Settings")
+            .onDisappear { store.persistConfiguration() }
+        }
+    }
+}

--- a/NextSigner/NextSigner/GitHubService.swift
+++ b/NextSigner/NextSigner/GitHubService.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+actor GitHubService {
+    struct Release: Decodable {
+        let id: Int
+        let tagName: String
+        let uploadURL: String
+        let assets: [Asset]
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case tagName = "tag_name"
+            case uploadURL = "upload_url"
+            case assets
+        }
+    }
+
+    struct Asset: Decodable {
+        let id: Int
+        let name: String
+    }
+
+    struct DispatchResponse: Decodable {
+        let workflowRunID: Int?
+        let htmlURL: String?
+
+        enum CodingKeys: String, CodingKey {
+            case workflowRunID = "workflow_run_id"
+            case htmlURL = "html_url"
+        }
+    }
+
+    private let session: URLSession
+    private let token: String
+    private let configuration: GitHubConfiguration
+    private let apiVersion = "2026-03-10"
+    private let stagingTag = "nextsigner-inbox"
+
+    init(token: String, configuration: GitHubConfiguration, session: URLSession = .shared) {
+        self.token = token
+        self.configuration = configuration
+        self.session = session
+    }
+
+    func uploadAndDispatch(
+        ipaURL: URL,
+        appName: String,
+        bundleID: String,
+        progress: @Sendable (Double) async -> Void
+    ) async throws -> DispatchResponse? {
+        guard configuration.isValid else { throw NextSignerError.invalidConfiguration }
+
+        let release = try await ensureStagingRelease()
+        let safeName = makeStagingAssetName(original: ipaURL.lastPathComponent)
+        try await deleteExistingAsset(named: safeName, from: release)
+        await progress(0.15)
+        try await uploadAsset(fileURL: ipaURL, name: safeName, release: release)
+        await progress(0.85)
+        let dispatch = try await dispatchSigningWorkflow(
+            assetName: safeName,
+            appName: appName,
+            bundleID: bundleID
+        )
+        await progress(1.0)
+        return dispatch
+    }
+
+    private func ensureStagingRelease() async throws -> Release {
+        let releasesURL = try apiURL("/repos/\(configuration.owner)/\(configuration.repository)/releases?per_page=100")
+        let (data, response) = try await session.data(for: request(url: releasesURL))
+        try validate(response: response, data: data)
+
+        if let releases = try? JSONDecoder().decode([Release].self, from: data),
+           let existing = releases.first(where: { $0.tagName == stagingTag }) {
+            return existing
+        }
+
+        let createURL = try apiURL("/repos/\(configuration.owner)/\(configuration.repository)/releases")
+        let body: [String: Any] = [
+            "tag_name": stagingTag,
+            "target_commitish": configuration.branch,
+            "name": "Next Signer Inbox",
+            "body": "Private staging release used by the Next Signer app.",
+            "draft": true,
+            "prerelease": true,
+            "make_latest": "false"
+        ]
+        let encoded = try JSONSerialization.data(withJSONObject: body)
+        let (createData, createResponse) = try await session.data(for: request(url: createURL, method: "POST", body: encoded))
+        try validate(response: createResponse, data: createData)
+        return try JSONDecoder().decode(Release.self, from: createData)
+    }
+
+    private func deleteExistingAsset(named name: String, from release: Release) async throws {
+        guard let asset = release.assets.first(where: { $0.name == name }) else { return }
+        let url = try apiURL("/repos/\(configuration.owner)/\(configuration.repository)/releases/assets/\(asset.id)")
+        let (data, response) = try await session.data(for: request(url: url, method: "DELETE"))
+        try validate(response: response, data: data, accepted: [204])
+    }
+
+    private func uploadAsset(fileURL: URL, name: String, release: Release) async throws {
+        guard var components = URLComponents(string: release.uploadURL.components(separatedBy: "{").first ?? release.uploadURL) else {
+            throw NextSignerError.malformedURL
+        }
+        components.queryItems = [URLQueryItem(name: "name", value: name)]
+        guard let url = components.url else { throw NextSignerError.malformedURL }
+
+        var uploadRequest = request(url: url, method: "POST")
+        uploadRequest.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        let (_, response) = try await session.upload(for: uploadRequest, fromFile: fileURL)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw NextSignerError.uploadFailed
+        }
+    }
+
+    private func dispatchSigningWorkflow(assetName: String, appName: String, bundleID: String) async throws -> DispatchResponse? {
+        let workflow = configuration.workflowFile.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? configuration.workflowFile
+        let url = try apiURL("/repos/\(configuration.owner)/\(configuration.repository)/actions/workflows/\(workflow)/dispatches")
+        let body: [String: Any] = [
+            "ref": configuration.branch,
+            "inputs": [
+                "staging_asset": assetName,
+                "requested_name": appName,
+                "requested_bundle_id": bundleID
+            ]
+        ]
+        let encoded = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await session.data(for: request(url: url, method: "POST", body: encoded))
+        try validate(response: response, data: data, accepted: [200, 204])
+        guard !data.isEmpty else { return nil }
+        return try? JSONDecoder().decode(DispatchResponse.self, from: data)
+    }
+
+    private func request(url: URL, method: String = "GET", body: Data? = nil) -> URLRequest {
+        var req = URLRequest(url: url)
+        req.httpMethod = method
+        req.httpBody = body
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        req.setValue(apiVersion, forHTTPHeaderField: "X-GitHub-Api-Version")
+        if body != nil {
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        req.timeoutInterval = 120
+        return req
+    }
+
+    private func apiURL(_ path: String) throws -> URL {
+        guard let url = URL(string: "https://api.github.com\(path)") else {
+            throw NextSignerError.malformedURL
+        }
+        return url
+    }
+
+    private func validate(response: URLResponse, data: Data, accepted: Set<Int>? = nil) throws {
+        guard let http = response as? HTTPURLResponse else { throw NextSignerError.invalidResponse }
+        let allowed = accepted ?? Set(200...299)
+        guard allowed.contains(http.statusCode) else {
+            let message: String
+            if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let apiMessage = object["message"] as? String {
+                message = apiMessage
+            } else {
+                message = String(data: data, encoding: .utf8) ?? "Unknown error"
+            }
+            throw NextSignerError.http(http.statusCode, message)
+        }
+    }
+
+    private func makeStagingAssetName(original: String) -> String {
+        let base = original.replacingOccurrences(of: " ", with: "-")
+        let stamp = Int(Date().timeIntervalSince1970)
+        return "\(stamp)-\(base.hasSuffix(".ipa") ? base : base + ".ipa")"
+    }
+}

--- a/NextSigner/NextSigner/KeychainStore.swift
+++ b/NextSigner/NextSigner/KeychainStore.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Security
+
+enum KeychainStore {
+    private static let service = "com.nextsolution.nextsigner"
+
+    static func save(_ value: String, account: String) throws {
+        let data = Data(value.utf8)
+        let base: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(base as CFDictionary)
+
+        var attributes = base
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(status))
+        }
+    }
+
+    static func load(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return value
+    }
+
+    static func delete(account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/NextSigner/NextSigner/Models.swift
+++ b/NextSigner/NextSigner/Models.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+struct SignRequest: Equatable {
+    var ipaURL: URL?
+    var appName: String = ""
+    var bundleID: String = ""
+
+    var isReady: Bool {
+        ipaURL != nil && !appName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && isValidBundleID
+    }
+
+    var isValidBundleID: Bool {
+        let value = bundleID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard value.count >= 3, value.contains("."), !value.hasPrefix("."), !value.hasSuffix(".") else { return false }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-")
+        return value.unicodeScalars.allSatisfy { allowed.contains($0) }
+    }
+}
+
+struct GitHubConfiguration: Equatable {
+    var owner: String = "zeshan0727"
+    var repository: String = "NextSolution"
+    var branch: String = "main"
+    var workflowFile: String = "nextsigner-sign-publish.yml"
+
+    var isValid: Bool {
+        !owner.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !repository.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !branch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !workflowFile.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+struct SigningJob: Identifiable, Equatable {
+    let id = UUID()
+    let sourceName: String
+    let requestedBundleID: String
+    let requestedAppName: String
+    var stage: Stage
+    var detail: String
+
+    enum Stage: String {
+        case preparing = "Preparing"
+        case uploading = "Uploading"
+        case queued = "Queued"
+        case failed = "Failed"
+    }
+}
+
+enum NextSignerError: LocalizedError {
+    case missingToken
+    case invalidConfiguration
+    case invalidResponse
+    case http(Int, String)
+    case uploadFailed
+    case malformedURL
+
+    var errorDescription: String? {
+        switch self {
+        case .missingToken:
+            return "GitHub access token is not configured."
+        case .invalidConfiguration:
+            return "GitHub repository settings are incomplete."
+        case .invalidResponse:
+            return "GitHub returned an invalid response."
+        case let .http(code, message):
+            return "GitHub error \(code): \(message)"
+        case .uploadFailed:
+            return "The IPA could not be uploaded."
+        case .malformedURL:
+            return "A GitHub API URL could not be created."
+        }
+    }
+}

--- a/NextSigner/NextSigner/NextSignerApp.swift
+++ b/NextSigner/NextSigner/NextSignerApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct NextSignerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/NextSigner/NextSigner/SignerStore.swift
+++ b/NextSigner/NextSigner/SignerStore.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+@MainActor
+final class SignerStore: ObservableObject {
+    @Published var request = SignRequest()
+    @Published var configuration: GitHubConfiguration
+    @Published var token: String
+    @Published var tokenIsStored: Bool
+    @Published var isWorking = false
+    @Published var progress: Double = 0
+    @Published var activeJob: SigningJob?
+    @Published var errorMessage: String?
+    @Published var successMessage: String?
+
+    private let defaults = UserDefaults.standard
+    private let tokenAccount = "github-token"
+
+    init() {
+        configuration = GitHubConfiguration(
+            owner: UserDefaults.standard.string(forKey: "githubOwner") ?? "zeshan0727",
+            repository: UserDefaults.standard.string(forKey: "githubRepository") ?? "NextSolution",
+            branch: UserDefaults.standard.string(forKey: "githubBranch") ?? "main",
+            workflowFile: UserDefaults.standard.string(forKey: "githubWorkflow") ?? "nextsigner-sign-publish.yml"
+        )
+        let stored = KeychainStore.load(account: tokenAccount) ?? ""
+        token = stored
+        tokenIsStored = !stored.isEmpty
+    }
+
+    func persistConfiguration() {
+        defaults.set(configuration.owner, forKey: "githubOwner")
+        defaults.set(configuration.repository, forKey: "githubRepository")
+        defaults.set(configuration.branch, forKey: "githubBranch")
+        defaults.set(configuration.workflowFile, forKey: "githubWorkflow")
+    }
+
+    func saveToken() {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
+            if trimmed.isEmpty {
+                KeychainStore.delete(account: tokenAccount)
+                tokenIsStored = false
+            } else {
+                try KeychainStore.save(trimmed, account: tokenAccount)
+                token = trimmed
+                tokenIsStored = true
+            }
+            errorMessage = nil
+        } catch {
+            errorMessage = "Could not save the GitHub token: \(error.localizedDescription)"
+        }
+    }
+
+    func importIPA(from pickedURL: URL) {
+        do {
+            let localURL = try copyIntoPrivateStaging(pickedURL)
+            request.ipaURL = localURL
+            if request.appName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                request.appName = suggestedAppName(from: localURL.lastPathComponent)
+            }
+            if request.bundleID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                request.bundleID = suggestedBundleID(from: request.appName)
+            }
+            errorMessage = nil
+            successMessage = nil
+        } catch {
+            errorMessage = "Unable to import IPA: \(error.localizedDescription)"
+        }
+    }
+
+    func clearSelectedIPA() {
+        if let url = request.ipaURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+        request.ipaURL = nil
+        activeJob = nil
+        progress = 0
+    }
+
+    func signAndPublish() {
+        guard !isWorking else { return }
+        guard request.isReady else {
+            errorMessage = "Choose an IPA and enter a valid app name and bundle identifier."
+            return
+        }
+        guard configuration.isValid else {
+            errorMessage = NextSignerError.invalidConfiguration.localizedDescription
+            return
+        }
+        let currentToken = KeychainStore.load(account: tokenAccount) ?? token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !currentToken.isEmpty else {
+            errorMessage = NextSignerError.missingToken.localizedDescription
+            return
+        }
+        guard let ipaURL = request.ipaURL else { return }
+
+        persistConfiguration()
+        isWorking = true
+        progress = 0
+        errorMessage = nil
+        successMessage = nil
+        activeJob = SigningJob(
+            sourceName: ipaURL.lastPathComponent,
+            requestedBundleID: request.bundleID,
+            requestedAppName: request.appName,
+            stage: .preparing,
+            detail: "Preparing secure upload"
+        )
+
+        let service = GitHubService(token: currentToken, configuration: configuration)
+        let appName = request.appName
+        let bundleID = request.bundleID
+
+        Task {
+            do {
+                activeJob?.stage = .uploading
+                activeJob?.detail = "Uploading IPA to the private signing inbox"
+                let response = try await service.uploadAndDispatch(
+                    ipaURL: ipaURL,
+                    appName: appName,
+                    bundleID: bundleID,
+                    progress: { value in
+                        await MainActor.run {
+                            self.progress = value
+                        }
+                    }
+                )
+                activeJob?.stage = .queued
+                if let runURL = response?.htmlURL, !runURL.isEmpty {
+                    activeJob?.detail = "Signing and publishing started: \(runURL)"
+                } else {
+                    activeJob?.detail = "Signing and publishing workflow queued"
+                }
+                successMessage = "Uploaded successfully. GitHub is now signing the IPA and publishing it to your private app page."
+                progress = 1
+            } catch {
+                activeJob?.stage = .failed
+                activeJob?.detail = error.localizedDescription
+                errorMessage = error.localizedDescription
+            }
+            isWorking = false
+        }
+    }
+
+    private func copyIntoPrivateStaging(_ source: URL) throws -> URL {
+        let accessed = source.startAccessingSecurityScopedResource()
+        defer {
+            if accessed { source.stopAccessingSecurityScopedResource() }
+        }
+
+        let folder = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("NextSignerInbox", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+
+        let sanitized = source.lastPathComponent.replacingOccurrences(of: "/", with: "-")
+        let destination = folder.appendingPathComponent("\(UUID().uuidString)-\(sanitized)")
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.copyItem(at: source, to: destination)
+        return destination
+    }
+
+    private func suggestedAppName(from filename: String) -> String {
+        var value = (filename as NSString).deletingPathExtension
+        value = value.replacingOccurrences(of: "_", with: " ")
+        value = value.replacingOccurrences(of: "-", with: " ")
+        return value.split(separator: " ").prefix(4).joined(separator: " ")
+    }
+
+    private func suggestedBundleID(from appName: String) -> String {
+        let slug = appName.lowercased().unicodeScalars.compactMap { scalar -> Character? in
+            if CharacterSet.alphanumerics.contains(scalar) { return Character(String(scalar)) }
+            return nil
+        }
+        let suffix = String(slug)
+        return "com.nextsolution.\(suffix.isEmpty ? "signedapp" : suffix)"
+    }
+}

--- a/NextSigner/NextSigner/SignerStore.swift
+++ b/NextSigner/NextSigner/SignerStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 @MainActor
 final class SignerStore: ObservableObject {

--- a/NextSigner/README.md
+++ b/NextSigner/README.md
@@ -1,0 +1,74 @@
+# Next Signer
+
+Next Signer is a small iOS utility for the Next Solution private app catalog.
+
+## Goal
+
+After one-time setup, publishing an app is:
+
+1. Open Next Signer.
+2. Choose an IPA from Files.
+3. Confirm the app name and a `com.nextsolution.*` bundle identifier.
+4. Tap **Sign & Publish**.
+5. The GitHub workflow signs the IPA and updates `https://nextsolution.cc/install/` automatically.
+
+No IPA needs to be sent through ChatGPT and no third-party signing app is required.
+
+## Security model
+
+Next Signer does **not** keep the Apple Distribution P12, P12 password, or provisioning profile on the iPhone. Those are stored once as encrypted GitHub Actions secrets. The iPhone stores only a repository-scoped GitHub token in the iOS Keychain.
+
+Required Actions secrets on `zeshan0727/NextSolution`:
+
+- `NEXTSIGNER_P12_BASE64`
+- `NEXTSIGNER_P12_PASSWORD`
+- `NEXTSIGNER_MOBILEPROVISION_BASE64`
+
+Create the base64 values locally. On macOS:
+
+```bash
+base64 -i Distribution.p12 | pbcopy
+base64 -i NS_3.mobileprovision | pbcopy
+```
+
+On Windows PowerShell:
+
+```powershell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("Distribution.p12")) | Set-Clipboard
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("NS_3.mobileprovision")) | Set-Clipboard
+```
+
+Never commit the P12, its password, or the raw provisioning profile to the repository.
+
+## GitHub token for the app
+
+Create a fine-grained personal access token scoped only to `zeshan0727/NextSolution` with:
+
+- Contents: Read and write
+- Actions: Read and write
+
+Enter the token once under Next Signer → Settings. It is stored in Keychain with `ThisDeviceOnly` accessibility.
+
+## Signing engine
+
+The backend workflow uses the MIT-licensed `zhlynn/zsign` project pinned to commit:
+
+`e803f870dc686e6161d00d9b22c425b8acdfacee`
+
+The workflow:
+
+- receives an IPA in a draft release inbox;
+- signs it with the configured P12 and Ad Hoc provisioning profile;
+- rewrites the requested main bundle identifier and app name;
+- publishes the signed IPA as a GitHub Release asset;
+- creates the OTA manifest;
+- updates `install/apps.json`;
+- removes the unsigned staging asset after a successful publish.
+
+## Important compatibility note
+
+A wildcard Ad Hoc profile is suitable only when the app's required entitlements are compatible with that profile. Apps using capabilities such as iCloud, Push Notifications, App Groups, Associated Domains, Network Extensions, or extension-specific entitlements may require explicit App IDs and additional provisioning profiles. Next Signer should fail rather than silently remove those capabilities.
+
+## TIPA build
+
+`build-nextsigner-tipa.yml` builds the app without an Apple code signature and packages both `.ipa` and `.tipa` artifacts for TrollStore testing.

--- a/NextSigner/project.yml
+++ b/NextSigner/project.yml
@@ -28,7 +28,6 @@ targets:
         INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
         INFOPLIST_KEY_UIFileSharingEnabled: "YES"
         INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace: "YES"
-        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
     scheme:
       shared: true
       gatherCoverageData: false

--- a/NextSigner/project.yml
+++ b/NextSigner/project.yml
@@ -1,0 +1,34 @@
+name: NextSigner
+options:
+  bundleIdPrefix: com.nextsolution
+  deploymentTarget:
+    iOS: "16.0"
+  createIntermediateGroups: true
+settings:
+  base:
+    SWIFT_VERSION: "5.7"
+    IPHONEOS_DEPLOYMENT_TARGET: "16.0"
+    TARGETED_DEVICE_FAMILY: "1"
+    SUPPORTS_MACCATALYST: "NO"
+    CODE_SIGN_STYLE: Automatic
+    MARKETING_VERSION: "1.0"
+    CURRENT_PROJECT_VERSION: "1"
+targets:
+  NextSigner:
+    type: application
+    platform: iOS
+    sources:
+      - path: NextSigner
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.nextsolution.nextsigner
+        PRODUCT_NAME: Next Signer
+        GENERATE_INFOPLIST_FILE: "YES"
+        INFOPLIST_KEY_CFBundleDisplayName: Next Signer
+        INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
+        INFOPLIST_KEY_UIFileSharingEnabled: "YES"
+        INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace: "YES"
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+    scheme:
+      shared: true
+      gatherCoverageData: false


### PR DESCRIPTION
Adds Next Signer 1.0: an iOS/TrollStore-friendly SwiftUI app that uploads an IPA to a private GitHub release inbox, triggers a GitHub Actions signing workflow using encrypted P12/provisioning secrets, publishes the signed IPA as a release asset, and automatically updates nextsolution.cc/install/.

Includes:
- iOS 16+ SwiftUI app
- Keychain storage for a repo-scoped GitHub token
- automatic bundle-ID suggestion under com.nextsolution.*
- draft-release IPA staging
- pinned zsign signing workflow
- automatic manifest/catalog publishing
- unsigned IPA/TIPA build workflow for TrollStore testing

The signing certificate and provisioning profile are never stored in the app or committed to the repository.