### PR TITLE
Next Post 1.0.4 proper LevelPlay SDK integration

### DIFF
--- a/.github/workflows/build-nextpost.yml
+++ b/.github/workflows/build-nextpost.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     runs-on: macos-15
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
       - name: Check out source
@@ -67,39 +67,41 @@ jobs:
           rm -rf Payload
           mkdir -p Payload
           cp -R "$APP_PATH" Payload/
-          ditto -c -k --sequesterRsrc --keepParent Payload NextPost-1.0.3-Article-Preview-Fix.tipa
-          shasum -a 256 NextPost-1.0.3-Article-Preview-Fix.tipa > NextPost-1.0.3-Article-Preview-Fix.sha256
+          ditto -c -k --sequesterRsrc --keepParent Payload NextPost-1.0.4-LevelPlay-Proper.tipa
+          shasum -a 256 NextPost-1.0.4-LevelPlay-Proper.tipa > NextPost-1.0.4-LevelPlay-Proper.sha256
 
           /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$APP_PATH/Info.plist"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$APP_PATH/Info.plist"
           /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Info.plist"
+          /usr/libexec/PlistBuddy -c "Print :SKAdNetworkItems:0:SKAdNetworkIdentifier" "$APP_PATH/Info.plist"
+          test -f "$APP_PATH/PrivacyInfo.xcprivacy"
           file "$APP_PATH/Next Post"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: NextPost-1.0.3-Article-Preview-Fix
+          name: NextPost-1.0.4-LevelPlay-Proper
           path: |
-            NextPost-1.0.3-Article-Preview-Fix.tipa
-            NextPost-1.0.3-Article-Preview-Fix.sha256
+            NextPost-1.0.4-LevelPlay-Proper.tipa
+            NextPost-1.0.4-LevelPlay-Proper.sha256
           if-no-files-found: error
 
       - name: Publish TIPA to repository
         if: github.event_name != 'pull_request'
         run: |
           mkdir -p applications
-          cp NextPost-1.0.3-Article-Preview-Fix.tipa applications/NextPost-1.0.3-Article-Preview-Fix.tipa
-          cp NextPost-1.0.3-Article-Preview-Fix.sha256 applications/NextPost-1.0.3-Article-Preview-Fix.sha256
+          cp NextPost-1.0.4-LevelPlay-Proper.tipa applications/NextPost-1.0.4-LevelPlay-Proper.tipa
+          cp NextPost-1.0.4-LevelPlay-Proper.sha256 applications/NextPost-1.0.4-LevelPlay-Proper.sha256
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add applications/NextPost-1.0.3-Article-Preview-Fix.tipa applications/NextPost-1.0.3-Article-Preview-Fix.sha256
+          git add applications/NextPost-1.0.4-LevelPlay-Proper.tipa applications/NextPost-1.0.4-LevelPlay-Proper.sha256
 
           if git diff --cached --quiet; then
-            echo "Next Post 1.0.3 preview-fix build is already published."
+            echo "Next Post 1.0.4 LevelPlay build is already published."
             exit 0
           fi
 
-          git commit -m "Publish Next Post 1.0.3 article preview fix TIPA"
+          git commit -m "Publish Next Post 1.0.4 LevelPlay proper TIPA"
           git pull --rebase origin main
           git push origin HEAD:main

--- a/.github/workflows/publish-nextpost-transfer.yml
+++ b/.github/workflows/publish-nextpost-transfer.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'applications/NextPost-1.0.3-Article-Preview-Fix.tipa'
+      - 'applications/NextPost-1.0.4-LevelPlay-Proper.tipa'
       - '.github/workflows/publish-nextpost-transfer.yml'
 
 permissions:
@@ -28,9 +28,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          SRC='applications/NextPost-1.0.3-Article-Preview-Fix.tipa'
-          DEST_DIR='transfer/files/NextPost/1.0.3'
-          DEST="$DEST_DIR/NextPost-1.0.3-Article-Preview-Fix.tipa"
+          SRC='applications/NextPost-1.0.4-LevelPlay-Proper.tipa'
+          DEST_DIR='transfer/files/NextPost/1.0.4'
+          DEST="$DEST_DIR/NextPost-1.0.4-LevelPlay-Proper.tipa"
           INDEX='transfer/index.json'
 
           test -s "$SRC"
