### PR TITLE
CI: build NextLock photo display modes

### DIFF
--- a/transfer/build-triggers/nextlock-photo-modes.txt
+++ b/transfer/build-triggers/nextlock-photo-modes.txt
@@ -1,0 +1,1 @@
+Build NextLock per-frame photo display modes validation package.


### PR DESCRIPTION
Build-only validation PR. Compiles the Test 5 CPU-fix shim plus per-frame Auto/Stretch/Full Photo/Cut-Crop display modes and injects the new PreferenceLoader cells into all four photo frame pages. No production merge required.