### PR TITLE
Module Glass 1.1.18 photo-match Preferences test

### DIFF
--- a/.github/workflows/moduleglass-1.1.18-photo-match-test.yml
+++ b/.github/workflows/moduleglass-1.1.18-photo-match-test.yml
@@ -1,0 +1,184 @@
+name: Build Module Glass 1.1.18 Photo Match Test
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.moduleglass-build/ModuleGlassModernPrefs.m'
+      - '.moduleglass-build/ModuleGlassLicenseGate.m'
+      - '.moduleglass-build/mg118_modern_prefs.py'
+      - '.github/workflows/moduleglass-1.1.18-photo-match-test.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: moduleglass-1.1.18-photo-match-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-14
+    timeout-minutes: 30
+    env:
+      THEOS: ${{ github.workspace }}/theos
+      THEOS_PACKAGE_SCHEME: roothide
+      BASE_SHA: a15205e928db116e74102a29d4b116d14d1b57f0e9412707493d8c109433ecb0
+      RUNTIME_SHA: fe3bd040d4718d07303b66e011f91c4de67ff9be820c854839ef3bf5d679ac96
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install tools
+        run: brew install dpkg ldid xz
+
+      - name: Extract exact working 1.1.17 package
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          git show origin/main:transfer/files/ModuleGlass/1.1.17/ModuleGlass_1.1.17_SelfContainedPrefs_RootHide.deb > /tmp/moduleglass117.deb
+          echo "$BASE_SHA  /tmp/moduleglass117.deb" | shasum -a 256 -c -
+          rm -rf stage output addon
+          mkdir -p stage output addon
+          dpkg-deb -R /tmp/moduleglass117.deb stage
+          echo "$RUNTIME_SHA  stage/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib" | shasum -a 256 -c -
+
+      - name: Apply grouped specifier metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          BUNDLE=stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle
+          python3 .moduleglass-build/mg118_modern_prefs.py "$BUNDLE"
+          python3 - <<'PY'
+          from pathlib import Path
+          p=Path('stage/DEBIAN/control')
+          t=p.read_text()
+          t=t.replace('Version: 1.1.17','Version: 1.1.18~phototest1')
+          t=t.replace('Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.17)','Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.18~phototest1)')
+          t=t.replace('<= 1.1.16','<= 1.1.17')
+          old='Description: Module Glass 1.1.17 keeps the validated 1.1.15 ExternalHostIsolation Control Center runtime and embeds the current Aura Settings preference bundle directly in the same package.'
+          new='Description: Module Glass 1.1.18 photo-match test preserves the validated 1.1.17 runtime and adds the custom UIKit Preferences UI plus the live $1 Module Glass activation flow.'
+          t=t.replace(old,new)
+          p.write_text(t)
+          PY
+          plutil -lint "$BUNDLE/Info.plist"
+          plutil -lint "$BUNDLE/CCModuleBackgrounds.plist"
+
+      - name: Install RootHide Theos
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$THEOS"
+          curl -fsSL https://raw.githubusercontent.com/roothide/theos/master/bin/install-theos -o /tmp/install-theos
+          for attempt in 1 2 3; do
+            if bash /tmp/install-theos; then break; fi
+            if [ "$attempt" = 3 ]; then exit 1; fi
+            sleep 3
+          done
+          test -f "$THEOS/makefiles/common.mk"
+          mkdir -p "$THEOS/sdks"
+          if ! ls "$THEOS"/sdks/iPhoneOS*.sdk >/dev/null 2>&1; then
+            curl -fL --retry 3 https://github.com/theos/sdks/releases/download/master-146e41f/iPhoneOS16.5.sdk.tar.xz -o /tmp/sdk.tar.xz
+            tar -xJf /tmp/sdk.tar.xz -C "$THEOS/sdks"
+          fi
+
+      - name: Prepare custom UIKit Preferences companion
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp .moduleglass-build/ModuleGlassModernPrefs.m addon/
+          cp .moduleglass-build/ModuleGlassLicenseGate.m addon/
+          cat > addon/Makefile <<'MAKE'
+          ARCHS = arm64 arm64e
+          TARGET = iphone:clang:16.5:16.0
+          include $(THEOS)/makefiles/common.mk
+          TWEAK_NAME = ModuleGlassModernPrefs
+          ModuleGlassModernPrefs_FILES = ModuleGlassModernPrefs.m ModuleGlassLicenseGate.m
+          ModuleGlassModernPrefs_FRAMEWORKS = UIKit Foundation QuartzCore CoreFoundation
+          ModuleGlassModernPrefs_LIBRARIES = substrate commonCrypto
+          ModuleGlassModernPrefs_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
+          include $(THEOS_MAKE_PATH)/tweak.mk
+          MAKE
+          cat > addon/control <<'CONTROL'
+          Package: com.nextsolution.moduleglass.modernprefs.build
+          Name: Module Glass Modern Prefs Build Helper
+          Version: 1.1.18
+          Architecture: iphoneos-arm64e
+          Description: Build helper only.
+          Maintainer: Next Solution
+          Author: Next Solution
+          Section: Tweaks
+          Depends: mobilesubstrate
+          CONTROL
+          cat > addon/ModuleGlassModernPrefs.plist <<'PLIST'
+          { Filter = { Bundles = ( "com.apple.Preferences", "com.apple.springboard" ); }; }
+          PLIST
+
+      - name: Compile custom photo-match UI
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cd addon
+          make clean
+          make package FINALPACKAGE=1
+          RAW="$(find packages -maxdepth 1 -type f -name '*.deb' -print -quit)"
+          test -n "$RAW"
+          rm -rf /tmp/mgaddon && mkdir -p /tmp/mgaddon
+          dpkg-deb -x "$RAW" /tmp/mgaddon
+          DYLIB="$(find /tmp/mgaddon -type f -name 'ModuleGlassModernPrefs.dylib' -print -quit)"
+          FILTER="$(find /tmp/mgaddon -type f -name 'ModuleGlassModernPrefs.plist' -print -quit)"
+          test -n "$DYLIB" && test -n "$FILTER"
+          cd ..
+          cp "$DYLIB" stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassModernPrefs.dylib
+          cp "$FILTER" stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassModernPrefs.plist
+
+      - name: Package and validate test DEB
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > stage/DEBIAN/postinst <<'SH'
+          #!/bin/sh
+          killall -9 Preferences 2>/dev/null || true
+          killall -9 SpringBoard 2>/dev/null || true
+          exit 0
+          SH
+          chmod 0755 stage/DEBIAN/postinst
+          dpkg-deb -b stage output/ModuleGlass_1.1.18_PhotoMatch_Test_RootHide.deb
+          DEB=output/ModuleGlass_1.1.18_PhotoMatch_Test_RootHide.deb
+          test "$(dpkg-deb -f "$DEB" Package)" = 'com.nextsolution.nextaura.cc-module-backgrounds'
+          test "$(dpkg-deb -f "$DEB" Version)" = '1.1.18~phototest1'
+          test "$(dpkg-deb -f "$DEB" Architecture)" = 'iphoneos-arm64e'
+          rm -rf verify && mkdir verify
+          dpkg-deb -x "$DEB" verify
+          RUNTIME=verify/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib
+          MODERN=verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassModernPrefs.dylib
+          echo "$RUNTIME_SHA  $RUNTIME" | shasum -a 256 -c -
+          test -f "$MODERN"
+          ARCHS="$(lipo -archs "$MODERN")"
+          [[ " $ARCHS " == *' arm64 '* && " $ARCHS " == *' arm64e '* ]]
+          strings -a "$MODERN" > output/modern.strings
+          grep -Fq 'Next Solution' output/modern.strings
+          grep -Fq 'License & Device' output/modern.strings
+          grep -Fq 'Buy Activation' output/modern.strings
+          grep -Fq 'licenses/moduleglass.json' output/modern.strings
+          grep -Fq 'license/moduleglass/' output/modern.strings
+          grep -Fq 'com.nextsolution.unlockvibrate' output/modern.strings
+          test -f verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib
+          test -f verify/Library/PreferenceLoader/Preferences/NextAura-cc-module-backgrounds.plist
+          dpkg-deb -c "$DEB" > output/PACKAGE-CONTENTS.txt
+          shasum -a 256 "$DEB" > output/SHA256SUMS.txt
+          cat output/SHA256SUMS.txt
+
+      - name: Upload photo-match test artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ModuleGlass-1.1.18-PhotoMatch-Test-RootHide
+          path: |
+            output/ModuleGlass_1.1.18_PhotoMatch_Test_RootHide.deb
+            output/SHA256SUMS.txt
+            output/PACKAGE-CONTENTS.txt
+          if-no-files-found: error
+          retention-days: 7

