### PR TITLE
CI: validate NextLock Test 13 hide elements

### DIFF
--- a/transfer/build-triggers/nextlock-test13.txt
+++ b/transfer/build-triggers/nextlock-test13.txt
@@ -1,0 +1,1 @@
+validate NextLock Test 13 hide elements runtime


### PR DESCRIPTION
Build-only validation for Test 13 hide controls before confirming NS Transfer publication.