### PR TITLE
CI: validate NextLock Test 13 hide elements v2

### DIFF
--- a/transfer/build-triggers/nextlock-test13.txt
+++ b/transfer/build-triggers/nextlock-test13.txt
@@ -1,0 +1,1 @@
+validate NextLock Test 13 hide elements runtime v2


### PR DESCRIPTION
Re-validation after fixing the Test 13 hide-elements runtime compile error.