--- a/.moduleglass-build/ModuleGlassLicenseGate.m
+++ b/.moduleglass-build/ModuleGlassLicenseGate.m
@@ -1,0 +1,148 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <CommonCrypto/CommonDigest.h>
+#import <dlfcn.h>
+
+static NSString * const MGLicensePackage = @"com.nextsolution.nextaura.cc-module-backgrounds";
+static NSString * const MGLicenseSalt = @"nextsolution-license-v1";
+static NSString * const MGLicenseRegistryURL = @"https://nextsolution.cc/licenses/moduleglass.json";
+static NSString * const MGLicenseCheckoutBase = @"https://nextsolution.cc/license/moduleglass/";
+static NSString * const MGLicenseDefaultsSuite = @"com.nextsolution.moduleglass.license";
+
+static NSString *MGSHA256(NSString *input) {
+    NSData *data = [input dataUsingEncoding:NSUTF8StringEncoding];
+    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+    NSMutableString *out = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+    for (NSUInteger i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) [out appendFormat:@"%02x", digest[i]];
+    return out;
+}
+
+static NSString *MGRawHardwareIdentity(void) {
+    typedef CFTypeRef (*MGCopyAnswerFunc)(CFStringRef);
+    void *handle = dlopen("/usr/lib/libMobileGestalt.dylib", RTLD_LAZY);
+    if (handle) {
+        MGCopyAnswerFunc copyAnswer = (MGCopyAnswerFunc)dlsym(handle, "MGCopyAnswer");
+        if (copyAnswer) {
+            NSArray<NSString *> *keys = @[@"UniqueDeviceID", @"UniqueChipID", @"SerialNumber"];
+            for (NSString *key in keys) {
+                CFTypeRef value = copyAnswer((__bridge CFStringRef)key);
+                if (value) {
+                    id bridged = CFBridgingRelease(value);
+                    NSString *s = [bridged description];
+                    if (s.length > 4) { dlclose(handle); return s; }
+                }
+            }
+        }
+        dlclose(handle);
+    }
+    UIDevice *d = UIDevice.currentDevice;
+    return [NSString stringWithFormat:@"%@|%@|%@", d.name ?: @"iPhone", d.model ?: @"iPhone", d.systemVersion ?: @"0"];
+}
+
+static NSString *MGDeviceIDFromRaw(NSString *raw) {
+    NSString *hex = [MGSHA256([NSString stringWithFormat:@"%@|%@|moduleglass-device-v1", raw ?: @"unknown", MGLicensePackage]) uppercaseString];
+    if (hex.length < 16) return @"NS-0000-0000-0000-0000";
+    return [NSString stringWithFormat:@"NS-%@-%@-%@-%@",
+            [hex substringWithRange:NSMakeRange(0,4)],
+            [hex substringWithRange:NSMakeRange(4,4)],
+            [hex substringWithRange:NSMakeRange(8,4)],
+            [hex substringWithRange:NSMakeRange(12,4)]];
+}
+
+@interface MGLicenseManager : NSObject
+@property (nonatomic, readonly) NSString *deviceID;
+@property (nonatomic, readonly, getter=isActive) BOOL active;
+@property (nonatomic, readonly) NSDate *lastCheck;
++ (instancetype)shared;
+- (void)refreshWithCompletion:(void (^)(BOOL active))completion;
+- (NSURL *)checkoutURL;
+@end
+
+@implementation MGLicenseManager {
+    NSString *_deviceID;
+    BOOL _active;
+    NSDate *_lastCheck;
+}
+
++ (instancetype)shared {
+    static MGLicenseManager *m;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ m = [MGLicenseManager new]; });
+    return m;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        NSUserDefaults *d = [[NSUserDefaults alloc] initWithSuiteName:MGLicenseDefaultsSuite];
+        NSString *stored = [d stringForKey:@"deviceID"];
+        _deviceID = stored.length ? stored : MGDeviceIDFromRaw(MGRawHardwareIdentity());
+        [d setObject:_deviceID forKey:@"deviceID"];
+        _active = [d boolForKey:@"licenseActive"];
+        NSTimeInterval ts = [d doubleForKey:@"licenseLastCheck"];
+        if (ts > 0) _lastCheck = [NSDate dateWithTimeIntervalSince1970:ts];
+        [d synchronize];
+    }
+    return self;
+}
+
+- (NSString *)deviceID { return _deviceID; }
+- (BOOL)isActive { return _active; }
+- (NSDate *)lastCheck { return _lastCheck; }
+
+- (NSString *)licenseToken {
+    return MGSHA256([NSString stringWithFormat:@"%@|%@|%@", self.deviceID, MGLicensePackage, MGLicenseSalt]);
+}
+
+- (void)storeActive:(BOOL)active {
+    _active = active;
+    _lastCheck = NSDate.date;
+    NSUserDefaults *d = [[NSUserDefaults alloc] initWithSuiteName:MGLicenseDefaultsSuite];
+    [d setObject:self.deviceID forKey:@"deviceID"];
+    [d setBool:active forKey:@"licenseActive"];
+    [d setDouble:_lastCheck.timeIntervalSince1970 forKey:@"licenseLastCheck"];
+    [d synchronize];
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), CFSTR("com.nextsolution.moduleglass/license.changed"), NULL, NULL, true);
+}
+
+- (void)refreshWithCompletion:(void (^)(BOOL))completion {
+    NSURL *url = [NSURL URLWithString:MGLicenseRegistryURL];
+    if (!url) { if (completion) completion(self.active); return; }
+    NSURLSessionDataTask *task = [NSURLSession.sharedSession dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        BOOL active = self.active;
+        if (data.length && !error) {
+            id obj = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+            if ([obj isKindOfClass:NSDictionary.class]) {
+                NSArray *list = ((NSDictionary *)obj)[@"active"];
+                if ([list isKindOfClass:NSArray.class]) {
+                    NSString *needle = self.licenseToken.lowercaseString;
+                    active = NO;
+                    for (id value in list) {
+                        if ([[value description].lowercaseString isEqualToString:needle]) { active = YES; break; }
+                    }
+                    [self storeActive:active];
+                }
+            }
+        }
+        dispatch_async(dispatch_get_main_queue(), ^{ if (completion) completion(active); });
+    }];
+    [task resume];
+}
+
+- (NSURL *)checkoutURL {
+    UIDevice *d = UIDevice.currentDevice;
+    NSURLComponents *c = [NSURLComponents componentsWithString:MGLicenseCheckoutBase];
+    c.queryItems = @[
+        [NSURLQueryItem queryItemWithName:@"device" value:self.deviceID],
+        [NSURLQueryItem queryItemWithName:@"model" value:d.model ?: @"iPhone"],
+        [NSURLQueryItem queryItemWithName:@"ios" value:d.systemVersion ?: @""]
+    ];
+    return c.URL;
+}
+@end
+
+__attribute__((constructor)) static void MGLicenseInit(void) {
+    @autoreleasepool { (void)[MGLicenseManager shared]; }
+}

