### PR TITLE
AppsDump DarkSword iOS 17 test port

### DIFF
--- a/.github/workflows/build-appsdump-darksword-ios17.yml
+++ b/.github/workflows/build-appsdump-darksword-ios17.yml
@@ -40,7 +40,9 @@ jobs:
           git submodule update --init --recursive || true
 
       - name: Apply AppsDump iOS 17 frontend patches
-        run: python3 AppsDumpDarkSword/patch_lara.py
+        run: |
+          python3 AppsDumpDarkSword/patch_lara.py
+          python3 AppsDumpDarkSword/compat_xcode16.py
 
       - name: Build unsigned iPhone IPA
         working-directory: lara-src

--- a/.github/workflows/build-appsdump-darksword-ios17.yml
+++ b/.github/workflows/build-appsdump-darksword-ios17.yml
@@ -8,6 +8,12 @@ on:
     paths:
       - 'AppsDumpDarkSword/**'
       - '.github/workflows/build-appsdump-darksword-ios17.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'AppsDumpDarkSword/**'
+      - '.github/workflows/build-appsdump-darksword-ios17.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/build-appsdump-darksword-ios17.yml
+++ b/.github/workflows/build-appsdump-darksword-ios17.yml
@@ -1,0 +1,68 @@
+name: Build AppsDump DarkSword iOS 17
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - feature/appsdump-darksword-ios17
+    paths:
+      - 'AppsDumpDarkSword/**'
+      - '.github/workflows/build-appsdump-darksword-ios17.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: appsdump-darksword-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - name: Checkout NextSolution patch branch
+        uses: actions/checkout@v4
+
+      - name: Fetch pinned LARA DarkSword source
+        run: |
+          set -euo pipefail
+          rm -rf lara-src
+          git clone https://github.com/rooootdev/lara.git lara-src
+          cd lara-src
+          git checkout 393331d12729f413c2f6346d731a442b77e3b270
+          git submodule update --init --recursive || true
+
+      - name: Apply AppsDump iOS 17 frontend patches
+        run: python3 AppsDumpDarkSword/patch_lara.py
+
+      - name: Build unsigned iPhone IPA
+        working-directory: lara-src
+        run: |
+          set -euo pipefail
+          chmod +x ipabuild.sh
+          ./ipabuild.sh
+          test -f lara.ipa
+
+      - name: Package AppsDump test TIPA and patched source
+        run: |
+          set -euo pipefail
+          cp lara-src/lara.ipa "$RUNNER_TEMP/AppsDump-DS-4.1.0-iOS17.ipa"
+          cp lara-src/lara.ipa "$RUNNER_TEMP/AppsDump-DS-4.1.0-iOS17.tipa"
+          unzip -t "$RUNNER_TEMP/AppsDump-DS-4.1.0-iOS17.tipa" >/dev/null
+          tar -czf "$RUNNER_TEMP/AppsDump-DS-4.1.0-Source.tar.gz" lara-src AppsDumpDarkSword
+          shasum -a 256 \
+            "$RUNNER_TEMP/AppsDump-DS-4.1.0-iOS17.ipa" \
+            "$RUNNER_TEMP/AppsDump-DS-4.1.0-iOS17.tipa" \
+            "$RUNNER_TEMP/AppsDump-DS-4.1.0-Source.tar.gz"
+
+      - name: Upload test build
+        uses: actions/upload-artifact@v4
+        with:
+          name: AppsDump-DS-4.1.0-iOS17
+          path: |
+            ${{ runner.temp }}/AppsDump-DS-4.1.0-iOS17.ipa
+            ${{ runner.temp }}/AppsDump-DS-4.1.0-iOS17.tipa
+            ${{ runner.temp }}/AppsDump-DS-4.1.0-Source.tar.gz
+          if-no-files-found: error
+          retention-days: 30

--- a/AppsDumpDarkSword/README.md
+++ b/AppsDumpDarkSword/README.md
@@ -1,0 +1,22 @@
+# AppsDump DarkSword iOS 17 test port
+
+This branch builds a focused AppsDump-style app-decrypt frontend on top of the open-source LARA DarkSword backend.
+
+## Goal
+
+- iOS 17 DarkSword kernel read/write
+- kernel offset initialization/fetch
+- sandbox escape
+- enumerate installed app bundles
+- decrypt the main executable and encrypted frameworks
+- package and share the decrypted app as an IPA
+
+## Source / licensing
+
+The exploit, sandbox escape, offsets and decrypt implementation are taken from the upstream `rooootdev/lara` project and remain under its AGPL-3.0 license. The build workflow pins an upstream commit and also uploads the patched source tree with every build artifact.
+
+Upstream credits include opa334 for DarkSword, ChOma and XPF, plus the LARA contributors.
+
+## Test notes
+
+This is the first backend-validation build, not the final AppsDump UI recreation. Do not force-close the app after a successful DarkSword run because upstream documents possible kernel panics while KRW is active. Reboot and retry after an exploit failure.

--- a/AppsDumpDarkSword/compat_xcode16.py
+++ b/AppsDumpDarkSword/compat_xcode16.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+ROOT = Path("lara-src")
+
+# The pinned LARA tree contains a few optional iOS 19/26 visual calls. They are
+# unrelated to AppsDump and cannot be parsed by the Xcode 16.4 runner SDK.
+# Removing only the glassEffect modifier leaves the normal SwiftUI fallback
+# layout intact and does not touch DarkSword, sandbox escape or decrypt code.
+for path in ROOT.rglob("*.swift"):
+    text = path.read_text()
+    if ".glassEffect(" not in text:
+        continue
+    lines = text.splitlines()
+    filtered = [line for line in lines if ".glassEffect(" not in line]
+    path.write_text("\n".join(filtered) + "\n")
+    print(f"removed SDK-new glassEffect from {path}")
+
+# Xcode 16.4 also diagnoses an unrelated MobileGestalt helper because its
+# validation function calls a @MainActor alert object from a nonisolated
+# function. AppsDump never uses this helper, so keep its validation behavior
+# but remove the UI alerts from that one standalone function.
+gestalt = ROOT / "lara" / "views" / "tweaks" / "mobilegestalt" / "GestaltView.swift"
+text = gestalt.read_text()
+marker = "func verifyPlist(_ plist: Any, targetPath: String) throws -> Data {"
+if marker in text:
+    prefix = text.split(marker, 1)[0]
+    replacement = r'''func verifyPlist(_ plist: Any, targetPath: String) throws -> Data {
+    let fm = FileManager.default
+
+    if fm.fileExists(atPath: targetPath) {
+        let attrs = try fm.attributesOfItem(atPath: targetPath)
+        if let current = attrs[.size] as? NSNumber, current.intValue == 0 {
+            throw "Current MobileGestalt file is 0 bytes."
+        }
+    }
+
+    guard PropertyListSerialization.propertyList(plist, isValidFor: .binary) else {
+        throw "Invalid plist structure."
+    }
+
+    let data = try PropertyListSerialization.data(
+        fromPropertyList: plist,
+        format: .binary,
+        options: 0
+    )
+    guard !data.isEmpty else {
+        throw "Serialized plist data is empty."
+    }
+
+    _ = try PropertyListSerialization.propertyList(
+        from: data,
+        options: [],
+        format: nil
+    )
+    return data
+}
+'''
+    gestalt.write_text(prefix + replacement)
+    print("patched unrelated Gestalt validation for Xcode 16.4")
+else:
+    raise SystemExit("Expected Gestalt verifyPlist helper was not found")

--- a/AppsDumpDarkSword/patch_lara.py
+++ b/AppsDumpDarkSword/patch_lara.py
@@ -1,0 +1,228 @@
+from pathlib import Path
+import plistlib
+import re
+
+ROOT = Path("lara-src")
+
+# Rebrand build metadata without touching the exploit/decrypt implementation.
+pbx = ROOT / "lara.xcodeproj" / "project.pbxproj"
+s = pbx.read_text()
+s = s.replace("com.roooot.lara", "cn.gblw.AppsDump.DarkSword")
+s = re.sub(r"MARKETING_VERSION = [^;]+;", "MARKETING_VERSION = 4.1.0;", s)
+pbx.write_text(s)
+
+info = ROOT / "lara" / "Info.plist"
+with info.open("rb") as f:
+    p = plistlib.load(f)
+p["CFBundleDisplayName"] = "AppsDump DS"
+p["CFBundleName"] = "AppsDump DS"
+p["UIFileSharingEnabled"] = True
+with info.open("wb") as f:
+    plistlib.dump(p, f, fmt=plistlib.FMT_XML, sort_keys=False)
+
+# Focus the app on the DarkSword + app-decrypt path needed by AppsDump.
+content = r'''import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var mgr: laramgr
+    @State private var fetchingKernelcache = false
+    @State private var showLogs = false
+
+    private var osText: String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return "iOS \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    LabeledContent("System", value: osText)
+                    LabeledContent("DarkSword") {
+                        statusView(ready: mgr.dsready, running: mgr.dsrunning, failed: mgr.dsfailed)
+                    }
+                    LabeledContent("Kernel offsets") {
+                        Image(systemName: mgr.hasOffsets ? "checkmark.circle.fill" : "xmark.circle")
+                            .foregroundStyle(mgr.hasOffsets ? .green : .secondary)
+                    }
+                    LabeledContent("Sandbox") {
+                        statusView(ready: mgr.sbxready, running: mgr.sbxrunning, failed: mgr.sbxfailed)
+                    }
+                } header: {
+                    Label("AppsDump DarkSword", systemImage: "shield.lefthalf.filled")
+                } footer: {
+                    Text("iOS 17 test backend. DarkSword provides kernel read/write; the sandbox escape exposes installed app bundles; the decrypt engine copies decrypted executable pages into an IPA.")
+                }
+
+                Section("Setup") {
+                    Button {
+                        offsets_init()
+                        mgr.run()
+                    } label: {
+                        HStack {
+                            Label(mgr.dsready ? "DarkSword Ready" : "1. Run DarkSword", systemImage: "bolt.shield")
+                            Spacer()
+                            if mgr.dsrunning {
+                                Text("\(Int(mgr.dsprogress * 100))%")
+                                    .foregroundStyle(.secondary)
+                                ProgressView()
+                            }
+                        }
+                    }
+                    .disabled(mgr.dsready || mgr.dsrunning || isdebugged())
+
+                    if !mgr.hasOffsets {
+                        Button {
+                            guard !fetchingKernelcache else { return }
+                            fetchingKernelcache = true
+                            DispatchQueue.global(qos: .userInitiated).async {
+                                let fetched = fetchkcache()
+                                let loaded = fetched ? dlkcache() : false
+                                DispatchQueue.main.async {
+                                    mgr.hasOffsets = loaded
+                                    fetchingKernelcache = false
+                                }
+                            }
+                        } label: {
+                            HStack {
+                                Label("2. Fetch Kernel Offsets", systemImage: "arrow.down.circle")
+                                Spacer()
+                                if fetchingKernelcache { ProgressView() }
+                            }
+                        }
+                        .disabled(!mgr.dsready || fetchingKernelcache)
+                    }
+
+                    Button {
+                        mgr.sbxescape()
+                    } label: {
+                        HStack {
+                            Label(mgr.sbxready ? "Sandbox Escaped" : "3. Escape Sandbox", systemImage: "lock.open")
+                            Spacer()
+                            if mgr.sbxrunning { ProgressView() }
+                        }
+                    }
+                    .disabled(!mgr.dsready || !mgr.hasOffsets || mgr.sbxready || mgr.sbxrunning)
+                }
+
+                Section("Dump Apps") {
+                    NavigationLink {
+                        DecryptView()
+                    } label: {
+                        Label("Installed Apps", systemImage: "square.stack.3d.up")
+                    }
+                    .disabled(!mgr.dsready || !mgr.sbxready)
+
+                    if !mgr.sbxready {
+                        Text("Run the three setup steps first. Once ready, AppsDump will list installed apps and export decrypted IPAs through the share sheet.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section("Safety") {
+                    Label("Do not force-close AppsDump while DarkSword kernel access is active. Use a normal reboot if the exploit becomes unstable.", systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.orange)
+                }
+
+                Section {
+                    Button(showLogs ? "Hide Logs" : "Show Logs") {
+                        showLogs.toggle()
+                    }
+                    if showLogs {
+                        ScrollView {
+                            Text(mgr.log.isEmpty ? "No logs yet." : mgr.log)
+                                .font(.system(size: 11, design: .monospaced))
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .frame(minHeight: 140, maxHeight: 280)
+                    }
+                } header: {
+                    Label("Diagnostics", systemImage: "terminal")
+                }
+            }
+            .navigationTitle("AppsDump DS")
+        }
+    }
+
+    @ViewBuilder
+    private func statusView(ready: Bool, running: Bool, failed: Bool) -> some View {
+        if ready {
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+        } else if running {
+            ProgressView()
+        } else if failed {
+            Image(systemName: "xmark.circle.fill").foregroundStyle(.red)
+        } else {
+            Image(systemName: "circle").foregroundStyle(.secondary)
+        }
+    }
+}
+'''
+(ROOT / "lara" / "views" / "app" / "ContentView.swift").write_text(content)
+
+# Keep Lara's proven initialization code, but remove toolbox tabs so the test
+# build opens directly to the AppsDump flow.
+main = r'''import SwiftUI
+import UniformTypeIdentifiers
+
+enum taboptions { case applying, tweaks, files, logs }
+let g_isunsupported: Bool = isunsupported()
+var weonadebugbuild_pjbweouttahereexclamationmark: Bool = false
+
+@main
+struct lara: App {
+    @StateObject private var mgr = laramgr.shared
+    @Environment(\.scenePhase) private var scenephase
+    @AppStorage("keepAlive") private var keepalive: Bool = false
+
+    init() {
+        #if DEBUG
+        weonadebugbuild_pjbweouttahereexclamationmark = true
+        #endif
+        let fixMethod = class_getInstanceMethod(UIDocumentPickerViewController.self, #selector(UIDocumentPickerViewController.fix_init(forOpeningContentTypes:asCopy:)))!
+        let origMethod = class_getInstanceMethod(UIDocumentPickerViewController.self, #selector(UIDocumentPickerViewController.init(forOpeningContentTypes:asCopy:)))!
+        method_exchangeImplementations(origMethod, fixMethod)
+        if keepalive { toggleka() }
+        globallogger.capture()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(mgr)
+                .onAppear {
+                    if !isunsupported() {
+                        init_offsets()
+                        offsets_init()
+                        mgr.hasOffsets = emergencyfixfunctiontobereplacedlateronquestionmark()
+                    } else {
+                        Alertinator.shared.alert(
+                            title: "Unsupported device",
+                            body: "This DarkSword test build targets supported iOS 17 devices. A19/M5 and patched iOS builds are not supported.",
+                            actionLabel: "Exit App",
+                            action: { exitinator() }
+                        )
+                    }
+                }
+                .onChange(of: scenephase) { phase in
+                    if phase == .active { globallogger.capture() }
+                    else { globallogger.stopcapture() }
+                }
+        }
+    }
+}
+
+extension UIDocumentPickerViewController {
+    @objc func fix_init(forOpeningContentTypes contentTypes: [UTType], asCopy: Bool) -> UIDocumentPickerViewController {
+        return fix_init(forOpeningContentTypes: contentTypes, asCopy: true)
+    }
+}
+
+extension String: @retroactive Error {}
+'''
+(ROOT / "lara" / "lara.swift").write_text(main)
+
+print("AppsDump DarkSword patches applied")


### PR DESCRIPTION
Adds a first backend-validation build for AppsDump on iOS 17 using the open-source LARA DarkSword kernel exploit + sandbox escape + app decrypt path. The build stays on a feature branch and uploads both TIPA/IPA and patched source for testing. Do not merge until device validation is complete.