@@ -49,18 +49,18 @@ jobs:
           index_path = Path('transfer/index.json')
           data = json.loads(index_path.read_text())
           files = data.get('files', [])
-          entry_id = 'nextpost-1.0.3-article-preview-fix'
+          entry_id = 'nextpost-1.0.4-levelplay-proper'
           files = [item for item in files if item.get('id') != entry_id]
           entry = {
               'id': entry_id,
-              'name': 'Next Post 1.0.3 Article Preview Fix',
-              'fileName': 'NextPost-1.0.3-Article-Preview-Fix.tipa',
+              'name': 'Next Post 1.0.4 LevelPlay Proper',
+              'fileName': 'NextPost-1.0.4-LevelPlay-Proper.tipa',
               'type': 'tipa',
               'platform': 'TrollStore / iOS 16+',
-              'version': '1.0.3',
-              'url': 'https://nextsolution.cc/transfer/files/NextPost/1.0.3/NextPost-1.0.3-Article-Preview-Fix.tipa',
+              'version': '1.0.4',
+              'url': 'https://nextsolution.cc/transfer/files/NextPost/1.0.4/NextPost-1.0.4-LevelPlay-Proper.tipa',
               'sha256': os.environ['SHA256'],
-              'notes': 'Fixes X/Twitter link cards so generated posts request the article-specific preview instead of the generic Next Solution image. Uses a cache-busting social share URL while keeping the clean canonical article route. Ads are not included in this build.'
+              'notes': 'Proper native Unity LevelPlay integration using the official Swift Package. Includes the configured Next Post app key, adaptive bottom banner, frequency-limited interstitial after five successful generations, ATS/SKAdNetwork/privacy configuration, adapter debug logging for device testing, and retains the article-specific X preview fix. Live ads still depend on LevelPlay account approval; configure this iPhone as a LevelPlay test device to force test inventory while approval is pending.'
           }
           data['files'] = [entry] + files
           data['updatedAt'] = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
@@ -68,7 +68,7 @@ jobs:
           PY
 
           python3 -m json.tool "$INDEX" >/dev/null
-          grep -q 'nextpost-1.0.3-article-preview-fix' "$INDEX"
+          grep -q 'nextpost-1.0.4-levelplay-proper' "$INDEX"
           grep -q "$SHA256" "$INDEX"
           test "$(sha256sum "$DEST" | awk '{print $1}')" = "$SHA256"
 
@@ -78,7 +78,7 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add transfer/files/NextPost/1.0.3/NextPost-1.0.3-Article-Preview-Fix.tipa transfer/index.json
-          git commit -m 'Publish Next Post 1.0.3 article preview fix to Transfer' || true
+          git add transfer/files/NextPost/1.0.4/NextPost-1.0.4-LevelPlay-Proper.tipa transfer/index.json
+          git commit -m 'Publish Next Post 1.0.4 LevelPlay proper to Transfer' || true
           git pull --rebase origin main
           git push origin HEAD:main

--- a/NextPost/Info.plist
+++ b/NextPost/Info.plist
@@ -20,6 +20,21 @@
     <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
     <string>$(CURRENT_PROJECT_VERSION)</string>
+
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+
+    <key>SKAdNetworkItems</key>
+    <array>
+        <dict>
+            <key>SKAdNetworkIdentifier</key>
+            <string>su67r6k2v3.skadnetwork</string>
+        </dict>
+    </array>
+
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>UILaunchScreen</key>

