### PR TITLE
CI: build NextLock 1.1.5 CPU Fix Test 3

### DIFF
--- a/transfer/build-triggers/nextlock-test3.txt
+++ b/transfer/build-triggers/nextlock-test3.txt
@@ -1,0 +1,1 @@
+build NextLock CPU Fix Test 3


### PR DESCRIPTION
Build-only PR used to compile and validate the RootHide NextLock 1.1.5 CPU Fix Test 3 package. No production merge is required.