### PR TITLE
CI: validate NextLock Test 12 custom clock

### DIFF
--- a/source/NextLockCustomClock/Makefile
+++ b/source/NextLockCustomClock/Makefile
@@ -6,7 +6,7 @@ INSTALL_TARGET_PROCESSES = SpringBoard
 include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = NextLockCustomClock
-NextLockCustomClock_FILES = Tweak.m
+NextLockCustomClock_FILES = TweakPatched.m
 NextLockCustomClock_CFLAGS = -fobjc-arc
 NextLockCustomClock_FRAMEWORKS = Foundation UIKit QuartzCore CoreFoundation
 NextLockCustomClock_LIBRARIES = substrate

--- a/source/NextLockCustomClock/TweakPatched.m
+++ b/source/NextLockCustomClock/TweakPatched.m
@@ -1,0 +1,13 @@
+#import <UIKit/UIKit.h>
+
+#define UIFontWeightUltraLight ((UIFontWeight)-0.8)
+#define UIFontWeightThin       ((UIFontWeight)-0.6)
+#define UIFontWeightLight      ((UIFontWeight)-0.4)
+#define UIFontWeightRegular    ((UIFontWeight)0.0)
+#define UIFontWeightMedium     ((UIFontWeight)0.23)
+#define UIFontWeightSemibold   ((UIFontWeight)0.30)
+#define UIFontWeightBold       ((UIFontWeight)0.40)
+#define UIFontWeightHeavy      ((UIFontWeight)0.56)
+#define UIFontWeightBlack      ((UIFontWeight)0.62)
+
+#include "Tweak.m"

--- a/transfer/build-triggers/nextlock-test12-readme.txt
+++ b/transfer/build-triggers/nextlock-test12-readme.txt
@@ -1,0 +1,1 @@
+Test 12 validation branch marker.

--- a/transfer/build-triggers/nextlock-test12.txt
+++ b/transfer/build-triggers/nextlock-test12.txt
@@ -1,0 +1,1 @@
+validate NextLock Test 12 custom replacement clock runtime

--- a/transfer/build-triggers/nextlock-test12.txt
+++ b/transfer/build-triggers/nextlock-test12.txt
@@ -1,1 +1,1 @@
-validate NextLock Test 12 custom replacement clock runtime
+validate NextLock Test 12 custom replacement clock runtime - compile fix 2


### PR DESCRIPTION
Build-only validation for the replacement lock-screen clock/date runtime. Test 12 hides Apple time/date text and renders independent custom labels with full-screen positioning and styling while retaining the low-CPU/photo fixes.