--- a/NextPost/PrivacyInfo.xcprivacy
+++ b/NextPost/PrivacyInfo.xcprivacy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/NextPost/Sources/AdsManager.swift
+++ b/NextPost/Sources/AdsManager.swift
@@ -1,0 +1,284 @@
+import SwiftUI
+import UIKit
+import IronSource
+
+@MainActor
+final class AdsManager: NSObject {
+    static let shared = AdsManager()
+
+    static let appKey = "27ad6d08d"
+    static let bannerAdUnitID = "3enr8l0rqws9op9z"
+    static let interstitialAdUnitID = "y23pc99ate029uga"
+
+    private(set) var isInitialized = false
+    private(set) var lastInitError: String?
+    private var isInitializing = false
+    private var interstitialAd: LPMInterstitialAd?
+    private var generationsSinceInterstitial = 0
+    private var interstitialRetryWorkItem: DispatchWorkItem?
+
+    private override init() {
+        super.init()
+    }
+
+    func initializeIfNeeded() {
+        guard !isInitialized, !isInitializing else { return }
+        isInitializing = true
+        lastInitError = nil
+
+        // Next Post is a general-audience utility, not a child-directed app.
+        LPMPrivacySettings.setCOPPA(false)
+
+        // Keep adapter diagnostics enabled in this test build so failures can be
+        // identified from device logs. Disable before the App Store release.
+        LevelPlay.setAdaptersDebug(true)
+
+        let request = LPMInitRequestBuilder(appKey: Self.appKey).build()
+        LevelPlay.initWith(request) { [weak self] _, error in
+            Task { @MainActor in
+                guard let self else { return }
+                self.isInitializing = false
+
+                if let error {
+                    self.isInitialized = false
+                    self.lastInitError = error.localizedDescription
+                    print("[NextPost][LevelPlay] init failed: \(error)")
+                    self.scheduleInitializationRetry()
+                    return
+                }
+
+                self.isInitialized = true
+                self.lastInitError = nil
+                print("[NextPost][LevelPlay] initialized with app key \(Self.appKey)")
+                self.configureInterstitial()
+            }
+        }
+    }
+
+    func recordSuccessfulGeneration() {
+        guard isInitialized else { return }
+        generationsSinceInterstitial += 1
+
+        guard generationsSinceInterstitial >= 5 else { return }
+        guard let interstitialAd, interstitialAd.isAdReady() else {
+            if interstitialAd == nil {
+                configureInterstitial()
+            } else {
+                interstitialAd.loadAd()
+            }
+            return
+        }
+        guard let presenter = Self.topViewController() else { return }
+
+        generationsSinceInterstitial = 0
+        interstitialAd.showAd(viewController: presenter, placementName: nil)
+    }
+
+    private func configureInterstitial() {
+        guard isInitialized else { return }
+        interstitialRetryWorkItem?.cancel()
+
+        if interstitialAd == nil {
+            let ad = LPMInterstitialAd(adUnitId: Self.interstitialAdUnitID)
+            ad.setDelegate(self)
+            interstitialAd = ad
+        }
+
+        interstitialAd?.loadAd()
+    }
+
+    private func scheduleInitializationRetry() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 15) { [weak self] in
+            self?.initializeIfNeeded()
+        }
+    }
+
+    private func scheduleInterstitialRetry() {
+        interstitialRetryWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            self?.interstitialAd?.loadAd()
+        }
+        interstitialRetryWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30, execute: item)
+    }
+
+    private static func topViewController() -> UIViewController? {
+        let root = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first(where: { $0.isKeyWindow })?
+            .rootViewController
+        return topViewController(from: root)
+    }
+
+    private static func topViewController(from root: UIViewController?) -> UIViewController? {
+        if let nav = root as? UINavigationController {
+            return topViewController(from: nav.visibleViewController)
+        }
+        if let tab = root as? UITabBarController {
+            return topViewController(from: tab.selectedViewController)
+        }
+        if let presented = root?.presentedViewController {
+            return topViewController(from: presented)
+        }
+        return root
+    }
+}
+
+extension AdsManager: @preconcurrency LPMInterstitialAdDelegate {
+    func didLoadAd(with adInfo: LPMAdInfo) {
+        print("[NextPost][LevelPlay] interstitial loaded")
+    }
+
+    func didFailToLoadAd(withAdUnitId adUnitId: String, error: Error) {
+        print("[NextPost][LevelPlay] interstitial load failed \(adUnitId): \(error)")
+        scheduleInterstitialRetry()
+    }
+
+    func didChangeAdInfo(_ adInfo: LPMAdInfo) {}
+
+    func didDisplayAd(with adInfo: LPMAdInfo) {
+        print("[NextPost][LevelPlay] interstitial displayed")
+    }
+
+    func didFailToDisplayAd(with adInfo: LPMAdInfo, error: Error) {
+        print("[NextPost][LevelPlay] interstitial display failed: \(error)")
+        scheduleInterstitialRetry()
+    }
+
+    func didClickAd(with adInfo: LPMAdInfo) {}
+
+    func didCloseAd(with adInfo: LPMAdInfo) {
+        interstitialAd?.loadAd()
+    }
+}
+
+struct LevelPlayBannerView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> LevelPlayBannerHostController {
+        LevelPlayBannerHostController()
+    }
+
+    func updateUIViewController(_ uiViewController: LevelPlayBannerHostController, context: Context) {
+        uiViewController.loadIfReady()
+    }
+}
+
+@MainActor
+final class LevelPlayBannerHostController: UIViewController, @preconcurrency LPMBannerAdViewDelegate {
+    private var bannerAd: LPMBannerAdView?
+    private var retryWorkItem: DispatchWorkItem?
+    private var retryCount = 0
+
+    private lazy var statusLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Ad loading…"
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 10, weight: .medium)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+        view.addSubview(statusLabel)
+        NSLayoutConstraint.activate([
+            statusLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8),
+            statusLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8),
+            statusLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+        loadIfReady()
+    }
+
+    func loadIfReady() {
+        guard bannerAd == nil else { return }
+
+        AdsManager.shared.initializeIfNeeded()
+        guard AdsManager.shared.isInitialized else {
+            statusLabel.text = AdsManager.shared.lastInitError.map { "Ad SDK error: \($0)" } ?? "Initializing ad SDK…"
+            scheduleRetry(after: 1)
+            return
+        }
+
+        guard let bannerSize = LPMAdSize.createAdaptive() else {
+            statusLabel.text = "Could not create banner size"
+            return
+        }
+
+        let config = LPMBannerAdViewConfigBuilder()
+            .set(adSize: bannerSize)
+            .set(placementName: "NextPostBottom")
+            .build()
+
+        let banner = LPMBannerAdView(adUnitId: AdsManager.bannerAdUnitID, config: config)
+        banner.setDelegate(self)
+        banner.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(banner)
+
+        NSLayoutConstraint.activate([
+            banner.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            banner.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            banner.widthAnchor.constraint(equalToConstant: CGFloat(bannerSize.width)),
+            banner.heightAnchor.constraint(equalToConstant: CGFloat(bannerSize.height))
+        ])
+
+        bannerAd = banner
+        statusLabel.text = "Requesting LevelPlay banner…"
+        banner.loadAd(with: self)
+    }
+
+    private func scheduleRetry(after seconds: TimeInterval) {
+        retryWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            self?.loadIfReady()
+        }
+        retryWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: item)
+    }
+
+    deinit {
+        retryWorkItem?.cancel()
+        if let bannerAd {
+            Task { @MainActor in
+                bannerAd.destroy()
+            }
+        }
+    }
+
+    func didLoadAd(with adInfo: LPMAdInfo) {
+        retryCount = 0
+        statusLabel.isHidden = true
+        print("[NextPost][LevelPlay] banner loaded")
+    }
+
+    func didFailToLoadAd(withAdUnitId adUnitId: String, error: Error) {
+        statusLabel.isHidden = false
+        statusLabel.text = "Banner unavailable: \(error.localizedDescription)"
+        print("[NextPost][LevelPlay] banner load failed \(adUnitId): \(error)")
+
+        guard retryCount < 2 else { return }
+        retryCount += 1
+        bannerAd?.destroy()
+        bannerAd = nil
+        scheduleRetry(after: 30)
+    }
+
+    func didClickAd(with adInfo: LPMAdInfo) {}
+
+    func didDisplayAd(with adInfo: LPMAdInfo) {
+        statusLabel.isHidden = true
+        print("[NextPost][LevelPlay] banner displayed")
+    }
+
+    func didFailToDisplayAd(with adInfo: LPMAdInfo, error: Error) {
+        statusLabel.isHidden = false
+        statusLabel.text = "Banner display failed: \(error.localizedDescription)"
+        print("[NextPost][LevelPlay] banner display failed: \(error)")
+    }
+
+    func didLeaveApp(with adInfo: LPMAdInfo) {}
+    func didExpandAd(with adInfo: LPMAdInfo) {}
+    func didCollapseAd(with adInfo: LPMAdInfo) {}
+}

