### PR TITLE
Persist Dopamine 3 publisher diagnostics

### DIFF
--- a/.github/workflows/dopamine3-cluster-publisher.yml
+++ b/.github/workflows/dopamine3-cluster-publisher.yml
@@ -73,12 +73,49 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: gpt-5.6-luna
+        shell: bash
         run: |
+          set +e
           python3 -m automation.dopamine_cluster \
             --repository-root . \
             --run-id "$GITHUB_RUN_ID" \
             --confirm-live \
-            --github-output "$GITHUB_OUTPUT" | tee dopamine-cluster-run.log
+            --github-output "$GITHUB_OUTPUT" 2>&1 | tee dopamine-cluster-run.log
+          status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$status" -ne 0 ]; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "reason=publisher-error" >> "$GITHUB_OUTPUT"
+            echo "target_path=" >> "$GITHUB_OUTPUT"
+            RUN_ID="$GITHUB_RUN_ID" RUN_NUMBER="$GITHUB_RUN_NUMBER" STATUS="$status" python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          log_path = Path("dopamine-cluster-run.log")
+          log = log_path.read_text(encoding="utf-8", errors="replace") if log_path.exists() else ""
+          # Keep only a bounded diagnostic tail and never persist environment variables or secrets.
+          tail = log[-6000:]
+          payload = {
+              "schema_version": 1,
+              "status": "error",
+              "exit_code": int(os.environ["STATUS"]),
+              "run_id": os.environ["RUN_ID"],
+              "run_number": os.environ["RUN_NUMBER"],
+              "recorded_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+              "diagnostic_tail": tail,
+          }
+          Path("automation/dopamine3-last-run.json").write_text(
+              json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          fi
+
+          # Deliberately return success here so the next step can persist a failure diagnostic.
+          exit 0
 
       - name: Commit approved cluster publication
         if: steps.cluster.outputs.published == 'true'
@@ -105,12 +142,31 @@ jobs:
           echo "- Page: https://nextsolution.cc/$TARGET_PATH" >> "$GITHUB_STEP_SUMMARY"
           echo "- Social post queued: **yes**" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Persist publisher error diagnostic
+        if: steps.api.outputs.enabled == 'true' && steps.cluster.outputs.reason == 'publisher-error'
+        run: |
+          git config user.name "nextsolution-publisher[bot]"
+          git config user.email "nextsolution-publisher[bot]@users.noreply.github.com"
+          if [ -f automation/dopamine3-last-run.json ]; then
+            git add -- automation/dopamine3-last-run.json
+            if ! git diff --cached --quiet; then
+              git commit -m "Record Dopamine 3 publisher diagnostic"
+              git push origin HEAD:main
+            fi
+          fi
+          echo "### Dopamine 3 publisher error" >> "$GITHUB_STEP_SUMMARY"
+          echo "A bounded, secret-safe diagnostic was saved to automation/dopamine3-last-run.json." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Record safe no-op
-        if: steps.api.outputs.enabled == 'true' && steps.cluster.outputs.published != 'true'
+        if: steps.api.outputs.enabled == 'true' && steps.cluster.outputs.published != 'true' && steps.cluster.outputs.reason != 'publisher-error'
         run: |
           echo "### Dopamine 3 publisher" >> "$GITHUB_STEP_SUMMARY"
           echo "No article was published on this run." >> "$GITHUB_STEP_SUMMARY"
           echo "Reason: **${{ steps.cluster.outputs.reason }}**" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail after diagnostic is persisted
+        if: steps.api.outputs.enabled == 'true' && steps.cluster.outputs.reason == 'publisher-error'
+        run: exit 1
 
       - name: Upload publisher log
         if: always()


### PR DESCRIPTION
Adds a bounded, secret-safe last-run diagnostic for production Dopamine 3 publishing failures. The workflow captures the publisher exit status and log tail, commits automation/dopamine3-last-run.json on failure, then marks the Actions run failed. This lets us diagnose and fix unattended OpenAI/workflow failures without exposing environment variables or secrets.