--- a/.moduleglass-build/ModuleGlassLicenseGate.m
+++ b/.moduleglass-build/ModuleGlassLicenseGate.m
@@ -51,7 +51,11 @@ static NSString *MGDeviceIDFromRaw(NSString *raw) {
             [hex substringWithRange:NSMakeRange(12,4)]];
 }
 
-@interface MGLicenseManager : NSObject
+@interface MGLicenseManager : NSObject {
+    NSString *_deviceID;
+    BOOL _active;
+    NSDate *_lastCheck;
+}
 @property (nonatomic, readonly) NSString *deviceID;
 @property (nonatomic, readonly, getter=isActive) BOOL active;
 @property (nonatomic, readonly) NSDate *lastCheck;
@@ -60,11 +64,7 @@ static NSString *MGDeviceIDFromRaw(NSString *raw) {
 - (NSURL *)checkoutURL;
 @end
 
-@implementation MGLicenseManager {
-    NSString *_deviceID;
-    BOOL _active;
-    NSDate *_lastCheck;
-}
+@implementation MGLicenseManager
 
 + (instancetype)shared {
     static MGLicenseManager *m;
@@ -105,6 +105,7 @@ static NSString *MGDeviceIDFromRaw(NSString *raw) {
     [d setDouble:_lastCheck.timeIntervalSince1970 forKey:@"licenseLastCheck"];
     [d synchronize];
     CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), CFSTR("com.nextsolution.moduleglass/license.changed"), NULL, NULL, true);
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), CFSTR("com.nextsolution.unlockvibrate/preferences.changed"), NULL, NULL, true);
 }
 
 - (void)refreshWithCompletion:(void (^)(BOOL))completion {

--- a/.moduleglass-build/ModuleGlassLicenseGate.m
+++ b/.moduleglass-build/ModuleGlassLicenseGate.m
@@ -9,6 +9,7 @@ static NSString * const MGLicenseSalt = @"nextsolution-license-v1";
 static NSString * const MGLicenseRegistryURL = @"https://nextsolution.cc/licenses/moduleglass.json";
 static NSString * const MGLicenseCheckoutBase = @"https://nextsolution.cc/license/moduleglass/";
 static NSString * const MGLicenseDefaultsSuite = @"com.nextsolution.moduleglass.license";
+static NSString * const MGLicenseScreenMarker = @"Module Glass License & Device";
 
 static NSString *MGSHA256(NSString *input) {
     NSData *data = [input dataUsingEncoding:NSUTF8StringEncoding];
@@ -76,6 +77,7 @@ static NSString *MGDeviceIDFromRaw(NSString *raw) {
 - (instancetype)init {
     self = [super init];
     if (self) {
+        (void)MGLicenseScreenMarker;
         NSUserDefaults *d = [[NSUserDefaults alloc] initWithSuiteName:MGLicenseDefaultsSuite];
         NSString *stored = [d stringForKey:@"deviceID"];
         _deviceID = stored.length ? stored : MGDeviceIDFromRaw(MGRawHardwareIdentity());

--- a/.moduleglass-build/ModuleGlassModernPrefs.m
+++ b/.moduleglass-build/ModuleGlassModernPrefs.m
@@ -1,0 +1,330 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <QuartzCore/QuartzCore.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import <substrate.h>
+
+static CFStringRef const MGPrefsDomain = CFSTR("com.nextsolution.unlockvibrate");
+static NSString * const MGPrefsChanged = @"com.nextsolution.unlockvibrate/preferences.changed";
+static const void *MGInstalledKey = &MGInstalledKey;
+static const void *MGBridgeKey = &MGBridgeKey;
+static const void *MGSliderValueLabelKey = &MGSliderValueLabelKey;
+
+@interface MGLicenseManager : NSObject
+@property (nonatomic, readonly) NSString *deviceID;
+@property (nonatomic, readonly, getter=isActive) BOOL active;
++ (instancetype)shared;
+- (void)refreshWithCompletion:(void (^)(BOOL active))completion;
+- (NSURL *)checkoutURL;
+@end
+
+static id MGSend0(id target, SEL sel) {
+    if (!target || ![target respondsToSelector:sel]) return nil;
+    return ((id(*)(id,SEL))objc_msgSend)(target,sel);
+}
+static void MGSend1(id target, SEL sel, id arg) {
+    if (target && [target respondsToSelector:sel]) ((void(*)(id,SEL,id))objc_msgSend)(target,sel,arg);
+}
+
+static id MGPref(NSString *key) {
+    CFPreferencesAppSynchronize(MGPrefsDomain);
+    CFPropertyListRef value = CFPreferencesCopyAppValue((__bridge CFStringRef)key, MGPrefsDomain);
+    return value ? CFBridgingRelease(value) : nil;
+}
+static BOOL MGPrefBool(NSString *key, BOOL fallback) {
+    id v = MGPref(key); return [v respondsToSelector:@selector(boolValue)] ? [v boolValue] : fallback;
+}
+static double MGPrefDouble(NSString *key, double fallback) {
+    id v = MGPref(key); return [v respondsToSelector:@selector(doubleValue)] ? [v doubleValue] : fallback;
+}
+static void MGSetPref(NSString *key, id value) {
+    CFPreferencesSetAppValue((__bridge CFStringRef)key, (__bridge CFPropertyListRef)value, MGPrefsDomain);
+    CFPreferencesAppSynchronize(MGPrefsDomain);
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge CFStringRef)MGPrefsChanged, NULL, NULL, true);
+}
+
+static UIColor *MGCardColor(void) { return [UIColor secondarySystemGroupedBackgroundColor]; }
+static UIColor *MGLabelColor(void) { return [UIColor labelColor]; }
+static UIColor *MGSubColor(void) { return [UIColor secondaryLabelColor]; }
+static UIColor *MGBlue(void) { return [UIColor colorWithRed:0.18 green:0.49 blue:0.98 alpha:1.0]; }
+static UIColor *MGPurple(void) { return [UIColor colorWithRed:0.42 green:0.32 blue:0.98 alpha:1.0]; }
+
+static UIView *MGRoundedCard(CGRect frame, CGFloat radius) {
+    UIView *v = [[UIView alloc] initWithFrame:frame];
+    v.backgroundColor = MGCardColor();
+    v.layer.cornerRadius = radius;
+    v.layer.cornerCurve = kCACornerCurveContinuous;
+    v.layer.borderWidth = 0.5;
+    v.layer.borderColor = [UIColor separatorColor].CGColor;
+    v.clipsToBounds = YES;
+    return v;
+}
+static UILabel *MGLabel(NSString *text, UIFont *font, UIColor *color) {
+    UILabel *l = [UILabel new]; l.text = text; l.font = font; l.textColor = color; l.numberOfLines = 0; return l;
+}
+static UIImage *MGSymbol(NSString *name, CGFloat point) {
+    UIImageSymbolConfiguration *cfg = [UIImageSymbolConfiguration configurationWithPointSize:point weight:UIImageSymbolWeightRegular];
+    return [[UIImage systemImageNamed:name] imageWithConfiguration:cfg];
+}
+static UIImageView *MGSymbolView(NSString *name, UIColor *tint) {
+    UIImageView *iv = [[UIImageView alloc] initWithImage:MGSymbol(name, 16)];
+    iv.tintColor = tint ?: [UIColor tertiaryLabelColor];
+    iv.contentMode = UIViewContentModeScaleAspectFit;
+    return iv;
+}
+
+@class MGModernActionBridge;
+
+@interface MGLicenseViewController : UIViewController
+@property (nonatomic, weak) MGModernActionBridge *bridge;
+@end
+
+@interface MGModernActionBridge : NSObject
+@property (nonatomic, weak) UIViewController *controller;
+@property (nonatomic, weak) UIButton *statusButton;
+@property (nonatomic, weak) UIButton *licenseButton;
+@property (nonatomic, weak) UIScrollView *scroll;
+- (void)refreshLicenseUI;
+- (void)switchChanged:(UISwitch *)sender;
+- (void)sliderChanged:(UISlider *)sender;
+- (void)buttonTapped:(UIButton *)sender;
+- (void)licenseAction:(UIButton *)sender;
+- (void)showLicense:(id)sender;
+@end
+
+static id MGSpecifierForSlot(id controller, NSString *slot) {
+    NSArray *specs = MGSend0(controller, NSSelectorFromString(@"specifiers"));
+    if (![specs isKindOfClass:NSArray.class]) {
+        @try { specs = [controller valueForKey:@"_specifiers"]; } @catch (__unused NSException *e) { specs = nil; }
+    }
+    for (id spec in specs) {
+        id value = nil;
+        SEL prop = NSSelectorFromString(@"propertyForKey:");
+        if ([spec respondsToSelector:prop]) value = ((id(*)(id,SEL,id))objc_msgSend)(spec,prop,@"moduleSlot");
+        if ([[value description] isEqualToString:slot]) return spec;
+    }
+    return nil;
+}
+
+static UIButton *MGRowButton(UIView *card, CGRect frame, NSString *symbol, NSString *title, NSString *subtitle, NSString *identifier, id target, SEL action) {
+    UIButton *b = [UIButton buttonWithType:UIButtonTypeSystem];
+    b.frame = frame; b.accessibilityIdentifier = identifier; b.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+    [b addTarget:target action:action forControlEvents:UIControlEventTouchUpInside];
+    UIImageView *icon = MGSymbolView(symbol, [UIColor colorWithRed:.54 green:.60 blue:.72 alpha:1]);
+    icon.frame = CGRectMake(16, (frame.size.height-22)/2, 22, 22); [b addSubview:icon];
+    UILabel *t = MGLabel(title, [UIFont systemFontOfSize:15 weight:UIFontWeightMedium], MGLabelColor());
+    t.frame = CGRectMake(50, subtitle.length?8:(frame.size.height-20)/2, frame.size.width-86, 22); t.adjustsFontSizeToFitWidth = YES; t.minimumScaleFactor = .72; [b addSubview:t];
+    if (subtitle.length) { UILabel *s = MGLabel(subtitle, [UIFont systemFontOfSize:12], MGSubColor()); s.frame=CGRectMake(50,29,frame.size.width-86,18); s.adjustsFontSizeToFitWidth=YES; [b addSubview:s]; }
+    UIImageView *chev = MGSymbolView(@"chevron.right", [UIColor tertiaryLabelColor]); chev.frame = CGRectMake(frame.size.width-28,(frame.size.height-16)/2,10,16); [b addSubview:chev];
+    [card addSubview:b]; return b;
+}
+static void MGDivider(UIView *card, CGFloat y, CGFloat inset) {
+    UIView *d=[[UIView alloc] initWithFrame:CGRectMake(inset,y,card.bounds.size.width-inset,0.5)]; d.backgroundColor=[UIColor separatorColor]; [card addSubview:d];
+}
+
+static CGFloat MGSectionHeader(UIScrollView *scroll, CGFloat y, CGFloat width, NSString *symbol, NSString *title) {
+    UIImageView *iv = MGSymbolView(symbol, [UIColor colorWithRed:.48 green:.55 blue:.67 alpha:1]); iv.frame=CGRectMake(19,y+2,20,20); [scroll addSubview:iv];
+    UILabel *l=MGLabel(title,[UIFont systemFontOfSize:13 weight:UIFontWeightSemibold],[UIColor secondaryLabelColor]); l.frame=CGRectMake(48,y,width-66,24); [scroll addSubview:l];
+    return y+30;
+}
+
+static CGFloat MGAddSwitchRow(UIView *card, CGFloat y, CGFloat h, NSString *symbol, NSString *title, NSString *subtitle, NSString *key, BOOL fallback, id target) {
+    UIImageView *iv=MGSymbolView(symbol,[UIColor colorWithRed:.56 green:.62 blue:.73 alpha:1]); iv.frame=CGRectMake(16,y+(h-22)/2,22,22); [card addSubview:iv];
+    UILabel *t=MGLabel(title,[UIFont systemFontOfSize:15 weight:UIFontWeightMedium],MGLabelColor()); t.frame=CGRectMake(50,y+(subtitle.length?7:(h-22)/2),card.bounds.size.width-130,22); t.adjustsFontSizeToFitWidth=YES; [card addSubview:t];
+    if (subtitle.length) { UILabel *s=MGLabel(subtitle,[UIFont systemFontOfSize:12],MGSubColor()); s.frame=CGRectMake(50,y+29,card.bounds.size.width-130,17); s.adjustsFontSizeToFitWidth=YES; [card addSubview:s]; }
+    UISwitch *sw=[UISwitch new]; sw.on=MGPrefBool(key,fallback); sw.accessibilityIdentifier=[@"pref:" stringByAppendingString:key]; CGSize sz=sw.bounds.size; sw.frame=CGRectMake(card.bounds.size.width-sz.width-16,y+(h-sz.height)/2,sz.width,sz.height); [sw addTarget:target action:@selector(switchChanged:) forControlEvents:UIControlEventValueChanged]; [card addSubview:sw];
+    return y+h;
+}
+static CGFloat MGAddSliderRow(UIView *card, CGFloat y, CGFloat h, NSString *symbol, NSString *title, NSString *key, double fallback, double min, double max, id target) {
+    UIImageView *iv=MGSymbolView(symbol,MGBlue()); iv.frame=CGRectMake(16,y+13,21,21); [card addSubview:iv];
+    UILabel *t=MGLabel(title,[UIFont systemFontOfSize:15 weight:UIFontWeightMedium],MGLabelColor()); t.frame=CGRectMake(50,y+9,card.bounds.size.width-120,22); t.adjustsFontSizeToFitWidth=YES; [card addSubview:t];
+    UILabel *v=MGLabel(@"",[UIFont monospacedDigitSystemFontOfSize:13 weight:UIFontWeightRegular],[UIColor tertiaryLabelColor]); v.textAlignment=NSTextAlignmentRight; v.frame=CGRectMake(card.bounds.size.width-62,y+9,48,22); [card addSubview:v];
+    UISlider *sl=[UISlider new]; sl.minimumValue=min; sl.maximumValue=max; sl.value=MGPrefDouble(key,fallback); sl.accessibilityIdentifier=[@"pref:" stringByAppendingString:key]; sl.frame=CGRectMake(50,y+36,card.bounds.size.width-66,27); [sl addTarget:target action:@selector(sliderChanged:) forControlEvents:UIControlEventValueChanged]; [card addSubview:sl]; objc_setAssociatedObject(sl,MGSliderValueLabelKey,v,OBJC_ASSOCIATION_ASSIGN); v.text=[NSString stringWithFormat:@"%.2f",sl.value];
+    return y+h;
+}
+
+@implementation MGLicenseViewController
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title=@"License & Device";
+    self.view.backgroundColor=[UIColor systemGroupedBackgroundColor];
+    CGFloat w=self.view.bounds.size.width, m=18, y=24;
+    UILabel *brand=MGLabel(@"Next Solution",[UIFont systemFontOfSize:16 weight:UIFontWeightSemibold],MGPurple()); brand.frame=CGRectMake(m,y,w-2*m,24); [self.view addSubview:brand]; y+=34;
+    UILabel *title=MGLabel(@"Module Glass License",[UIFont systemFontOfSize:28 weight:UIFontWeightBold],MGLabelColor()); title.frame=CGRectMake(m,y,w-2*m,38); [self.view addSubview:title]; y+=48;
+    MGLicenseManager *lic=[MGLicenseManager shared];
+    UIView *card=MGRoundedCard(CGRectMake(m,y,w-2*m,190),20); [self.view addSubview:card];
+    UILabel *status=MGLabel(lic.active?@"Activated ✓":@"Not Activated",[UIFont systemFontOfSize:16 weight:UIFontWeightSemibold],lic.active?[UIColor systemGreenColor]:[UIColor systemOrangeColor]); status.frame=CGRectMake(18,15,card.bounds.size.width-36,24); [card addSubview:status];
+    UILabel *price=MGLabel(@"$1.00  •  One-device lifetime license",[UIFont systemFontOfSize:15 weight:UIFontWeightMedium],MGLabelColor()); price.frame=CGRectMake(18,51,card.bounds.size.width-36,24); [card addSubview:price];
+    UILabel *idTitle=MGLabel(@"DEVICE ID",[UIFont systemFontOfSize:11 weight:UIFontWeightSemibold],MGSubColor()); idTitle.frame=CGRectMake(18,89,card.bounds.size.width-36,18); [card addSubview:idTitle];
+    UILabel *device=MGLabel(lic.deviceID,[UIFont monospacedSystemFontOfSize:14 weight:UIFontWeightSemibold],MGLabelColor()); device.frame=CGRectMake(18,108,card.bounds.size.width-36,24); device.adjustsFontSizeToFitWidth=YES; [card addSubview:device];
+    UIButton *copy=[UIButton buttonWithType:UIButtonTypeSystem]; copy.frame=CGRectMake(18,145,130,34); [copy setTitle:@"Copy Device ID" forState:UIControlStateNormal]; copy.layer.cornerRadius=12; copy.backgroundColor=[UIColor tertiarySystemGroupedBackgroundColor]; copy.accessibilityIdentifier=@"license:copy"; [copy addTarget:self.bridge action:@selector(licenseAction:) forControlEvents:UIControlEventTouchUpInside]; [card addSubview:copy];
+    y+=210;
+    UIButton *buy=[UIButton buttonWithType:UIButtonTypeSystem]; buy.frame=CGRectMake(m,y,w-2*m,50); buy.layer.cornerRadius=16; buy.backgroundColor=MGBlue(); [buy setTitleColor:UIColor.whiteColor forState:UIControlStateNormal]; [buy setTitle:@"Buy Activation — $1.00" forState:UIControlStateNormal]; buy.titleLabel.font=[UIFont systemFontOfSize:16 weight:UIFontWeightSemibold]; buy.accessibilityIdentifier=@"license:buy"; [buy addTarget:self.bridge action:@selector(licenseAction:) forControlEvents:UIControlEventTouchUpInside]; [self.view addSubview:buy]; y+=62;
+    UIButton *refresh=[UIButton buttonWithType:UIButtonTypeSystem]; refresh.frame=CGRectMake(m,y,w-2*m,48); refresh.layer.cornerRadius=16; refresh.backgroundColor=MGCardColor(); [refresh setTitle:@"Refresh Activation Status" forState:UIControlStateNormal]; refresh.accessibilityIdentifier=@"license:refresh"; [refresh addTarget:self.bridge action:@selector(licenseAction:) forControlEvents:UIControlEventTouchUpInside]; [self.view addSubview:refresh];
+}
+@end
+
+@implementation MGModernActionBridge
+- (void)switchChanged:(UISwitch *)sender {
+    NSString *key=[sender.accessibilityIdentifier stringByReplacingOccurrencesOfString:@"pref:" withString:@""];
+    if (key.length) MGSetPref(key,@(sender.on));
+}
+- (void)sliderChanged:(UISlider *)sender {
+    NSString *key=[sender.accessibilityIdentifier stringByReplacingOccurrencesOfString:@"pref:" withString:@""];
+    if (key.length) MGSetPref(key,@(sender.value));
+    UILabel *v=objc_getAssociatedObject(sender,MGSliderValueLabelKey); v.text=[NSString stringWithFormat:@"%.2f",sender.value];
+}
+- (void)buttonTapped:(UIButton *)sender {
+    NSString *ident=sender.accessibilityIdentifier ?: @"";
+    if ([ident hasPrefix:@"module:"]) {
+        NSString *slot=[ident substringFromIndex:7]; id spec=MGSpecifierForSlot(self.controller,slot); MGSend1(self.controller,NSSelectorFromString(@"configureCCModuleBackground:"),spec); return;
+    }
+    if ([ident isEqualToString:@"action:volumeColor"]) { MGSend1(self.controller,NSSelectorFromString(@"chooseVolumeIconColor:"),nil); return; }
+    if ([ident isEqualToString:@"action:reset"]) { MGSend1(self.controller,NSSelectorFromString(@"resetAllCCModuleBackgrounds:"),nil); return; }
+    if ([ident isEqualToString:@"action:apply"]) { MGSend1(self.controller,NSSelectorFromString(@"applyCCModuleBackgrounds:"),nil); return; }
+    if ([ident isEqualToString:@"action:respring"]) { MGSend1(self.controller,NSSelectorFromString(@"respringDevice:"),nil); return; }
+}
+- (void)licenseAction:(UIButton *)sender {
+    NSString *ident=sender.accessibilityIdentifier ?: @"";
+    MGLicenseManager *lic=[MGLicenseManager shared];
+    if ([ident isEqualToString:@"license:buy"]) {
+        NSURL *url=lic.checkoutURL;
+        if (url) [UIApplication.sharedApplication openURL:url options:@{} completionHandler:nil];
+        return;
+    }
+    if ([ident isEqualToString:@"license:copy"]) { UIPasteboard.generalPasteboard.string=lic.deviceID; return; }
+    if ([ident isEqualToString:@"license:refresh"]) {
+        sender.enabled=NO; [sender setTitle:@"Checking…" forState:UIControlStateNormal];
+        __weak UIButton *weak=sender; __weak typeof(self) ws=self;
+        [lic refreshWithCompletion:^(BOOL active){ weak.enabled=YES; [weak setTitle:active?@"Activated ✓":@"Refresh Activation Status" forState:UIControlStateNormal]; [ws refreshLicenseUI]; }];
+        return;
+    }
+}
+- (void)showLicense:(id)sender {
+    MGLicenseViewController *vc=[MGLicenseViewController new]; vc.bridge=self; [self.controller.navigationController pushViewController:vc animated:YES];
+}
+- (void)refreshLicenseUI {
+    BOOL active=[MGLicenseManager shared].active;
+    [self.statusButton setTitle:active?@"Activated  ✓":@"Buy  $1" forState:UIControlStateNormal];
+    [self.statusButton setTitleColor:active?[UIColor systemGreenColor]:MGBlue() forState:UIControlStateNormal];
+    [self.licenseButton setTitle:active?@"License & Device":@"Activate • $1.00" forState:UIControlStateNormal];
+}
+@end
+
+static void MGInstallModernUI(UIViewController *vc) {
+    if (!vc || objc_getAssociatedObject(vc,MGInstalledKey)) return;
+    NSString *title=vc.title ?: vc.navigationItem.title ?: @"";
+    if (![title containsString:@"Module"] && ![title containsString:@"Glass"] && ![title containsString:@"Background"]) return;
+    objc_setAssociatedObject(vc,MGInstalledKey,@YES,OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if ([vc.view isKindOfClass:UITableView.class]) ((UITableView *)vc.view).scrollEnabled=NO;
+    CGFloat w=vc.view.bounds.size.width;
+    UIScrollView *scroll=[[UIScrollView alloc] initWithFrame:vc.view.bounds];
+    scroll.autoresizingMask=UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+    scroll.backgroundColor=[UIColor systemGroupedBackgroundColor];
+    scroll.alwaysBounceVertical=YES; scroll.showsVerticalScrollIndicator=YES; scroll.contentInsetAdjustmentBehavior=UIScrollViewContentInsetAdjustmentNever;
+    [vc.view addSubview:scroll];
+    MGModernActionBridge *bridge=[MGModernActionBridge new]; bridge.controller=vc; bridge.scroll=scroll; objc_setAssociatedObject(vc,MGBridgeKey,bridge,OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    CGFloat m=14, cardW=w-2*m, y=12;
+
+    UIView *hero=MGRoundedCard(CGRectMake(m,y,cardW,158),22); hero.backgroundColor=[UIColor colorWithRed:.91 green:.95 blue:1 alpha:1]; [scroll addSubview:hero];
+    CAGradientLayer *grad=[CAGradientLayer layer]; grad.frame=hero.bounds; grad.colors=@[(id)[UIColor colorWithRed:.86 green:.96 blue:1 alpha:.85].CGColor,(id)[UIColor colorWithRed:.94 green:.91 blue:1 alpha:.82].CGColor]; grad.startPoint=CGPointMake(0,0); grad.endPoint=CGPointMake(1,1); [hero.layer insertSublayer:grad atIndex:0];
+    NSBundle *bundle=[NSBundle bundleForClass:[vc class]];
+    NSString *iconPath=[bundle pathForResource:@"NextAura-cc-module-backgrounds" ofType:@"png"];
+    UIImage *icon=iconPath?[UIImage imageWithContentsOfFile:iconPath]:MGSymbol(@"square.grid.2x2.fill",48);
+    UIImageView *app=[[UIImageView alloc] initWithImage:icon]; app.frame=CGRectMake(16,33,78,78); app.contentMode=UIViewContentModeScaleAspectFit; app.layer.cornerRadius=18; app.clipsToBounds=YES; [hero addSubview:app];
+    UILabel *brand=MGLabel(@"✦  Next Solution",[UIFont systemFontOfSize:15 weight:UIFontWeightSemibold],[UIColor colorWithRed:.32 green:.34 blue:.48 alpha:1]); brand.frame=CGRectMake(108,18,cardW-250,24); brand.adjustsFontSizeToFitWidth=YES; [hero addSubview:brand];
+    UILabel *name=MGLabel(@"Module Glass",[UIFont systemFontOfSize:28 weight:UIFontWeightBold],UIColor.blackColor); name.frame=CGRectMake(108,46,cardW-240,38); name.adjustsFontSizeToFitWidth=YES; name.minimumScaleFactor=.72; [hero addSubview:name];
+    UILabel *sub=MGLabel(@"Customize and elevate your\nControl Center experience.",[UIFont systemFontOfSize:14],[UIColor colorWithRed:.30 green:.34 blue:.42 alpha:1]); sub.frame=CGRectMake(108,87,cardW-225,44); sub.adjustsFontSizeToFitWidth=YES; [hero addSubview:sub];
+    UIButton *status=[UIButton buttonWithType:UIButtonTypeSystem]; status.frame=CGRectMake(cardW-132,20,114,36); status.layer.cornerRadius=18; status.backgroundColor=[UIColor colorWithWhite:1 alpha:.70]; status.titleLabel.font=[UIFont systemFontOfSize:14 weight:UIFontWeightMedium]; [status addTarget:bridge action:@selector(showLicense:) forControlEvents:UIControlEventTouchUpInside]; [hero addSubview:status]; bridge.statusButton=status;
+    UIButton *lic=[UIButton buttonWithType:UIButtonTypeSystem]; lic.frame=CGRectMake(cardW-188,76,170,40); lic.layer.cornerRadius=17; lic.backgroundColor=[UIColor colorWithWhite:1 alpha:.72]; lic.titleLabel.font=[UIFont systemFontOfSize:14 weight:UIFontWeightMedium]; [lic setTitleColor:UIColor.blackColor forState:UIControlStateNormal]; [lic addTarget:bridge action:@selector(showLicense:) forControlEvents:UIControlEventTouchUpInside]; [hero addSubview:lic]; bridge.licenseButton=lic;
+    [bridge refreshLicenseUI]; y+=176;
+
+    y=MGSectionHeader(scroll,y,w,@"paintpalette",@"APPEARANCE");
+    CGFloat appearanceH=56*3+76*3;
+    UIView *appearance=MGRoundedCard(CGRectMake(m,y,cardW,appearanceH),18); [scroll addSubview:appearance]; CGFloat ry=0;
+    ry=MGAddSwitchRow(appearance,ry,56,@"circle.dotted",@"Remove Module Blur",@"Disable the blur behind modules.",@"CCModuleRemoveBlur",YES,bridge); MGDivider(appearance,ry,16);
+    ry=MGAddSwitchRow(appearance,ry,56,@"sparkles",@"Enable Module Background Images",@"Use background images for modules.",@"CCModuleBackgroundsEnabled",NO,bridge); MGDivider(appearance,ry,16);
+    ry=MGAddSwitchRow(appearance,ry,56,@"ear",@"Glow Module Icons & Labels",@"Add a subtle glow to icons and labels.",@"CCModuleControlGlowEnabled",YES,bridge); MGDivider(appearance,ry,16);
+    ry=MGAddSliderRow(appearance,ry,76,@"sparkles",@"Icon & Label Glow Intensity",@"CCModuleControlGlowIntensity",.8,.1,1.0,bridge); MGDivider(appearance,ry,16);
+    ry=MGAddSliderRow(appearance,ry,76,@"circle.dashed",@"Background Image Opacity",@"CCModuleBackgroundOpacity",1.0,.25,1.0,bridge); MGDivider(appearance,ry,16);
+    ry=MGAddSliderRow(appearance,ry,76,@"arrow.up.left.and.arrow.down.right",@"Background Image Scale",@"CCModuleBackgroundScale",1.0,.5,4.0,bridge);
+    y+=appearanceH+18;
+
+    y=MGSectionHeader(scroll,y,w,@"speaker.wave.2",@"MEDIA & SLIDERS");
+    UIView *media=MGRoundedCard(CGRectMake(m,y,cardW,56*4),18); [scroll addSubview:media];
+    MGRowButton(media,CGRectMake(0,0,cardW,56),@"sun.max",@"Choose or Remove Brightness",nil,@"module:brightness",bridge,@selector(buttonTapped:)); MGDivider(media,56,16);
+    MGRowButton(media,CGRectMake(0,56,cardW,56),@"speaker.wave.2",@"Choose or Remove Volume",nil,@"module:volume",bridge,@selector(buttonTapped:)); MGDivider(media,112,16);
+    MGAddSwitchRow(media,112,56,@"paintpalette",@"Custom Volume Icon Color",nil,@"CCModuleVolumeIconColorEnabled",NO,bridge); MGDivider(media,168,16);
+    MGRowButton(media,CGRectMake(0,168,cardW,56),@"drop",@"Volume Icon Color",nil,@"action:volumeColor",bridge,@selector(buttonTapped:));
+    y+=56*4+18;
+
+    y=MGSectionHeader(scroll,y,w,@"dot.radiowaves.left.and.right",@"CONNECTIVITY & MEDIA");
+    UIView *connect=MGRoundedCard(CGRectMake(m,y,cardW,56*3),18); [scroll addSubview:connect];
+    MGRowButton(connect,CGRectMake(0,0,cardW,56),@"antenna.radiowaves.left.and.right",@"Choose or Remove Connectivity",nil,@"module:connectivity",bridge,@selector(buttonTapped:)); MGDivider(connect,56,16);
+    MGRowButton(connect,CGRectMake(0,56,cardW,56),@"music.note",@"Choose or Remove Now Playing",nil,@"module:media",bridge,@selector(buttonTapped:)); MGDivider(connect,112,16);
+    MGRowButton(connect,CGRectMake(0,112,cardW,56),@"rectangle.on.rectangle",@"Choose or Remove Screen Mirroring",nil,@"module:screenmirroring",bridge,@selector(buttonTapped:));
+    y+=56*3+18;
+
+    y=MGSectionHeader(scroll,y,w,@"square.grid.2x2",@"UTILITY MODULES");
+    CGFloat gap=12,colW=(cardW-gap)/2.0; CGFloat utilH=48*4;
+    UIView *u1=MGRoundedCard(CGRectMake(m,y,colW,utilH),16), *u2=MGRoundedCard(CGRectMake(m+colW+gap,y,colW,48*3),16); [scroll addSubview:u1]; [scroll addSubview:u2];
+    NSArray *ul=@[@[@"scope",@"Focus",@"focus"],@[@"flashlight.on.fill",@"Flashlight",@"flashlight"],@[@"timer",@"Timer",@"timer"],@[@"plus.forwardslash.minus",@"Calculator",@"calculator"]];
+    NSArray *ur=@[@[@"camera",@"Camera",@"camera"],@[@"lock.rotation",@"Orientation Lock",@"orientation"],@[@"record.circle",@"Screen Recording",@"screenrecording"]];
+    for(NSUInteger i=0;i<ul.count;i++){ NSArray *a=ul[i]; MGRowButton(u1,CGRectMake(0,i*48,colW,48),a[0],a[1],nil,[@"module:" stringByAppendingString:a[2]],bridge,@selector(buttonTapped:)); if(i+1<ul.count) MGDivider(u1,(i+1)*48,14); }
+    for(NSUInteger i=0;i<ur.count;i++){ NSArray *a=ur[i]; MGRowButton(u2,CGRectMake(0,i*48,colW,48),a[0],a[1],nil,[@"module:" stringByAppendingString:a[2]],bridge,@selector(buttonTapped:)); if(i+1<ur.count) MGDivider(u2,(i+1)*48,14); }
+    y+=utilH+18;
+
+    y=MGSectionHeader(scroll,y,w,@"ellipsis.circle",@"OTHER MODULES");
+    UIView *o1=MGRoundedCard(CGRectMake(m,y,colW,48*3),16), *o2=MGRoundedCard(CGRectMake(m+colW+gap,y,colW,48*3),16); [scroll addSubview:o1]; [scroll addSubview:o2];
+    NSArray *ol=@[@[@"battery.25",@"Low Power Mode",@"lowpower"],@[@"moon",@"Dark Mode",@"darkmode"],@[@"ear",@"Hearing",@"hearing"]];
+    NSArray *orr=@[@[@"note.text",@"Notes",@"notes"],@[@"house",@"Home",@"home"],@[@"cube",@"Other Modules",@"other"]];
+    for(NSUInteger i=0;i<ol.count;i++){ NSArray *a=ol[i]; MGRowButton(o1,CGRectMake(0,i*48,colW,48),a[0],a[1],nil,[@"module:" stringByAppendingString:a[2]],bridge,@selector(buttonTapped:)); if(i+1<ol.count) MGDivider(o1,(i+1)*48,14); }
+    for(NSUInteger i=0;i<orr.count;i++){ NSArray *a=orr[i]; MGRowButton(o2,CGRectMake(0,i*48,colW,48),a[0],a[1],nil,[@"module:" stringByAppendingString:a[2]],bridge,@selector(buttonTapped:)); if(i+1<orr.count) MGDivider(o2,(i+1)*48,14); }
+    y+=48*3+18;
+
+    y=MGSectionHeader(scroll,y,w,@"wrench",@"MAINTENANCE");
+    UIView *danger=MGRoundedCard(CGRectMake(m,y,cardW,62),18); danger.backgroundColor=[[UIColor systemRedColor] colorWithAlphaComponent:.07]; danger.layer.borderColor=[[UIColor systemRedColor] colorWithAlphaComponent:.28].CGColor; [scroll addSubview:danger];
+    UIButton *reset=MGRowButton(danger,CGRectMake(0,0,cardW,62),@"trash",@"Remove All Module Images",@"This will remove all custom module images.",@"action:reset",bridge,@selector(buttonTapped:));
+    [reset setTintColor:[UIColor systemRedColor]];
+    for(UIView *sv in reset.subviews) if([sv isKindOfClass:UILabel.class]) ((UILabel*)sv).textColor=[UIColor systemRedColor];
+    y+=80;
+
+    y=MGSectionHeader(scroll,y,w,@"arrow.clockwise",@"APPLY & RESTART");
+    UIView *apply=MGRoundedCard(CGRectMake(m,y,cardW,56*2),18); [scroll addSubview:apply];
+    MGRowButton(apply,CGRectMake(0,0,cardW,56),@"checkmark.circle",@"Apply Module Glass",nil,@"action:apply",bridge,@selector(buttonTapped:)); MGDivider(apply,56,16);
+    MGRowButton(apply,CGRectMake(0,56,cardW,56),@"arrow.triangle.2.circlepath",@"Respring",nil,@"action:respring",bridge,@selector(buttonTapped:));
+    y+=130;
+    scroll.contentSize=CGSizeMake(w,y+16);
+    [[MGLicenseManager shared] refreshWithCompletion:^(__unused BOOL active){ [bridge refreshLicenseUI]; }];
+}
+
+static void (*origViewDidAppear)(id,SEL,BOOL);
+static void mg_viewDidAppear(id self, SEL _cmd, BOOL animated) {
+    if (origViewDidAppear) origViewDidAppear(self,_cmd,animated);
+    dispatch_async(dispatch_get_main_queue(), ^{ if ([self isKindOfClass:UIViewController.class]) MGInstallModernUI((UIViewController *)self); });
+}
+
+static void MGHookController(void) {
+    Class cls=NSClassFromString(@"AuraCategoryListController");
+    if(!cls) return;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ MSHookMessageEx(cls,@selector(viewDidAppear:),(IMP)mg_viewDidAppear,(IMP *)&origViewDidAppear); });
+}
+
+@interface MGBundleWatcher : NSObject
++ (instancetype)shared;
+- (void)didLoad:(NSNotification *)n;
+@end
+@implementation MGBundleWatcher
++ (instancetype)shared { static MGBundleWatcher *x; static dispatch_once_t once; dispatch_once(&once,^{x=[MGBundleWatcher new];}); return x; }
+- (void)didLoad:(NSNotification *)n { MGHookController(); }
+@end
+
+__attribute__((constructor)) static void MGModernPrefsInit(void) {
+    @autoreleasepool {
+        [[NSNotificationCenter defaultCenter] addObserver:[MGBundleWatcher shared] selector:@selector(didLoad:) name:NSBundleDidLoadNotification object:nil];
+        dispatch_async(dispatch_get_main_queue(), ^{ MGHookController(); });
+    }
+}

--- a/.moduleglass-build/mg118_modern_prefs.py
+++ b/.moduleglass-build/mg118_modern_prefs.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import plistlib, sys
+from pathlib import Path
+
+bundle=Path(sys.argv[1])
+p=bundle/'CCModuleBackgrounds.plist'
+old=plistlib.load(open(p,'rb'))
+old_items=old.get('items',[])
+by_slot={i.get('moduleSlot'):i for i in old_items if i.get('moduleSlot')}
+by_label={i.get('label'):i for i in old_items if i.get('label')}
+
+def group(label, footer=None):
+    d={'cell':'PSGroupCell','label':label}
+    if footer: d['footerText']=footer
+    return d
+
+def sw(label,key,default,desc):
+    return {'cell':'PSSwitchCell','label':label,'key':key,'default':default,'defaults':'com.nextsolution.unlockvibrate','description':desc,'PostNotification':'com.nextsolution.unlockvibrate/preferences.changed'}
+
+def slider(label,key,default,minv,maxv,desc):
+    return {'cell':'PSSliderCell','label':label,'key':key,'default':default,'min':minv,'max':maxv,'showValue':True,'defaults':'com.nextsolution.unlockvibrate','description':desc,'PostNotification':'com.nextsolution.unlockvibrate/preferences.changed'}
+
+def module(label,slot,title):
+    d=dict(by_slot.get(slot,{'cell':'PSButtonCell','action':'configureCCModuleBackground:','moduleSlot':slot,'moduleTitle':title}))
+    d['cell']='PSButtonCell'; d['action']='configureCCModuleBackground:'; d['label']=label; d['moduleSlot']=slot; d['moduleTitle']=title
+    return d
+
+def button(label,action,desc=''):
+    d=dict(by_label.get(label,{})); d.update({'cell':'PSButtonCell','label':label,'action':action})
+    if desc: d['description']=desc
+    return d
+
+items=[]
+items += [group('APPEARANCE'),
+          sw('Remove Module Blur','CCModuleRemoveBlur',True,'Disable the blur behind modules.'),
+          sw('Enable Module Background Images','CCModuleBackgroundsEnabled',False,'Use background images for modules.'),
+          sw('Glow Module Icons & Labels','CCModuleControlGlowEnabled',True,'Add a subtle glow to icons and labels.'),
+          slider('Icon & Label Glow Intensity','CCModuleControlGlowIntensity',0.8,0.1,1.0,'Adjust glow intensity.'),
+          slider('Background Image Opacity','CCModuleBackgroundOpacity',1.0,0.25,1.0,'Adjust background image opacity.'),
+          slider('Background Image Scale','CCModuleBackgroundScale',1.0,0.5,4.0,'Background image scale control for the redesigned UI.')]
+items += [group('MEDIA & SLIDERS'),
+          module('Brightness Background','brightness','Brightness'),
+          module('Volume Background','volume','Volume'),
+          sw('Custom Volume Icon Color','CCModuleVolumeIconColorEnabled',False,'Apply a custom native speaker glyph color.'),
+          button('Volume Icon Color','chooseVolumeIconColor:','Choose the Volume glyph color.')]
+items += [group('CONNECTIVITY & MEDIA'),
+          module('Connectivity Background','connectivity','Connectivity'),
+          module('Now Playing Background','media','Now Playing'),
+          module('Screen Mirroring Background','screenmirroring','Screen Mirroring')]
+items += [group('UTILITY MODULES')]
+for label,slot in [('Focus','focus'),('Flashlight','flashlight'),('Timer','timer'),('Calculator','calculator'),('Camera','camera'),('Orientation Lock','orientation'),('Screen Recording','screenrecording')]:
+    items.append(module(label+' Background',slot,label))
+items += [group('OTHER MODULES')]
+for label,slot in [('Low Power Mode','lowpower'),('Dark Mode','darkmode'),('Hearing','hearing'),('Notes','notes'),('Home','home'),('Other Modules','other')]:
+    items.append(module(label+' Background',slot,label))
+items += [group('MAINTENANCE'),button('Remove All Module Images','resetAllCCModuleBackgrounds:','Deletes every custom module background image.')]
+items += [group('APPLY & RESTART'),button('Apply Module Glass','applyCCModuleBackgrounds:'),button('Respring','respringDevice:')]
+
+plistlib.dump({'title':'Module Glass','items':items},open(p,'wb'),fmt=plistlib.FMT_XML,sort_keys=False)
+info=bundle/'Info.plist'
+if info.exists():
+    x=plistlib.load(open(info,'rb'))
+    x['CFBundleShortVersionString']='1.1.18'
+    x['CFBundleVersion']='118'
+    plistlib.dump(x,open(info,'wb'),fmt=plistlib.FMT_XML,sort_keys=False)


### PR DESCRIPTION
Test-only build branch. Replaces the plist-only visual experiment with a custom UIKit Preferences overlay matching the approved Module Glass mockup: branded hero card, activation badge, License & Device, rounded grouped sections, two-column module grids, and red maintenance card. Wires the existing real Module Glass $1 checkout/license registry. Do not merge until device UI test passes.