--- a/NextPost/Sources/AdsManager.swift
+++ b/NextPost/Sources/AdsManager.swift
@@ -60,18 +60,18 @@ final class AdsManager: NSObject {
         generationsSinceInterstitial += 1
 
         guard generationsSinceInterstitial >= 5 else { return }
-        guard let interstitialAd, interstitialAd.isAdReady() else {
+        guard let readyInterstitial = interstitialAd, readyInterstitial.isAdReady() else {
             if interstitialAd == nil {
                 configureInterstitial()
             } else {
-                interstitialAd.loadAd()
+                interstitialAd?.loadAd()
             }
             return
         }
         guard let presenter = Self.topViewController() else { return }
 
         generationsSinceInterstitial = 0
-        interstitialAd.showAd(viewController: presenter, placementName: nil)
+        readyInterstitial.showAd(viewController: presenter, placementName: nil)
     }
 
     private func configureInterstitial() {

--- a/NextPost/Sources/ContentView.swift
+++ b/NextPost/Sources/ContentView.swift
@@ -30,6 +30,9 @@ struct ContentView: View {
                 .padding(.bottom, 30)
             }
         }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            adBanner
+        }
         .task {
             await store.refreshStats()
         }
@@ -232,6 +235,20 @@ struct ContentView: View {
         }
         .buttonStyle(.plain)
         .opacity(store.generatedPost.isEmpty ? 0.55 : 1)
