### PR TITLE
Clean resolved Dopamine publisher diagnostics

### DIFF
--- a/.github/workflows/dopamine3-cluster-publisher.yml
+++ b/.github/workflows/dopamine3-cluster-publisher.yml
@@ -126,6 +126,9 @@ jobs:
         run: |
           git config user.name "nextsolution-publisher[bot]"
           git config user.email "nextsolution-publisher[bot]@users.noreply.github.com"
+          if [ -f automation/dopamine3-last-run.json ]; then
+            git rm -f -- automation/dopamine3-last-run.json
+          fi
           git add -- \
             "$TARGET_PATH" \
             index.html \
@@ -141,6 +144,7 @@ jobs:
           echo "- Topic: **$TOPIC_ID**" >> "$GITHUB_STEP_SUMMARY"
           echo "- Page: https://nextsolution.cc/$TARGET_PATH" >> "$GITHUB_STEP_SUMMARY"
           echo "- Social post queued: **yes**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Stale failure diagnostic cleared: **yes**" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Persist publisher error diagnostic
         if: steps.api.outputs.enabled == 'true' && steps.cluster.outputs.reason == 'publisher-error'

--- a/automation/dopamine3-last-run.json
+++ b/automation/dopamine3-last-run.json
@@ -1,9 +1,0 @@
-{
-  "schema_version": 1,
-  "status": "error",
-  "exit_code": 2,
-  "run_id": "32270883502",
-  "run_number": "7",
-  "recorded_at": "2026-08-19T15:35:45+00:00",
-  "diagnostic_tail": "Dopamine cluster publisher error: Dopamine cluster draft rejected: The article omits the documented iOS 26.0 through iOS 26.0.1 compatibility range for A12 and A13 devices. Because the page presents itself as a central Dopamine 3 compatibility reference and repeatedly summarizes the supported ranges, this omission makes the compatibility coverage incomplete.; The statement that A12/A13 devices are listed from iOS 15.0 through iOS 18.7.1 is incomplete without clarifying the additional, separate iOS 26.0–26.0.1 range. It should not imply that iOS 18.7.1 is the final A12/A13 endpoint.\n"
-}


### PR DESCRIPTION
Clears the stale failure diagnostic now that the first Dopamine 3 hub published successfully, and makes every future successful cluster publication remove any previous automation/dopamine3-last-run.json before committing the new article.