### PR TITLE
Next Post 1.0.7 complete LevelPlay iOS guide setup

### DIFF
--- a/.github/workflows/build-nextpost.yml
+++ b/.github/workflows/build-nextpost.yml
@@ -67,13 +67,13 @@ jobs:
           rm -rf Payload
           mkdir -p Payload
           cp -R "$APP_PATH" Payload/
-          ditto -c -k --sequesterRsrc --keepParent Payload NextPost-1.0.6-Test-Device-ID.tipa
-          shasum -a 256 NextPost-1.0.6-Test-Device-ID.tipa > NextPost-1.0.6-Test-Device-ID.sha256
+          ditto -c -k --sequesterRsrc --keepParent Payload NextPost-1.0.7-LevelPlay-Guide-Complete.tipa
+          shasum -a 256 NextPost-1.0.7-LevelPlay-Guide-Complete.tipa > NextPost-1.0.7-LevelPlay-Guide-Complete.sha256
 
           /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$APP_PATH/Info.plist"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$APP_PATH/Info.plist"
           /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Info.plist"
-          /usr/libexec/PlistBuddy -c "Print :NSUserTrackingUsageDescription" "$APP_PATH/Info.plist"
+          /usr/libexec/PlistBuddy -c "Print :NSAdvertisingAttributionReportEndpoint" "$APP_PATH/Info.plist"
           /usr/libexec/PlistBuddy -c "Print :SKAdNetworkItems:0:SKAdNetworkIdentifier" "$APP_PATH/Info.plist"
           test -f "$APP_PATH/PrivacyInfo.xcprivacy"
           file "$APP_PATH/Next Post"
@@ -81,28 +81,28 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: NextPost-1.0.6-Test-Device-ID
+          name: NextPost-1.0.7-LevelPlay-Guide-Complete
           path: |
-            NextPost-1.0.6-Test-Device-ID.tipa
-            NextPost-1.0.6-Test-Device-ID.sha256
+            NextPost-1.0.7-LevelPlay-Guide-Complete.tipa
+            NextPost-1.0.7-LevelPlay-Guide-Complete.sha256
           if-no-files-found: error
 
       - name: Publish TIPA to repository
         if: github.event_name != 'pull_request'
         run: |
           mkdir -p applications
-          cp NextPost-1.0.6-Test-Device-ID.tipa applications/NextPost-1.0.6-Test-Device-ID.tipa
-          cp NextPost-1.0.6-Test-Device-ID.sha256 applications/NextPost-1.0.6-Test-Device-ID.sha256
+          cp NextPost-1.0.7-LevelPlay-Guide-Complete.tipa applications/NextPost-1.0.7-LevelPlay-Guide-Complete.tipa
+          cp NextPost-1.0.7-LevelPlay-Guide-Complete.sha256 applications/NextPost-1.0.7-LevelPlay-Guide-Complete.sha256
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add applications/NextPost-1.0.6-Test-Device-ID.tipa applications/NextPost-1.0.6-Test-Device-ID.sha256
+          git add applications/NextPost-1.0.7-LevelPlay-Guide-Complete.tipa applications/NextPost-1.0.7-LevelPlay-Guide-Complete.sha256
 
           if git diff --cached --quiet; then
-            echo "Next Post 1.0.6 test device helper is already published."
+            echo "Next Post 1.0.7 LevelPlay guide-complete build is already published."
             exit 0
           fi
 
-          git commit -m "Publish Next Post 1.0.6 test device helper TIPA"
+          git commit -m "Publish Next Post 1.0.7 LevelPlay guide complete TIPA"
           git pull --rebase origin main
           git push origin HEAD:main

--- a/.github/workflows/publish-nextpost-transfer.yml
+++ b/.github/workflows/publish-nextpost-transfer.yml
@@ -1,12 +1,12 @@
 name: Publish Next Post to Transfer
 
-# 1.0.6 LevelPlay test-device ID helper publication trigger (forced after build)
+# 1.0.7 LevelPlay guide-complete publication trigger
 on:
   workflow_dispatch:
   push:
     branches: [main]
     paths:
-      - 'applications/NextPost-1.0.6-Test-Device-ID.tipa'
+      - 'applications/NextPost-1.0.7-LevelPlay-Guide-Complete.tipa'
       - '.github/workflows/publish-nextpost-transfer.yml'
 
 permissions:
@@ -29,9 +29,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          SRC='applications/NextPost-1.0.6-Test-Device-ID.tipa'
-          DEST_DIR='transfer/files/NextPost/1.0.6'
-          DEST="$DEST_DIR/NextPost-1.0.6-Test-Device-ID.tipa"
+          SRC='applications/NextPost-1.0.7-LevelPlay-Guide-Complete.tipa'
+          DEST_DIR='transfer/files/NextPost/1.0.7'
+          DEST="$DEST_DIR/NextPost-1.0.7-LevelPlay-Guide-Complete.tipa"
           INDEX='transfer/index.json'
 
           test -s "$SRC"