+    }
+
+    private var adBanner: some View {
+        VStack(spacing: 2) {
+            Text("ADVERTISEMENT")
+                .font(.system(size: 8, weight: .medium))
+                .foregroundStyle(.tertiary)
+
+            LevelPlayBannerView()
+                .frame(maxWidth: .infinity)
+                .frame(height: 58)
+        }
+        .padding(.top, 3)
+        .background(Color.black.opacity(0.96))
     }
 
     private var sourceFooter: some View {

--- a/NextPost/Sources/NextPostApp.swift
+++ b/NextPost/Sources/NextPostApp.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 @main
 struct NextPostApp: App {
+    init() {
+        AdsManager.shared.initializeIfNeeded()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/NextPost/Sources/NextPostStore.swift
+++ b/NextPost/Sources/NextPostStore.swift
@@ -111,6 +111,7 @@ final class NextPostStore: ObservableObject {
                 : "\(remainingThisCycle) article\(remainingThisCycle == 1 ? "" : "s") left before repeats"
 
             persist()
+            AdsManager.shared.recordSuccessfulGeneration()
         } catch {
             errorMessage = error.localizedDescription
             statusText = "Generation failed"

--- a/NextPost/project.yml
+++ b/NextPost/project.yml
@@ -5,6 +5,11 @@ options:
     iOS: "16.0"
   createIntermediateGroups: true
 
+packages:
+  LevelPlay:
+    url: https://github.com/ironsource-mobile/LevelPlay-Swift-Package
+    branch: main
+
 settings:
   base:
     SWIFT_VERSION: "5.9"
@@ -12,8 +17,9 @@ settings:
     TARGETED_DEVICE_FAMILY: "1"
     SUPPORTS_MACCATALYST: "NO"
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "1.0.3"
-    CURRENT_PROJECT_VERSION: "3"
+    MARKETING_VERSION: "1.0.4"
+    CURRENT_PROJECT_VERSION: "4"
+    OTHER_LDFLAGS: "$(inherited) -ObjC"
 
 targets:
   NextPost:
@@ -23,6 +29,11 @@ targets:
       - path: Sources
       - path: Assets.xcassets
         buildPhase: resources
+      - path: PrivacyInfo.xcprivacy
+        buildPhase: resources
+    dependencies:
+      - package: LevelPlay
+        product: UnityMediationSDK
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.nextsolution.nextpost


### PR DESCRIPTION
Proper native iOS LevelPlay integration for Next Post 1.0.4. Attaches the official LevelPlay Swift Package, initializes with the app key, implements Banner + Interstitial ad-unit APIs, adds required iOS ATS/SKAdNetwork/privacy manifest configuration, preserves the 1.0.3 article-preview fix, and keeps diagnostic adapter logging for device testing. Interstitial is frequency-limited to every 5 successful generations when ready.