### PR TITLE
Fix NextLock SpringBoard CPU drain in photo frames

### DIFF
--- a/.github/workflows/test-nextlock-115-cpu.yml
+++ b/.github/workflows/test-nextlock-115-cpu.yml
@@ -1,0 +1,126 @@
+name: Test NextLock 1.1.5 CPU Fix
+
+on:
+  push:
+    branches: [fix/nextlock-1.1.5-cpu]
+    paths:
+      - "DailyTweaks/LockGlyphTime/**"
+      - ".github/workflows/test-nextlock-115-cpu.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nextlock-115-cpu-test
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-15
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: brew install dpkg ldid xz zstd
+
+      - name: Generate 1.1.5 source and validate hot-path fix
+        shell: bash
+        run: |
+          set -euo pipefail
+          P="$GITHUB_WORKSPACE/DailyTweaks/LockGlyphTime"
+          cd "$P"
+          python3 prefs/generate_root.py
+          python3 patch_v023.py
+          python3 patch_v024.py
+          python3 patch_v025.py
+          python3 patch_v026.py
+          python3 patch_v027.py
+          python3 patch_v028.py
+          python3 patch_v029.py
+          python3 patch_v030.py
+          python3 patch_v031.py
+          python3 patch_v032.py
+          python3 patch_v033.py
+
+          grep -q '^Version: 1.1.5$' control
+          grep -q 'gPhotoSlotIsSticker\[4\]' RuntimeV023.xm
+          grep -q 'gPhotoSlotDisplayImage\[4\]' RuntimeV023.xm
+          grep -q 'BOOL sticker=gPhotoSlotIsSticker\[i\]' RuntimeV023.xm
+          grep -q 'if(photoView.image != displayImage) photoView.image=displayImage' RuntimeV023.xm
+
+          # The expensive alpha probe is allowed during preference/photo load,
+          # but it must not appear inside LGTApplyPhotoFrames anymore.
+          python3 - <<'PY'
+          from pathlib import Path
+          s=Path('RuntimeV023.xm').read_text()
+          start=s.index('static void LGTApplyPhotoFrames(')
+          end=s.index('static void LGTResetContainerBeforeAppleLayout', start)
+          body=s[start:end]
+          assert 'LGTImageHasVisibleTransparency(' not in body, body
+          assert 'gPhotoSlotIsSticker[i]' in body
+          print('PASS: no transparency bitmap scan in photo-frame layout path')
+          PY
+
+      - name: Build Rootless
+        shell: bash
+        run: |
+          set -euo pipefail
+          P="$GITHUB_WORKSPACE/DailyTweaks/LockGlyphTime"
+          OUT="$RUNNER_TEMP/nextlock-115"
+          mkdir -p "$OUT"
+          git clone --recursive --depth 1 https://github.com/theos/theos.git "$RUNNER_TEMP/theos-rootless"
+          export THEOS="$RUNNER_TEMP/theos-rootless" THEOS_PACKAGE_SCHEME=rootless
+          rm -rf "$P/packages"
+          make -C "$P" clean package FINALPACKAGE=1
+          DEB="$(find "$P/packages" -type f -name '*_iphoneos-arm64.deb' -print -quit)"
+          test -n "$DEB"
+          cp "$DEB" "$OUT/NextLock_1.1.5_Rootless.deb"
+
+      - name: Build RootHide
+        shell: bash
+        run: |
+          set -euo pipefail
+          P="$GITHUB_WORKSPACE/DailyTweaks/LockGlyphTime"
+          OUT="$RUNNER_TEMP/nextlock-115"
+          git init "$RUNNER_TEMP/theos-roothide"
+          git -C "$RUNNER_TEMP/theos-roothide" remote add origin https://github.com/roothide/theos.git
+          git -C "$RUNNER_TEMP/theos-roothide" fetch --depth 1 origin 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+          git -C "$RUNNER_TEMP/theos-roothide" checkout --detach 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+          git -C "$RUNNER_TEMP/theos-roothide" submodule update --init --recursive --depth 1
+          sed -i '' 's/^Architecture: iphoneos-arm64$/Architecture: iphoneos-arm64e/' "$P/control"
+          export THEOS="$RUNNER_TEMP/theos-roothide" THEOS_PACKAGE_SCHEME=roothide
+          rm -rf "$P/packages"
+          make -C "$P" clean package FINALPACKAGE=1
+          DEB="$(find "$P/packages" -type f -name '*_iphoneos-arm64e.deb' -print -quit)"
+          test -n "$DEB"
+          cp "$DEB" "$OUT/NextLock_1.1.5_RootHide.deb"
+
+      - name: Validate packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/nextlock-115"
+          for deb in "$OUT"/*.deb; do
+            test "$(dpkg-deb -f "$deb" Version)" = 1.1.5
+            x="$(mktemp -d)"
+            dpkg-deb -x "$deb" "$x"
+            dylib="$(find "$x" -name LockGlyphTime.dylib -print -quit)"
+            test -n "$dylib"
+            strings -a "$dylib" | grep -q 'LGTImageHasVisibleTransparency'
+            strings -a "$dylib" | grep -q 'gPhotoSlotIsSticker'
+            rm -rf "$x"
+          done
+          shasum -a 256 "$OUT"/*.deb | tee "$OUT/SHA256SUMS.txt"
+
+      - name: Upload test packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: NextLock-1.1.5-CPU-Fix-DEBs
+          path: |
+            ${{ runner.temp }}/nextlock-115/NextLock_1.1.5_Rootless.deb
+            ${{ runner.temp }}/nextlock-115/NextLock_1.1.5_RootHide.deb
+            ${{ runner.temp }}/nextlock-115/SHA256SUMS.txt
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/test-nextlock-115-cpu.yml
+++ b/.github/workflows/test-nextlock-115-cpu.yml
@@ -6,13 +6,18 @@ on:
     paths:
       - "DailyTweaks/LockGlyphTime/**"
       - ".github/workflows/test-nextlock-115-cpu.yml"
+  pull_request:
+    branches: [agent/lockglyphtime]
+    paths:
+      - "DailyTweaks/LockGlyphTime/**"
+      - ".github/workflows/test-nextlock-115-cpu.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: nextlock-115-cpu-test
+  group: nextlock-115-cpu-test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -50,8 +55,6 @@ jobs:
           grep -q 'BOOL sticker=gPhotoSlotIsSticker\[i\]' RuntimeV023.xm
           grep -q 'if(photoView.image != displayImage) photoView.image=displayImage' RuntimeV023.xm
 
-          # The expensive alpha probe is allowed during preference/photo load,
-          # but it must not appear inside LGTApplyPhotoFrames anymore.
           python3 - <<'PY'
           from pathlib import Path
           s=Path('RuntimeV023.xm').read_text()

--- a/DailyTweaks/LockGlyphTime/Makefile
+++ b/DailyTweaks/LockGlyphTime/Makefile
@@ -18,6 +18,7 @@ before-all::
 	python3 patch_v030.py
 	python3 patch_v031.py
 	python3 patch_v032.py
+	python3 patch_v033.py
 	python3 generate_nextlock_icon.py
 
 TWEAK_NAME = LockGlyphTime

--- a/DailyTweaks/LockGlyphTime/patch_v033.py
+++ b/DailyTweaks/LockGlyphTime/patch_v033.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import plistlib
+
+ROOT = Path(__file__).resolve().parent
+runtime_path = ROOT / 'RuntimeV023.xm'
+runtime = runtime_path.read_text()
+
+# ---------------------------------------------------------------------------
+# NextLock 1.1.5 CPU fix
+#
+# 1.1.4 classified every custom photo as "sticker vs opaque photo" from
+# LGTApplyPhotoFrames(). That method runs from the lock-screen layout/geometry
+# path. LGTImageHasVisibleTransparency() draws the image into a temporary
+# bitmap and scans its alpha bytes, which sends SpringBoard through
+# CoreGraphics/vImage on every layout pass (up to four times per pass).
+#
+# Preserve the exact visual behavior, but classify each decoded image ONCE
+# when preferences/photo data are loaded. Runtime layout then performs only a
+# cached boolean lookup and reuses a cached AlwaysOriginal UIImage.
+# ---------------------------------------------------------------------------
+
+globals_anchor = 'static UIImage *gPhotoSlotImage[4] = {nil,nil,nil,nil};'
+globals_new = globals_anchor + r'''
+static UIImage *gPhotoSlotDisplayImage[4] = {nil,nil,nil,nil};
+static BOOL gPhotoSlotIsSticker[4] = {NO,NO,NO,NO};'''
+if globals_anchor not in runtime:
+    raise SystemExit('1.1.4 photo slot globals anchor not found')
+runtime = runtime.replace(globals_anchor, globals_new, 1)
+
+load_anchor = r'''    for(NSInteger i=1;i<4;i++) {
+        NSString *dataKey=[NSString stringWithFormat:@"customPhotoData%ld",(long)(i+1)];
+        id slotData=[prefs objectForKey:dataKey];
+        gPhotoSlotData[i]=[slotData isKindOfClass:NSData.class]?slotData:nil;
+        gPhotoSlotImage[i]=gPhotoSlotData[i].length?[UIImage imageWithData:gPhotoSlotData[i]]:nil;
+    }'''
+load_new = load_anchor + r'''
+
+    // EXPENSIVE IMAGE CLASSIFICATION MUST NEVER RUN FROM layoutSubviews.
+    // A 32x32 alpha probe still uses CoreGraphics/vImage internally, so do it
+    // once per preference/photo reload and cache the answer for each frame.
+    for(NSInteger i=0;i<4;i++) {
+        UIImage *decoded=gPhotoSlotImage[i];
+        if(decoded) {
+            gPhotoSlotIsSticker[i]=LGTImageHasVisibleTransparency(decoded);
+            gPhotoSlotDisplayImage[i]=[decoded imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+        } else {
+            gPhotoSlotIsSticker[i]=NO;
+            gPhotoSlotDisplayImage[i]=nil;
+        }
+    }'''
+if load_anchor not in runtime:
+    raise SystemExit('1.1.4 photo decode block not found')
+runtime = runtime.replace(load_anchor, load_new, 1)
+
+hot_old = r'''        UIImageView *photoView=host.imageView;
+        BOOL sticker=LGTImageHasVisibleTransparency(image);
+        photoView.image=[image imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];'''
+hot_new = r'''        UIImageView *photoView=host.imageView;
+        BOOL sticker=gPhotoSlotIsSticker[i];
+        UIImage *displayImage=gPhotoSlotDisplayImage[i]?:image;
+        if(photoView.image != displayImage) photoView.image=displayImage;'''
+if hot_old not in runtime:
+    raise SystemExit('1.1.4 per-layout transparency probe not found')
+runtime = runtime.replace(hot_old, hot_new, 1)
+
+runtime_path.write_text(runtime)
+
+# ---------------------------------------------------------------------------
+# Metadata: 1.1.5 is a feature-preserving performance/stability release.
+# ---------------------------------------------------------------------------
+control_path = ROOT / 'control'
+control = control_path.read_text()
+if 'Version: 1.1.4' not in control:
+    raise SystemExit('expected 1.1.4 control version not found')
+control = control.replace('Version: 1.1.4', 'Version: 1.1.5', 1)
+lines = control.splitlines()
+for i, line in enumerate(lines):
+    if line.startswith('Description:'):
+        lines[i] = ('Description: Next Solution lock-screen customization suite. '
+                    'Version 1.1.5 keeps all four independent custom-photo/sticker frames '
+                    'while eliminating repeated CoreGraphics/vImage transparency scans from '
+                    'SpringBoard layout passes.')
+        break
+control_path.write_text('\n'.join(lines) + '\n')
+
+resources = ROOT / 'prefs' / 'Resources'
+info_path = resources / 'Info.plist'
+info = plistlib.loads(info_path.read_bytes())
+info['CFBundleShortVersionString'] = '1.1.5'
+info['CFBundleVersion'] = '115'
+info_path.write_bytes(plistlib.dumps(info, fmt=plistlib.FMT_XML, sort_keys=False))
+
+about_path = resources / 'About.plist'
+about = plistlib.loads(about_path.read_bytes())
+for item in about.get('items', []):
+    footer = item.get('footerText')
+    if isinstance(footer, str):
+        item['footerText'] = footer.replace('Version 1.1.4', 'Version 1.1.5')
+about_path.write_bytes(plistlib.dumps(about, fmt=plistlib.FMT_XML, sort_keys=False))
+
+print('Patched NextLock 1.1.5: cached photo transparency classification; no vImage work in layoutSubviews')

--- a/DailyTweaks/LockGlyphTime/patch_v033.py
+++ b/DailyTweaks/LockGlyphTime/patch_v033.py
@@ -18,23 +18,27 @@ runtime = runtime_path.read_text()
 # Preserve the exact visual behavior, but classify each decoded image ONCE
 # when preferences/photo data are loaded. Runtime layout then performs only a
 # cached boolean lookup and reuses a cached AlwaysOriginal UIImage.
+#
+# Keep this patch idempotent because CI may generate sources once for static
+# validation and Makefile's before-all target generates them again.
 # ---------------------------------------------------------------------------
 
-globals_anchor = 'static UIImage *gPhotoSlotImage[4] = {nil,nil,nil,nil};'
-globals_new = globals_anchor + r'''
+if 'static BOOL gPhotoSlotIsSticker[4]' not in runtime:
+    globals_anchor = 'static UIImage *gPhotoSlotImage[4] = {nil,nil,nil,nil};'
+    globals_new = globals_anchor + r'''
 static UIImage *gPhotoSlotDisplayImage[4] = {nil,nil,nil,nil};
 static BOOL gPhotoSlotIsSticker[4] = {NO,NO,NO,NO};'''
-if globals_anchor not in runtime:
-    raise SystemExit('1.1.4 photo slot globals anchor not found')
-runtime = runtime.replace(globals_anchor, globals_new, 1)
+    if globals_anchor not in runtime:
+        raise SystemExit('1.1.4 photo slot globals anchor not found')
+    runtime = runtime.replace(globals_anchor, globals_new, 1)
 
-load_anchor = r'''    for(NSInteger i=1;i<4;i++) {
+    load_anchor = r'''    for(NSInteger i=1;i<4;i++) {
         NSString *dataKey=[NSString stringWithFormat:@"customPhotoData%ld",(long)(i+1)];
         id slotData=[prefs objectForKey:dataKey];
         gPhotoSlotData[i]=[slotData isKindOfClass:NSData.class]?slotData:nil;
         gPhotoSlotImage[i]=gPhotoSlotData[i].length?[UIImage imageWithData:gPhotoSlotData[i]]:nil;
     }'''
-load_new = load_anchor + r'''
+    load_new = load_anchor + r'''
 
     // EXPENSIVE IMAGE CLASSIFICATION MUST NEVER RUN FROM layoutSubviews.
     // A 32x32 alpha probe still uses CoreGraphics/vImage internally, so do it
@@ -49,31 +53,35 @@ load_new = load_anchor + r'''
             gPhotoSlotDisplayImage[i]=nil;
         }
     }'''
-if load_anchor not in runtime:
-    raise SystemExit('1.1.4 photo decode block not found')
-runtime = runtime.replace(load_anchor, load_new, 1)
+    if load_anchor not in runtime:
+        raise SystemExit('1.1.4 photo decode block not found')
+    runtime = runtime.replace(load_anchor, load_new, 1)
 
-hot_old = r'''        UIImageView *photoView=host.imageView;
+    hot_old = r'''        UIImageView *photoView=host.imageView;
         BOOL sticker=LGTImageHasVisibleTransparency(image);
         photoView.image=[image imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];'''
-hot_new = r'''        UIImageView *photoView=host.imageView;
+    hot_new = r'''        UIImageView *photoView=host.imageView;
         BOOL sticker=gPhotoSlotIsSticker[i];
         UIImage *displayImage=gPhotoSlotDisplayImage[i]?:image;
         if(photoView.image != displayImage) photoView.image=displayImage;'''
-if hot_old not in runtime:
-    raise SystemExit('1.1.4 per-layout transparency probe not found')
-runtime = runtime.replace(hot_old, hot_new, 1)
+    if hot_old not in runtime:
+        raise SystemExit('1.1.4 per-layout transparency probe not found')
+    runtime = runtime.replace(hot_old, hot_new, 1)
 
-runtime_path.write_text(runtime)
+    runtime_path.write_text(runtime)
+else:
+    print('NextLock 1.1.5 runtime CPU fix already applied; skipping duplicate runtime patch')
 
 # ---------------------------------------------------------------------------
 # Metadata: 1.1.5 is a feature-preserving performance/stability release.
 # ---------------------------------------------------------------------------
 control_path = ROOT / 'control'
 control = control_path.read_text()
-if 'Version: 1.1.4' not in control:
-    raise SystemExit('expected 1.1.4 control version not found')
-control = control.replace('Version: 1.1.4', 'Version: 1.1.5', 1)
+if 'Version: 1.1.4' in control:
+    control = control.replace('Version: 1.1.4', 'Version: 1.1.5', 1)
+elif 'Version: 1.1.5' not in control:
+    raise SystemExit('expected 1.1.4 or 1.1.5 control version not found')
+
 lines = control.splitlines()
 for i, line in enumerate(lines):
     if line.startswith('Description:'):


### PR DESCRIPTION
Fixes the confirmed NextLock/LockGlyphTime SpringBoard CPU regression without removing any features.

Device-side Frida profiling showed one SpringBoard thread dominating CPU while repeatedly executing CoreGraphics/vImage bitmap conversion. A synchronous caller trace identified LockGlyphTime.dylib, and disabling only LockGlyphTime returned SpringBoard CPU to normal.

Root cause in NextLock 1.1.4: LGTApplyPhotoFrames() called LGTImageHasVisibleTransparency() during lock-screen layout. That helper creates a bitmap context, draws the UIImage, and scans alpha pixels. With four independent photo frames, this expensive CoreGraphics/vImage work could execute repeatedly from layout/geometry updates.

1.1.5 keeps all existing functionality:
- four simultaneous independent photo/sticker frames
- transparency/sticker detection
- transparent PNG alpha preservation
- opaque-photo rounded frames
- independent width/height, anchor, placement and X/Y offsets
- shadows and all time/date/icon features

Performance fix:
- decode photos on preference reload as before
- perform transparency classification once per photo reload
- cache sticker/opaque result per frame
- cache AlwaysOriginal UIImage per frame
- remove alpha bitmap scanning from LGTApplyPhotoFrames/layout path
- avoid reassigning identical UIImage on every layout

Includes a macOS/Theos Rootless + RootHide test workflow that asserts the expensive transparency function no longer exists in the photo-frame layout body and validates generated 1.1.5 packages.