@@ -50,18 +50,18 @@ jobs:
           index_path = Path('transfer/index.json')
           data = json.loads(index_path.read_text())
           files = data.get('files', [])
-          entry_id = 'nextpost-1.0.6-test-device-id'
+          entry_id = 'nextpost-1.0.7-levelplay-guide-complete'
           files = [item for item in files if item.get('id') != entry_id]
           entry = {
               'id': entry_id,
-              'name': 'Next Post 1.0.6 Test Device ID',
-              'fileName': 'NextPost-1.0.6-Test-Device-ID.tipa',
+              'name': 'Next Post 1.0.7 LevelPlay Guide Complete',
+              'fileName': 'NextPost-1.0.7-LevelPlay-Guide-Complete.tipa',
               'type': 'tipa',
               'platform': 'TrollStore / iOS 16+',
-              'version': '1.0.6',
-              'url': 'https://nextsolution.cc/transfer/files/NextPost/1.0.6/NextPost-1.0.6-Test-Device-ID.tipa',
+              'version': '1.0.7',
+              'url': 'https://nextsolution.cc/transfer/files/NextPost/1.0.7/NextPost-1.0.7-LevelPlay-Guide-Complete.tipa',
               'sha256': os.environ['SHA256'],
-              'notes': 'Adds an in-app LevelPlay test-device helper. Tap Test ID, grant Apple tracking permission, copy the iPhone Advertising ID (IDFA), and paste it into LevelPlay Setup > Test devices. Keeps the corrected banner ID and native LevelPlay integration.'
+              'notes': 'Aligns Next Post with Unity LevelPlay iOS setup guidance: official Swift Package integration, -ObjC, z/sqlite3 and required Apple frameworks, ironSource SKAdNetwork ID, Universal SKAN postback endpoint, ATS settings, corrected banner/interstitial IDs, and existing native LevelPlay initialization.'
           }
           data['files'] = [entry] + files
           data['updatedAt'] = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
@@ -69,7 +69,7 @@ jobs:
           PY
 
           python3 -m json.tool "$INDEX" >/dev/null
-          grep -q 'nextpost-1.0.6-test-device-id' "$INDEX"
+          grep -q 'nextpost-1.0.7-levelplay-guide-complete' "$INDEX"
           grep -q "$SHA256" "$INDEX"
           test "$(sha256sum "$DEST" | awk '{print $1}')" = "$SHA256"
 
@@ -79,7 +79,7 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add transfer/files/NextPost/1.0.6/NextPost-1.0.6-Test-Device-ID.tipa transfer/index.json
-          git commit -m 'Publish Next Post 1.0.6 test device helper to Transfer' || true
+          git add transfer/files/NextPost/1.0.7/NextPost-1.0.7-LevelPlay-Guide-Complete.tipa transfer/index.json
+          git commit -m 'Publish Next Post 1.0.7 LevelPlay guide complete to Transfer' || true
           git pull --rebase origin main
           git push origin HEAD:main

--- a/NextPost/Info.plist
+++ b/NextPost/Info.plist
@@ -22,7 +22,10 @@
     <string>$(CURRENT_PROJECT_VERSION)</string>
 
     <key>NSUserTrackingUsageDescription</key>
-    <string>Next Post uses the device advertising identifier to support and test advertising delivery.</string>
+    <string>Next Post uses the device advertising identifier to support advertising delivery and measurement.</string>
+
+    <key>NSAdvertisingAttributionReportEndpoint</key>
+    <string>https://postbacks-is.com/</string>
 
     <key>NSAppTransportSecurity</key>
     <dict>

--- a/NextPost/project.yml
+++ b/NextPost/project.yml
@@ -17,9 +17,9 @@ settings:
     TARGETED_DEVICE_FAMILY: "1"
     SUPPORTS_MACCATALYST: "NO"
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "1.0.6"
-    CURRENT_PROJECT_VERSION: "6"
-    OTHER_LDFLAGS: "$(inherited) -ObjC"
+    MARKETING_VERSION: "1.0.7"
+    CURRENT_PROJECT_VERSION: "7"
+    OTHER_LDFLAGS: "$(inherited) -ObjC -lz -lsqlite3 -framework JavaScriptCore -framework WebKit -framework AdSupport -framework SystemConfiguration"
 
 targets:
   NextPost:


### PR DESCRIPTION
Aligns Next Post with the Unity LevelPlay iOS integration guide supplied by the user. Keeps the supported Swift Package integration rather than duplicating the SDK manually, adds the missing Universal SKAN postback endpoint, explicitly links z/sqlite3 plus JavaScriptCore/WebKit/AdSupport/SystemConfiguration along with -ObjC, retains SKAdNetwork and ATS settings, bumps to 1.0.7, and updates TIPA/NS Transfer workflows. This configuration cleanup does not by itself guarantee fill while the ironSource account/app has no live inventory or is pending approval.