### PR TITLE
Module Glass 1.1.18 current UI with activation

### DIFF
--- a/.github/workflows/moduleglass-1.1.18-current-ui-activation.yml
+++ b/.github/workflows/moduleglass-1.1.18-current-ui-activation.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -41,11 +41,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          mkdir -p output
           git fetch origin main --depth=1
           git show origin/main:transfer/files/ModuleGlass/1.1.17/ModuleGlass_1.1.17_SelfContainedPrefs_RootHide.deb > /tmp/mg117.deb
           echo "$BASE_SHA  /tmp/mg117.deb" | shasum -a 256 -c -
-          rm -rf stage addon output verify
-          mkdir -p stage addon output
+          rm -rf stage addon verify
+          mkdir -p stage addon
           dpkg-deb -R /tmp/mg117.deb stage
           cp stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist /tmp/mg117-prefs.plist
           echo "$RUNTIME_SHA  stage/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib" | shasum -a 256 -c -
@@ -125,7 +126,7 @@ jobs:
           cat > addon/ModuleGlassActivation.plist <<'PLIST'
           { Filter = { Bundles = ( "com.apple.Preferences", "com.apple.springboard" ); }; }
           PLIST
-          make -C addon clean package FINALPACKAGE=1
+          (make -C addon clean package FINALPACKAGE=1) 2>&1 | tee output/activation-build.log
           RAW="$(find addon/packages -type f -name '*.deb' -print -quit)"
           test -n "$RAW"
           mkdir -p /tmp/mga
@@ -172,6 +173,7 @@ jobs:
           cat output/SHA256SUMS.txt
 
       - name: Upload working DEB
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: ModuleGlass-1.1.18-CurrentUI-Activation-RootHide
@@ -181,3 +183,24 @@ jobs:
             output/PACKAGE-CONTENTS.txt
           if-no-files-found: error
           retention-days: 7
+
+      - name: Publish branch build result
+        if: always() && github.event_name == 'push'
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEST=transfer/builds/ModuleGlass/1.1.18-current-ui-activation
+          mkdir -p "$DEST"
+          rm -f "$DEST"/*
+          cp output/activation-build.log "$DEST"/activation-build.log 2>/dev/null || true
+          cp output/PACKAGE-CONTENTS.txt "$DEST"/PACKAGE-CONTENTS.txt 2>/dev/null || true
+          cp output/SHA256SUMS.txt "$DEST"/SHA256SUMS.txt 2>/dev/null || true
+          cp output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb "$DEST"/ 2>/dev/null || true
+          echo "${{ job.status }}" > "$DEST"/STATUS.txt
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add "$DEST"
+          if ! git diff --cached --quiet; then
+            git commit -m 'ci: publish Module Glass 1.1.18 activation build result'
+            git push origin HEAD:feature/moduleglass-1.1.18-current-ui-activation
+          fi

--- a/.github/workflows/moduleglass-1.1.18-current-ui-activation.yml
+++ b/.github/workflows/moduleglass-1.1.18-current-ui-activation.yml
@@ -204,3 +204,5 @@ jobs:
             git commit -m 'ci: publish Module Glass 1.1.18 activation build result'
             git push origin HEAD:feature/moduleglass-1.1.18-current-ui-activation
           fi
+
+# manual trigger 2026-08-20T16:29+03:00

--- a/.github/workflows/moduleglass-1.1.18-current-ui-activation.yml
+++ b/.github/workflows/moduleglass-1.1.18-current-ui-activation.yml
@@ -1,6 +1,12 @@
 name: Module Glass 1.1.18 Current UI Activation Build
 
 on:
+  push:
+    branches:
+      - feature/moduleglass-1.1.18-current-ui-activation
+    paths:
+      - '.moduleglass-build/ModuleGlassActivation.m'
+      - '.github/workflows/moduleglass-1.1.18-current-ui-activation.yml'
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/moduleglass-1.1.18-current-ui-activation.yml
+++ b/.github/workflows/moduleglass-1.1.18-current-ui-activation.yml
@@ -1,0 +1,177 @@
+name: Module Glass 1.1.18 Current UI Activation Build
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.moduleglass-build/ModuleGlassActivation.m'
+      - '.github/workflows/moduleglass-1.1.18-current-ui-activation.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-14
+    timeout-minutes: 25
+    env:
+      THEOS: ${{ runner.temp }}/theos-roothide
+      THEOS_PACKAGE_SCHEME: roothide
+      BASE_SHA: a15205e928db116e74102a29d4b116d14d1b57f0e9412707493d8c109433ecb0
+      RUNTIME_SHA: fe3bd040d4718d07303b66e011f91c4de67ff9be820c854839ef3bf5d679ac96
+      PREFS_BINARY_SHA: 4aaaf04adbfebe652262d4e5572ac04f3a51fcd2d0d2eb95a113b5d3d93181d1
+      STANDALONE_PREFS_SHA: dbfce7323f000a84354eb891f854f2192e04e181c7ceffdf8cf3512d5764472f
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install tools
+        run: brew install dpkg ldid xz
+
+      - name: Stage validated 1.1.17 baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          git show origin/main:transfer/files/ModuleGlass/1.1.17/ModuleGlass_1.1.17_SelfContainedPrefs_RootHide.deb > /tmp/mg117.deb
+          echo "$BASE_SHA  /tmp/mg117.deb" | shasum -a 256 -c -
+          rm -rf stage addon output verify
+          mkdir -p stage addon output
+          dpkg-deb -R /tmp/mg117.deb stage
+          cp stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist /tmp/mg117-prefs.plist
+          echo "$RUNTIME_SHA  stage/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib" | shasum -a 256 -c -
+          echo "$PREFS_BINARY_SHA  stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/AuraPrefs" | shasum -a 256 -c -
+          echo "$STANDALONE_PREFS_SHA  stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib" | shasum -a 256 -c -
+
+      - name: Append native Activation section only
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          import plistlib
+          bundle=Path('stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle')
+          p=bundle/'CCModuleBackgrounds.plist'
+          old=plistlib.load(open('/tmp/mg117-prefs.plist','rb'))
+          x=plistlib.load(p.open('rb'))
+          assert x == old
+          x['items'] += [
+            {'cell':'PSGroupCell','label':'Activation','footerText':'Module Glass is enabled only for activated devices. Use License & Device to copy your Device ID or refresh activation.'},
+            {'cell':'PSTitleValueCell','label':'Status','defaults':'com.nextsolution.moduleglass','key':'licenseStatusDisplay','default':'Not Activated'},
+            {'cell':'PSButtonCell','label':'License & Device','action':'openModuleGlassLicense:','description':'Shows activation status, Device ID, activation check, and purchase option.'}
+          ]
+          plistlib.dump(x,p.open('wb'),sort_keys=False)
+          info=bundle/'Info.plist'
+          i=plistlib.load(info.open('rb')); i['CFBundleShortVersionString']='1.1.18'; i['CFBundleVersion']='1.1.18'; plistlib.dump(i,info.open('wb'),sort_keys=False)
+          c=Path('stage/DEBIAN/control'); t=c.read_text()
+          t=t.replace('Version: 1.1.17','Version: 1.1.18')
+          t=t.replace('Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.17)','Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.18)')
+          t=t.replace('<= 1.1.16','<= 1.1.17')
+          t=t.replace('Description: Module Glass 1.1.17 keeps the validated 1.1.15 ExternalHostIsolation Control Center runtime and embeds the current Aura Settings preference bundle directly in the same package.','Description: Module Glass 1.1.18 preserves the validated 1.1.17 interface and Control Center runtime, adding Next Solution device activation as the final Settings section.')
+          c.write_text(t)
+          PY
+          plutil -lint stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist
+          plutil -lint stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/Info.plist
+
+      - name: Install pinned RootHide Theos
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$THEOS"
+          git init "$THEOS"
+          git -C "$THEOS" remote add origin https://github.com/roothide/theos.git
+          git -C "$THEOS" fetch --depth 1 origin 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+          git -C "$THEOS" checkout --detach 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+          git -C "$THEOS" submodule update --init --recursive --depth 1
+          test -f "$THEOS/makefiles/common.mk"
+          xcrun --sdk iphoneos --show-sdk-path
+
+      - name: Build activation dylib
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp .moduleglass-build/ModuleGlassActivation.m addon/
+          cat > addon/Makefile <<'MAKE'
+          ARCHS = arm64 arm64e
+          TARGET = iphone:clang:latest:16.0
+          include $(THEOS)/makefiles/common.mk
+          TWEAK_NAME = ModuleGlassActivation
+          ModuleGlassActivation_FILES = ModuleGlassActivation.m
+          ModuleGlassActivation_FRAMEWORKS = UIKit Foundation CoreFoundation
+          ModuleGlassActivation_LIBRARIES = substrate commonCrypto
+          ModuleGlassActivation_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
+          include $(THEOS_MAKE_PATH)/tweak.mk
+          MAKE
+          cat > addon/control <<'CONTROL'
+          Package: com.nextsolution.moduleglass.activation.build
+          Name: Module Glass Activation Build Helper
+          Version: 1.1.18
+          Architecture: iphoneos-arm64e
+          Description: Build helper only.
+          Maintainer: Next Solution
+          Author: Next Solution
+          Section: Tweaks
+          Depends: mobilesubstrate
+          CONTROL
+          cat > addon/ModuleGlassActivation.plist <<'PLIST'
+          { Filter = { Bundles = ( "com.apple.Preferences", "com.apple.springboard" ); }; }
+          PLIST
+          make -C addon clean package FINALPACKAGE=1
+          RAW="$(find addon/packages -type f -name '*.deb' -print -quit)"
+          test -n "$RAW"
+          mkdir -p /tmp/mga
+          dpkg-deb -x "$RAW" /tmp/mga
+          DYLIB="$(find /tmp/mga -type f -name ModuleGlassActivation.dylib -print -quit)"
+          FILTER="$(find /tmp/mga -type f -name ModuleGlassActivation.plist -print -quit)"
+          test -n "$DYLIB"; test -n "$FILTER"
+          cp "$DYLIB" stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.dylib
+          cp "$FILTER" stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.plist
+
+      - name: Package and verify
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod 0755 stage/DEBIAN/postinst
+          DEB=output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb
+          dpkg-deb -b stage "$DEB"
+          dpkg-deb -I "$DEB"
+          dpkg-deb -c "$DEB" > output/PACKAGE-CONTENTS.txt
+          test "$(dpkg-deb -f "$DEB" Package)" = com.nextsolution.nextaura.cc-module-backgrounds
+          test "$(dpkg-deb -f "$DEB" Version)" = 1.1.18
+          test "$(dpkg-deb -f "$DEB" Architecture)" = iphoneos-arm64e
+          mkdir -p verify; dpkg-deb -x "$DEB" verify
+          echo "$RUNTIME_SHA  verify/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib" | shasum -a 256 -c -
+          echo "$PREFS_BINARY_SHA  verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/AuraPrefs" | shasum -a 256 -c -
+          echo "$STANDALONE_PREFS_SHA  verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib" | shasum -a 256 -c -
+          ACT=verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.dylib
+          test -f "$ACT"
+          ARCHS="$(lipo -archs "$ACT")"; echo "$ARCHS"; [[ " $ARCHS " == *' arm64 '* && " $ARCHS " == *' arm64e '* ]]
+          strings -a "$ACT" > output/activation.strings
+          grep -Fq 'Module Glass License & Device' output/activation.strings
+          grep -Fq 'nextsolution-license-v1' output/activation.strings
+          grep -Fq 'licenses/moduleglass.json' output/activation.strings
+          grep -Fq 'openModuleGlassLicense:' output/activation.strings
+          python3 - <<'PY'
+          import plistlib
+          old=plistlib.load(open('/tmp/mg117-prefs.plist','rb'))
+          new=plistlib.load(open('verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist','rb'))
+          assert new['items'][:-3] == old['items']
+          assert [x.get('label') for x in new['items'][-3:]] == ['Activation','Status','License & Device']
+          assert new['items'][-1].get('action') == 'openModuleGlassLicense:'
+          PY
+          shasum -a 256 "$DEB" > output/SHA256SUMS.txt
+          cat output/SHA256SUMS.txt
+
+      - name: Upload working DEB
+        uses: actions/upload-artifact@v4
+        with:
+          name: ModuleGlass-1.1.18-CurrentUI-Activation-RootHide
+          path: |
+            output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb
+            output/SHA256SUMS.txt
+            output/PACKAGE-CONTENTS.txt
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/moduleglass-1.1.18-current-ui-activation.yml
+++ b/.github/workflows/moduleglass-1.1.18-current-ui-activation.yml
@@ -53,34 +53,97 @@ jobs:
           echo "$PREFS_BINARY_SHA  stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/AuraPrefs" | shasum -a 256 -c -
           echo "$STANDALONE_PREFS_SHA  stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib" | shasum -a 256 -c -
 
-      - name: Append native Activation section only
+      - name: Keep 1.1.17 panes and append Activation pane
         shell: bash
         run: |
           set -euo pipefail
           python3 - <<'PY'
           from pathlib import Path
           import plistlib
-          bundle=Path('stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle')
-          p=bundle/'CCModuleBackgrounds.plist'
-          old=plistlib.load(open('/tmp/mg117-prefs.plist','rb'))
-          x=plistlib.load(p.open('rb'))
-          assert x == old
-          x['items'] += [
-            {'cell':'PSGroupCell','label':'Activation','footerText':'Module Glass is enabled only for activated devices. Use License & Device to copy your Device ID or refresh activation.'},
-            {'cell':'PSTitleValueCell','label':'Status','defaults':'com.nextsolution.moduleglass','key':'licenseStatusDisplay','default':'Not Activated'},
-            {'cell':'PSButtonCell','label':'License & Device','action':'openModuleGlassLicense:','description':'Shows activation status, Device ID, activation check, and purchase option.'}
-          ]
-          plistlib.dump(x,p.open('wb'),sort_keys=False)
-          info=bundle/'Info.plist'
-          i=plistlib.load(info.open('rb')); i['CFBundleShortVersionString']='1.1.18'; i['CFBundleVersion']='1.1.18'; plistlib.dump(i,info.open('wb'),sort_keys=False)
-          c=Path('stage/DEBIAN/control'); t=c.read_text()
-          t=t.replace('Version: 1.1.17','Version: 1.1.18')
-          t=t.replace('Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.17)','Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.18)')
-          t=t.replace('<= 1.1.16','<= 1.1.17')
-          t=t.replace('Description: Module Glass 1.1.17 keeps the validated 1.1.15 ExternalHostIsolation Control Center runtime and embeds the current Aura Settings preference bundle directly in the same package.','Description: Module Glass 1.1.18 preserves the validated 1.1.17 interface and Control Center runtime, adding Next Solution device activation as the final Settings section.')
-          c.write_text(t)
+
+          bundle = Path('stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle')
+          root_path = bundle / 'CCModuleBackgrounds.plist'
+          old = plistlib.load(open('/tmp/mg117-prefs.plist','rb'))
+          root = plistlib.load(root_path.open('rb'))
+          assert root == old
+
+          # Preserve every existing 1.1.17 pane/specifier and add one pane only.
+          root['items'].append({
+              'cell': 'PSLinkCell',
+              'label': 'Activation',
+              'detail': 'PSListController',
+              'file': 'ModuleGlassActivation'
+          })
+          plistlib.dump(root, root_path.open('wb'), sort_keys=False)
+
+          activation = {
+              'items': [
+                  {
+                      'cell': 'PSGroupCell',
+                      'label': 'Module Glass Activation',
+                      'footerText': 'One-time activation: $1.00. Activation is tied to this device.'
+                  },
+                  {
+                      'cell': 'PSTitleValueCell',
+                      'label': 'Status',
+                      'defaults': 'com.nextsolution.moduleglass',
+                      'key': 'licenseStatusDisplay',
+                      'default': 'Not Activated'
+                  },
+                  {
+                      'cell': 'PSTitleValueCell',
+                      'label': 'Device ID',
+                      'defaults': 'com.nextsolution.moduleglass',
+                      'key': 'deviceIDDisplay',
+                      'default': 'Loading…'
+                  },
+                  {
+                      'cell': 'PSButtonCell',
+                      'label': 'Copy Device ID',
+                      'action': 'moduleGlassCopyDeviceID:'
+                  },
+                  {
+                      'cell': 'PSButtonCell',
+                      'label': 'Buy Activation — $1.00',
+                      'action': 'moduleGlassBuyActivation:'
+                  },
+                  {
+                      'cell': 'PSButtonCell',
+                      'label': 'Check / Refresh Activation',
+                      'action': 'moduleGlassCheckActivation:'
+                  },
+                  {
+                      'cell': 'PSButtonCell',
+                      'label': 'Restore Activation',
+                      'action': 'moduleGlassRestoreActivation:'
+                  }
+              ]
+          }
+          plistlib.dump(activation, (bundle/'ModuleGlassActivation.plist').open('wb'), sort_keys=False)
+
+          info = bundle/'Info.plist'
+          i = plistlib.load(info.open('rb'))
+          i['CFBundleShortVersionString'] = '1.1.18'
+          i['CFBundleVersion'] = '1.1.18'
+          plistlib.dump(i, info.open('wb'), sort_keys=False)
+
+          control = Path('stage/DEBIAN/control')
+          text = control.read_text()
+          text = text.replace('Version: 1.1.17', 'Version: 1.1.18')
+          text = text.replace('Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.17)', 'Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.18)')
+          text = text.replace('<= 1.1.16', '<= 1.1.17')
+          if 'Description:' in text:
+              lines = text.splitlines()
+              lines = [
+                  'Description: Module Glass 1.1.18 preserves the validated 1.1.17 pane-based Settings UI and Control Center runtime, adding only a final Activation pane.'
+                  if line.startswith('Description:') else line
+                  for line in lines
+              ]
+              text = '\n'.join(lines) + '\n'
+          control.write_text(text)
           PY
           plutil -lint stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist
+          plutil -lint stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/ModuleGlassActivation.plist
           plutil -lint stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/Info.plist
 
       - name: Install pinned RootHide Theos
@@ -108,7 +171,7 @@ jobs:
           TWEAK_NAME = ModuleGlassActivation
           ModuleGlassActivation_FILES = ModuleGlassActivation.m
           ModuleGlassActivation_FRAMEWORKS = UIKit Foundation CoreFoundation
-          ModuleGlassActivation_LIBRARIES = substrate commonCrypto
+          ModuleGlassActivation_LIBRARIES = substrate
           ModuleGlassActivation_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
           include $(THEOS_MAKE_PATH)/tweak.mk
           MAKE
@@ -129,7 +192,7 @@ jobs:
           (make -C addon clean package FINALPACKAGE=1) 2>&1 | tee output/activation-build.log
           RAW="$(find addon/packages -type f -name '*.deb' -print -quit)"
           test -n "$RAW"
-          mkdir -p /tmp/mga
+          rm -rf /tmp/mga && mkdir -p /tmp/mga
           dpkg-deb -x "$RAW" /tmp/mga
           DYLIB="$(find /tmp/mga -type f -name ModuleGlassActivation.dylib -print -quit)"
           FILTER="$(find /tmp/mga -type f -name ModuleGlassActivation.plist -print -quit)"
@@ -142,33 +205,50 @@ jobs:
         run: |
           set -euo pipefail
           chmod 0755 stage/DEBIAN/postinst
-          DEB=output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb
+          DEB=output/ModuleGlass_1.1.18_Final_Activation_RootHide.deb
           dpkg-deb -b stage "$DEB"
           dpkg-deb -I "$DEB"
           dpkg-deb -c "$DEB" > output/PACKAGE-CONTENTS.txt
           test "$(dpkg-deb -f "$DEB" Package)" = com.nextsolution.nextaura.cc-module-backgrounds
           test "$(dpkg-deb -f "$DEB" Version)" = 1.1.18
           test "$(dpkg-deb -f "$DEB" Architecture)" = iphoneos-arm64e
-          mkdir -p verify; dpkg-deb -x "$DEB" verify
+          mkdir -p verify
+          dpkg-deb -x "$DEB" verify
+
+          # Baseline runtime/UI binaries must remain byte-identical to 1.1.17.
           echo "$RUNTIME_SHA  verify/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib" | shasum -a 256 -c -
           echo "$PREFS_BINARY_SHA  verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/AuraPrefs" | shasum -a 256 -c -
           echo "$STANDALONE_PREFS_SHA  verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib" | shasum -a 256 -c -
+
           ACT=verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.dylib
           test -f "$ACT"
-          ARCHS="$(lipo -archs "$ACT")"; echo "$ARCHS"; [[ " $ARCHS " == *' arm64 '* && " $ARCHS " == *' arm64e '* ]]
+          ARCHS="$(lipo -archs "$ACT")"
+          echo "Activation dylib architectures: $ARCHS"
+          [[ " $ARCHS " == *' arm64 '* && " $ARCHS " == *' arm64e '* ]]
           strings -a "$ACT" > output/activation.strings
-          grep -Fq 'Module Glass License & Device' output/activation.strings
           grep -Fq 'nextsolution-license-v1' output/activation.strings
           grep -Fq 'licenses/moduleglass.json' output/activation.strings
-          grep -Fq 'openModuleGlassLicense:' output/activation.strings
+          grep -Fq 'moduleGlassCopyDeviceID:' output/activation.strings
+          grep -Fq 'moduleGlassBuyActivation:' output/activation.strings
+          grep -Fq 'moduleGlassCheckActivation:' output/activation.strings
+          grep -Fq 'moduleGlassRestoreActivation:' output/activation.strings
+
           python3 - <<'PY'
           import plistlib
-          old=plistlib.load(open('/tmp/mg117-prefs.plist','rb'))
-          new=plistlib.load(open('verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist','rb'))
-          assert new['items'][:-3] == old['items']
-          assert [x.get('label') for x in new['items'][-3:]] == ['Activation','Status','License & Device']
-          assert new['items'][-1].get('action') == 'openModuleGlassLicense:'
+          old = plistlib.load(open('/tmp/mg117-prefs.plist','rb'))
+          new = plistlib.load(open('verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist','rb'))
+          assert new['items'][:-1] == old['items']
+          link = new['items'][-1]
+          assert link.get('cell') == 'PSLinkCell'
+          assert link.get('label') == 'Activation'
+          assert link.get('detail') == 'PSListController'
+          assert link.get('file') == 'ModuleGlassActivation'
+          child = plistlib.load(open('verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/ModuleGlassActivation.plist','rb'))
+          labels = [x.get('label') for x in child['items']]
+          for wanted in ['Status','Device ID','Copy Device ID','Buy Activation — $1.00','Check / Refresh Activation','Restore Activation']:
+              assert wanted in labels
           PY
+
           shasum -a 256 "$DEB" > output/SHA256SUMS.txt
           cat output/SHA256SUMS.txt
 
@@ -176,9 +256,9 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: ModuleGlass-1.1.18-CurrentUI-Activation-RootHide
+          name: ModuleGlass-1.1.18-Final-Activation-RootHide
           path: |
-            output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb
+            output/ModuleGlass_1.1.18_Final_Activation_RootHide.deb
             output/SHA256SUMS.txt
             output/PACKAGE-CONTENTS.txt
           if-no-files-found: error
@@ -195,7 +275,7 @@ jobs:
           cp output/activation-build.log "$DEST"/activation-build.log 2>/dev/null || true
           cp output/PACKAGE-CONTENTS.txt "$DEST"/PACKAGE-CONTENTS.txt 2>/dev/null || true
           cp output/SHA256SUMS.txt "$DEST"/SHA256SUMS.txt 2>/dev/null || true
-          cp output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb "$DEST"/ 2>/dev/null || true
+          cp output/ModuleGlass_1.1.18_Final_Activation_RootHide.deb "$DEST"/ 2>/dev/null || true
           echo "${{ job.status }}" > "$DEST"/STATUS.txt
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
@@ -204,5 +284,3 @@ jobs:
             git commit -m 'ci: publish Module Glass 1.1.18 activation build result'
             git push origin HEAD:feature/moduleglass-1.1.18-current-ui-activation
           fi
-
-# manual trigger 2026-08-20T16:29+03:00

--- a/.github/workflows/moduleglass-1.1.18-modern-settings-test-v2.yml
+++ b/.github/workflows/moduleglass-1.1.18-modern-settings-test-v2.yml
@@ -18,129 +18,89 @@ concurrency:
 jobs:
   build:
     runs-on: macos-14
-    timeout-minutes: 30
+    timeout-minutes: 25
     env:
-      THEOS: ${{ github.workspace }}/theos
+      THEOS: ${{ runner.temp }}/theos-roothide
       THEOS_PACKAGE_SCHEME: roothide
       BASE_SHA: a15205e928db116e74102a29d4b116d14d1b57f0e9412707493d8c109433ecb0
       RUNTIME_SHA: fe3bd040d4718d07303b66e011f91c4de67ff9be820c854839ef3bf5d679ac96
       PREFS_BINARY_SHA: 4aaaf04adbfebe652262d4e5572ac04f3a51fcd2d0d2eb95a113b5d3d93181d1
       STANDALONE_PREFS_SHA: dbfce7323f000a84354eb891f854f2192e04e181c7ceffdf8cf3512d5764472f
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install packaging tools
+      - name: Install tools
         run: brew install dpkg ldid xz
 
-      - name: Extract exact working 1.1.17 baseline
+      - name: Stage validated 1.1.17 baseline
         shell: bash
         run: |
           set -euo pipefail
           git fetch origin main --depth=1
-          git show origin/main:transfer/files/ModuleGlass/1.1.17/ModuleGlass_1.1.17_SelfContainedPrefs_RootHide.deb > /tmp/moduleglass117.deb
-          echo "$BASE_SHA  /tmp/moduleglass117.deb" | shasum -a 256 -c -
-          rm -rf stage output addon verify
-          mkdir -p stage output addon
-          dpkg-deb -R /tmp/moduleglass117.deb stage
-          cp stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist /tmp/CCModuleBackgrounds.1.1.17.plist
+          git show origin/main:transfer/files/ModuleGlass/1.1.17/ModuleGlass_1.1.17_SelfContainedPrefs_RootHide.deb > /tmp/mg117.deb
+          echo "$BASE_SHA  /tmp/mg117.deb" | shasum -a 256 -c -
+          rm -rf stage addon output verify
+          mkdir -p stage addon output
+          dpkg-deb -R /tmp/mg117.deb stage
+          cp stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist /tmp/mg117-prefs.plist
           echo "$RUNTIME_SHA  stage/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib" | shasum -a 256 -c -
           echo "$PREFS_BINARY_SHA  stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/AuraPrefs" | shasum -a 256 -c -
           echo "$STANDALONE_PREFS_SHA  stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib" | shasum -a 256 -c -
 
-      - name: Keep current Settings design and append Activation at the end
+      - name: Append native Activation section only
         shell: bash
         run: |
           set -euo pipefail
           python3 - <<'PY'
           from pathlib import Path
           import plistlib
-
-          bundle = Path('stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle')
-          prefs = bundle / 'CCModuleBackgrounds.plist'
-          original = Path('/tmp/CCModuleBackgrounds.1.1.17.plist')
-          before = plistlib.load(original.open('rb'))
-          current = plistlib.load(prefs.open('rb'))
-          assert current == before, '1.1.17 preferences changed before activation patch'
-          items = current['items']
-          assert not any(i.get('label') == 'Activation' for i in items), 'Activation already present'
-          items.extend([
-              {
-                  'cell': 'PSGroupCell',
-                  'label': 'Activation',
-                  'footerText': 'Module Glass is enabled only for activated devices. Use License & Device to copy your Device ID or refresh activation.'
-              },
-              {
-                  'cell': 'PSTitleValueCell',
-                  'label': 'Status',
-                  'defaults': 'com.nextsolution.moduleglass',
-                  'key': 'licenseStatusDisplay',
-                  'default': 'Not Activated'
-              },
-              {
-                  'cell': 'PSButtonCell',
-                  'label': 'License & Device',
-                  'action': 'openModuleGlassLicense:',
-                  'description': 'Shows activation status, Device ID, activation check, and purchase option.'
-              }
-          ])
-          with prefs.open('wb') as f:
-              plistlib.dump(current, f, sort_keys=False)
-
-          info_path = bundle / 'Info.plist'
-          info = plistlib.load(info_path.open('rb'))
-          info['CFBundleShortVersionString'] = '1.1.18'
-          info['CFBundleVersion'] = '1.1.18'
-          with info_path.open('wb') as f:
-              plistlib.dump(info, f, sort_keys=False)
-
-          control = Path('stage/DEBIAN/control')
-          text = control.read_text()
-          text = text.replace('Version: 1.1.17', 'Version: 1.1.18')
-          text = text.replace('Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.17)', 'Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.18)')
-          text = text.replace('<= 1.1.16', '<= 1.1.17')
-          old = 'Description: Module Glass 1.1.17 keeps the validated 1.1.15 ExternalHostIsolation Control Center runtime and embeds the current Aura Settings preference bundle directly in the same package.'
-          new = 'Description: Module Glass 1.1.18 preserves the validated 1.1.17 interface and Control Center runtime, adding Next Solution device activation as the final Settings section.'
-          if old not in text:
-              raise SystemExit('baseline description anchor missing')
-          text = text.replace(old, new)
-          control.write_text(text)
+          bundle=Path('stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle')
+          p=bundle/'CCModuleBackgrounds.plist'
+          old=plistlib.load(open('/tmp/mg117-prefs.plist','rb'))
+          x=plistlib.load(p.open('rb'))
+          assert x == old
+          x['items'] += [
+            {'cell':'PSGroupCell','label':'Activation','footerText':'Module Glass is enabled only for activated devices. Use License & Device to copy your Device ID or refresh activation.'},
+            {'cell':'PSTitleValueCell','label':'Status','defaults':'com.nextsolution.moduleglass','key':'licenseStatusDisplay','default':'Not Activated'},
+            {'cell':'PSButtonCell','label':'License & Device','action':'openModuleGlassLicense:','description':'Shows activation status, Device ID, activation check, and purchase option.'}
+          ]
+          plistlib.dump(x,p.open('wb'),sort_keys=False)
+          info=bundle/'Info.plist'
+          i=plistlib.load(info.open('rb')); i['CFBundleShortVersionString']='1.1.18'; i['CFBundleVersion']='1.1.18'; plistlib.dump(i,info.open('wb'),sort_keys=False)
+          c=Path('stage/DEBIAN/control'); t=c.read_text()
+          t=t.replace('Version: 1.1.17','Version: 1.1.18')
+          t=t.replace('Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.17)','Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.18)')
+          t=t.replace('<= 1.1.16','<= 1.1.17')
+          t=t.replace('Description: Module Glass 1.1.17 keeps the validated 1.1.15 ExternalHostIsolation Control Center runtime and embeds the current Aura Settings preference bundle directly in the same package.','Description: Module Glass 1.1.18 preserves the validated 1.1.17 interface and Control Center runtime, adding Next Solution device activation as the final Settings section.')
+          c.write_text(t)
           PY
-          plutil -lint stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/Info.plist
           plutil -lint stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist
-          test "$(dpkg-deb -f /tmp/moduleglass117.deb Package)" = 'com.nextsolution.nextaura.cc-module-backgrounds'
-          test "$(grep '^Version:' stage/DEBIAN/control | awk '{print $2}')" = '1.1.18'
-          echo "$RUNTIME_SHA  stage/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib" | shasum -a 256 -c -
-          echo "$PREFS_BINARY_SHA  stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/AuraPrefs" | shasum -a 256 -c -
-          echo "$STANDALONE_PREFS_SHA  stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib" | shasum -a 256 -c -
+          plutil -lint stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/Info.plist
 
-      - name: Install RootHide Theos
+      - name: Install pinned RootHide Theos
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "$THEOS"
-          curl -fsSL https://raw.githubusercontent.com/roothide/theos/master/bin/install-theos -o /tmp/install-theos
-          for attempt in 1 2 3; do
-            if bash /tmp/install-theos; then break; fi
-            if [ "$attempt" = 3 ]; then exit 1; fi
-            sleep 3
-          done
+          rm -rf "$THEOS"
+          git init "$THEOS"
+          git -C "$THEOS" remote add origin https://github.com/roothide/theos.git
+          git -C "$THEOS" fetch --depth 1 origin 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+          git -C "$THEOS" checkout --detach 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+          git -C "$THEOS" submodule update --init --recursive --depth 1
           test -f "$THEOS/makefiles/common.mk"
-          mkdir -p "$THEOS/sdks"
-          if ! ls "$THEOS"/sdks/iPhoneOS*.sdk >/dev/null 2>&1; then
-            curl -fL --retry 3 https://github.com/theos/sdks/releases/download/master-146e41f/iPhoneOS16.5.sdk.tar.xz -o /tmp/sdk.tar.xz
-            tar -xJf /tmp/sdk.tar.xz -C "$THEOS/sdks"
-          fi
+          xcrun --sdk iphoneos --show-sdk-path
 
-      - name: Prepare activation build helper
+      - name: Build activation dylib
         shell: bash
         run: |
           set -euo pipefail
           cp .moduleglass-build/ModuleGlassActivation.m addon/
           cat > addon/Makefile <<'MAKE'
           ARCHS = arm64 arm64e
-          TARGET = iphone:clang:16.5:16.0
+          TARGET = iphone:clang:latest:16.0
           include $(THEOS)/makefiles/common.mk
           TWEAK_NAME = ModuleGlassActivation
           ModuleGlassActivation_FILES = ModuleGlassActivation.m
@@ -163,83 +123,58 @@ jobs:
           cat > addon/ModuleGlassActivation.plist <<'PLIST'
           { Filter = { Bundles = ( "com.apple.Preferences", "com.apple.springboard" ); }; }
           PLIST
-
-      - name: Compile activation layer
-        shell: bash
-        run: |
-          set -euxo pipefail
-          cd addon
-          make clean
-          make package FINALPACKAGE=1
-          RAW="$(find packages -maxdepth 1 -type f -name '*.deb' -print -quit)"
+          make -C addon clean package FINALPACKAGE=1
+          RAW="$(find addon/packages -type f -name '*.deb' -print -quit)"
           test -n "$RAW"
-          rm -rf /tmp/mgactivation && mkdir -p /tmp/mgactivation
-          dpkg-deb -x "$RAW" /tmp/mgactivation
-          DYLIB="$(find /tmp/mgactivation -type f -name 'ModuleGlassActivation.dylib' -print -quit)"
-          FILTER="$(find /tmp/mgactivation -type f -name 'ModuleGlassActivation.plist' -print -quit)"
-          test -n "$DYLIB" && test -n "$FILTER"
-          cd ..
+          rm -rf /tmp/mga && mkdir -p /tmp/mga
+          dpkg-deb -x "$RAW" /tmp/mga
+          DYLIB="$(find /tmp/mga -type f -name ModuleGlassActivation.dylib -print -quit)"
+          FILTER="$(find /tmp/mga -type f -name ModuleGlassActivation.plist -print -quit)"
+          test -n "$DYLIB"; test -n "$FILTER"
           cp "$DYLIB" stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.dylib
           cp "$FILTER" stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.plist
 
-      - name: Package and validate 1.1.18 RootHide DEB
+      - name: Package and verify
         shell: bash
         run: |
           set -euo pipefail
           chmod 0755 stage/DEBIAN/postinst
-          dpkg-deb -b stage output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb
           DEB=output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb
+          dpkg-deb -b stage "$DEB"
           dpkg-deb -I "$DEB"
           dpkg-deb -c "$DEB" > output/PACKAGE-CONTENTS.txt
-          test "$(dpkg-deb -f "$DEB" Package)" = 'com.nextsolution.nextaura.cc-module-backgrounds'
-          test "$(dpkg-deb -f "$DEB" Version)" = '1.1.18'
-          test "$(dpkg-deb -f "$DEB" Architecture)" = 'iphoneos-arm64e'
-          rm -rf verify && mkdir verify
-          dpkg-deb -x "$DEB" verify
-          RUNTIME=verify/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib
-          ACTIVATION=verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.dylib
-          echo "$RUNTIME_SHA  $RUNTIME" | shasum -a 256 -c -
+          test "$(dpkg-deb -f "$DEB" Package)" = com.nextsolution.nextaura.cc-module-backgrounds
+          test "$(dpkg-deb -f "$DEB" Version)" = 1.1.18
+          test "$(dpkg-deb -f "$DEB" Architecture)" = iphoneos-arm64e
+          mkdir -p verify; dpkg-deb -x "$DEB" verify
+          echo "$RUNTIME_SHA  verify/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib" | shasum -a 256 -c -
           echo "$PREFS_BINARY_SHA  verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/AuraPrefs" | shasum -a 256 -c -
           echo "$STANDALONE_PREFS_SHA  verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib" | shasum -a 256 -c -
-          test -f "$ACTIVATION"
-          test -f verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.plist
-          test -f verify/Library/PreferenceLoader/Preferences/NextAura-cc-module-backgrounds.plist
-          ARCHS="$(lipo -archs "$ACTIVATION")"
-          [[ " $ARCHS " == *' arm64 '* && " $ARCHS " == *' arm64e '* ]]
-          strings -a "$ACTIVATION" > output/activation.strings
+          ACT=verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.dylib
+          test -f "$ACT"
+          ARCHS="$(lipo -archs "$ACT")"; echo "$ARCHS"; [[ " $ARCHS " == *' arm64 '* && " $ARCHS " == *' arm64e '* ]]
+          strings -a "$ACT" > output/activation.strings
           grep -Fq 'Module Glass License & Device' output/activation.strings
-          grep -Fq 'licenses/moduleglass.json' output/activation.strings
           grep -Fq 'nextsolution-license-v1' output/activation.strings
+          grep -Fq 'licenses/moduleglass.json' output/activation.strings
           grep -Fq 'openModuleGlassLicense:' output/activation.strings
-          grep -Fq 'com.nextsolution.unlockvibrate' output/activation.strings
           python3 - <<'PY'
           import plistlib
-          old = plistlib.load(open('/tmp/CCModuleBackgrounds.1.1.17.plist','rb'))
-          new = plistlib.load(open('verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist','rb'))
-          assert new['items'][:-3] == old['items'], 'existing 1.1.17 settings were modified'
-          tail = new['items'][-3:]
-          assert [x.get('label') for x in tail] == ['Activation', 'Status', 'License & Device'], tail
-          assert tail[2].get('action') == 'openModuleGlassLicense:'
-          assert tail[1].get('defaults') == 'com.nextsolution.moduleglass'
-          info = plistlib.load(open('verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/Info.plist','rb'))
-          assert info['CFBundleShortVersionString'] == '1.1.18'
-          assert info['CFBundleVersion'] == '1.1.18'
+          old=plistlib.load(open('/tmp/mg117-prefs.plist','rb'))
+          new=plistlib.load(open('verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist','rb'))
+          assert new['items'][:-3] == old['items']
+          assert [x.get('label') for x in new['items'][-3:]] == ['Activation','Status','License & Device']
+          assert new['items'][-1].get('action') == 'openModuleGlassLicense:'
           PY
-          mkdir -p output/source/ModuleGlass-1.1.18-CurrentUI-Activation
-          cp .moduleglass-build/ModuleGlassActivation.m output/source/ModuleGlass-1.1.18-CurrentUI-Activation/
-          cp verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist output/source/ModuleGlass-1.1.18-CurrentUI-Activation/
-          cp verify/DEBIAN/control output/source/ModuleGlass-1.1.18-CurrentUI-Activation/control 2>/dev/null || cp stage/DEBIAN/control output/source/ModuleGlass-1.1.18-CurrentUI-Activation/control
-          ditto -c -k --sequesterRsrc --keepParent output/source/ModuleGlass-1.1.18-CurrentUI-Activation output/ModuleGlass_1.1.18_CurrentUI_Activation_Source.zip
-          shasum -a 256 "$DEB" output/ModuleGlass_1.1.18_CurrentUI_Activation_Source.zip > output/SHA256SUMS.txt
+          shasum -a 256 "$DEB" > output/SHA256SUMS.txt
           cat output/SHA256SUMS.txt
 
-      - name: Upload validated artifacts
+      - name: Upload working DEB
         uses: actions/upload-artifact@v4
         with:
           name: ModuleGlass-1.1.18-CurrentUI-Activation-RootHide
           path: |
             output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb
-            output/ModuleGlass_1.1.18_CurrentUI_Activation_Source.zip
             output/SHA256SUMS.txt
             output/PACKAGE-CONTENTS.txt
           if-no-files-found: error

--- a/.github/workflows/moduleglass-1.1.18-modern-settings-test-v2.yml
+++ b/.github/workflows/moduleglass-1.1.18-modern-settings-test-v2.yml
@@ -1,12 +1,10 @@
-name: Build Module Glass 1.1.18 Modern Settings Test V2
+name: Build Module Glass 1.1.18 Current UI + Activation
 
 on:
   pull_request:
     branches: [main]
     paths:
-      - '.moduleglass-build/ModuleGlassModernPrefs.m'
-      - '.moduleglass-build/ModuleGlassLicenseGate.m'
-      - '.moduleglass-build/mg118_modern_prefs.py'
+      - '.moduleglass-build/ModuleGlassActivation.m'
       - '.github/workflows/moduleglass-1.1.18-modern-settings-test-v2.yml'
   workflow_dispatch:
 
@@ -14,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: moduleglass-1.1.18-modern-v2-${{ github.event.pull_request.number || github.ref }}
+  group: moduleglass-1.1.18-current-ui-activation-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -26,48 +24,96 @@ jobs:
       THEOS_PACKAGE_SCHEME: roothide
       BASE_SHA: a15205e928db116e74102a29d4b116d14d1b57f0e9412707493d8c109433ecb0
       RUNTIME_SHA: fe3bd040d4718d07303b66e011f91c4de67ff9be820c854839ef3bf5d679ac96
+      PREFS_BINARY_SHA: 4aaaf04adbfebe652262d4e5572ac04f3a51fcd2d0d2eb95a113b5d3d93181d1
+      STANDALONE_PREFS_SHA: dbfce7323f000a84354eb891f854f2192e04e181c7ceffdf8cf3512d5764472f
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install tools
+      - name: Install packaging tools
         run: brew install dpkg ldid xz
 
-      - name: Extract exact working 1.1.17 package
+      - name: Extract exact working 1.1.17 baseline
         shell: bash
         run: |
           set -euo pipefail
           git fetch origin main --depth=1
           git show origin/main:transfer/files/ModuleGlass/1.1.17/ModuleGlass_1.1.17_SelfContainedPrefs_RootHide.deb > /tmp/moduleglass117.deb
           echo "$BASE_SHA  /tmp/moduleglass117.deb" | shasum -a 256 -c -
-          rm -rf stage output addon
+          rm -rf stage output addon verify
           mkdir -p stage output addon
           dpkg-deb -R /tmp/moduleglass117.deb stage
+          cp stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist /tmp/CCModuleBackgrounds.1.1.17.plist
           echo "$RUNTIME_SHA  stage/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib" | shasum -a 256 -c -
+          echo "$PREFS_BINARY_SHA  stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/AuraPrefs" | shasum -a 256 -c -
+          echo "$STANDALONE_PREFS_SHA  stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib" | shasum -a 256 -c -
 
-      - name: Apply modern grouped preferences
+      - name: Keep current Settings design and append Activation at the end
         shell: bash
         run: |
           set -euo pipefail
-          BUNDLE=stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle
-          python3 .moduleglass-build/mg118_modern_prefs.py "$BUNDLE"
           python3 - <<'PY'
           from pathlib import Path
-          p=Path('stage/DEBIAN/control')
-          t=p.read_text()
-          t=t.replace('Version: 1.1.17','Version: 1.1.18')
-          t=t.replace('Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.17)','Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.18)')
-          t=t.replace('<= 1.1.16','<= 1.1.17')
-          old='Description: Module Glass 1.1.17 keeps the validated 1.1.15 ExternalHostIsolation Control Center runtime and embeds the current Aura Settings preference bundle directly in the same package.'
-          new='Description: Module Glass 1.1.18 UI Test 1 preserves the validated 1.1.15 External Host Isolation Control Center runtime bit-for-bit and adds a Next Solution branded modern Settings UI, grouped module selectors, and live device activation.'
-          t=t.replace(old,new)
-          p.write_text(t)
+          import plistlib
+
+          bundle = Path('stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle')
+          prefs = bundle / 'CCModuleBackgrounds.plist'
+          original = Path('/tmp/CCModuleBackgrounds.1.1.17.plist')
+          before = plistlib.load(original.open('rb'))
+          current = plistlib.load(prefs.open('rb'))
+          assert current == before, '1.1.17 preferences changed before activation patch'
+          items = current['items']
+          assert not any(i.get('label') == 'Activation' for i in items), 'Activation already present'
+          items.extend([
+              {
+                  'cell': 'PSGroupCell',
+                  'label': 'Activation',
+                  'footerText': 'Module Glass is enabled only for activated devices. Use License & Device to copy your Device ID or refresh activation.'
+              },
+              {
+                  'cell': 'PSTitleValueCell',
+                  'label': 'Status',
+                  'defaults': 'com.nextsolution.moduleglass',
+                  'key': 'licenseStatusDisplay',
+                  'default': 'Not Activated'
+              },
+              {
+                  'cell': 'PSButtonCell',
+                  'label': 'License & Device',
+                  'action': 'openModuleGlassLicense:',
+                  'description': 'Shows activation status, Device ID, activation check, and purchase option.'
+              }
+          ])
+          with prefs.open('wb') as f:
+              plistlib.dump(current, f, sort_keys=False)
+
+          info_path = bundle / 'Info.plist'
+          info = plistlib.load(info_path.open('rb'))
+          info['CFBundleShortVersionString'] = '1.1.18'
+          info['CFBundleVersion'] = '1.1.18'
+          with info_path.open('wb') as f:
+              plistlib.dump(info, f, sort_keys=False)
+
+          control = Path('stage/DEBIAN/control')
+          text = control.read_text()
+          text = text.replace('Version: 1.1.17', 'Version: 1.1.18')
+          text = text.replace('Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.17)', 'Provides: com.nextsolution.nextaura.runtime.ccbackgrounds (= 1.1.18)')
+          text = text.replace('<= 1.1.16', '<= 1.1.17')
+          old = 'Description: Module Glass 1.1.17 keeps the validated 1.1.15 ExternalHostIsolation Control Center runtime and embeds the current Aura Settings preference bundle directly in the same package.'
+          new = 'Description: Module Glass 1.1.18 preserves the validated 1.1.17 interface and Control Center runtime, adding Next Solution device activation as the final Settings section.'
+          if old not in text:
+              raise SystemExit('baseline description anchor missing')
+          text = text.replace(old, new)
+          control.write_text(text)
           PY
+          plutil -lint stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/Info.plist
+          plutil -lint stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist
+          test "$(dpkg-deb -f /tmp/moduleglass117.deb Package)" = 'com.nextsolution.nextaura.cc-module-backgrounds'
           test "$(grep '^Version:' stage/DEBIAN/control | awk '{print $2}')" = '1.1.18'
-          plutil -lint "$BUNDLE/Info.plist"
-          plutil -lint "$BUNDLE/CCModuleBackgrounds.plist"
           echo "$RUNTIME_SHA  stage/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib" | shasum -a 256 -c -
+          echo "$PREFS_BINARY_SHA  stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/AuraPrefs" | shasum -a 256 -c -
+          echo "$STANDALONE_PREFS_SHA  stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib" | shasum -a 256 -c -
 
       - name: Install RootHide Theos
         shell: bash
@@ -87,42 +133,25 @@ jobs:
             tar -xJf /tmp/sdk.tar.xz -C "$THEOS/sdks"
           fi
 
-      - name: Prepare corrected modern UI sources
+      - name: Prepare activation build helper
         shell: bash
         run: |
           set -euo pipefail
-          cp .moduleglass-build/ModuleGlassModernPrefs.m addon/
-          cp .moduleglass-build/ModuleGlassLicenseGate.m addon/
-          python3 - <<'PY'
-          from pathlib import Path
-          p=Path('addon/ModuleGlassModernPrefs.m')
-          t=p.read_text()
-          old='''    if ([app respondsToSelector:@selector(openURL:options:completionHandler:)]) {\n        [app openURL:url options:@{} completionHandler:nil];\n    } else {\n#pragma clang diagnostic push\n#pragma clang diagnostic ignored "-Wdeprecated-declarations"\n        [app openURL:url];\n#pragma clang diagnostic pop\n    }'''
-          new='''    if ([app respondsToSelector:@selector(openURL:options:completionHandler:)]) {\n        [app openURL:url options:@{} completionHandler:nil];\n    }'''
-          if old not in t: raise SystemExit('openURL compatibility patch anchor missing')
-          t=t.replace(old,new)
-          old_bundle='''    NSString *bundlePath = @"/Library/PreferenceBundles/ModuleGlassPrefs.bundle";\n    NSBundle *bundle = [NSBundle bundleWithPath:bundlePath];'''
-          new_bundle='''    NSBundle *bundle = [NSBundle bundleForClass:[controller class]];'''
-          if old_bundle in t: t=t.replace(old_bundle,new_bundle)
-          old_store='''    [d setDouble:NSDate.date.timeIntervalSince1970 forKey:@"licenseLastCheck"];\n    [d synchronize];'''
-          new_store='''    [d setDouble:NSDate.date.timeIntervalSince1970 forKey:@"licenseLastCheck"];\n    [d synchronize];\n    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), CFSTR("com.nextsolution.moduleglass/license.changed"), NULL, NULL, true);\n    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), CFSTR("com.nextsolution.unlockvibrate/preferences.changed"), NULL, NULL, true);'''
-          if old_store in t: t=t.replace(old_store,new_store)
-          p.write_text(t)
-          PY
+          cp .moduleglass-build/ModuleGlassActivation.m addon/
           cat > addon/Makefile <<'MAKE'
           ARCHS = arm64 arm64e
           TARGET = iphone:clang:16.5:16.0
           include $(THEOS)/makefiles/common.mk
-          TWEAK_NAME = ModuleGlassModernPrefs
-          ModuleGlassModernPrefs_FILES = ModuleGlassModernPrefs.m ModuleGlassLicenseGate.m
-          ModuleGlassModernPrefs_FRAMEWORKS = UIKit Foundation QuartzCore CoreFoundation
-          ModuleGlassModernPrefs_LIBRARIES = substrate commonCrypto
-          ModuleGlassModernPrefs_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
+          TWEAK_NAME = ModuleGlassActivation
+          ModuleGlassActivation_FILES = ModuleGlassActivation.m
+          ModuleGlassActivation_FRAMEWORKS = UIKit Foundation CoreFoundation
+          ModuleGlassActivation_LIBRARIES = substrate commonCrypto
+          ModuleGlassActivation_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
           include $(THEOS_MAKE_PATH)/tweak.mk
           MAKE
           cat > addon/control <<'CONTROL'
-          Package: com.nextsolution.moduleglass.modernprefs.build
-          Name: Module Glass Modern Prefs Build Helper
+          Package: com.nextsolution.moduleglass.activation.build
+          Name: Module Glass Activation Build Helper
           Version: 1.1.18
           Architecture: iphoneos-arm64e
           Description: Build helper only.
@@ -131,11 +160,11 @@ jobs:
           Section: Tweaks
           Depends: mobilesubstrate
           CONTROL
-          cat > addon/ModuleGlassModernPrefs.plist <<'PLIST'
+          cat > addon/ModuleGlassActivation.plist <<'PLIST'
           { Filter = { Bundles = ( "com.apple.Preferences", "com.apple.springboard" ); }; }
           PLIST
 
-      - name: Build branded Settings and activation layer
+      - name: Compile activation layer
         shell: bash
         run: |
           set -euxo pipefail
@@ -144,77 +173,73 @@ jobs:
           make package FINALPACKAGE=1
           RAW="$(find packages -maxdepth 1 -type f -name '*.deb' -print -quit)"
           test -n "$RAW"
-          rm -rf /tmp/mgaddon && mkdir -p /tmp/mgaddon
-          dpkg-deb -x "$RAW" /tmp/mgaddon
-          DYLIB="$(find /tmp/mgaddon -type f -name 'ModuleGlassModernPrefs.dylib' -print -quit)"
-          FILTER="$(find /tmp/mgaddon -type f -name 'ModuleGlassModernPrefs.plist' -print -quit)"
+          rm -rf /tmp/mgactivation && mkdir -p /tmp/mgactivation
+          dpkg-deb -x "$RAW" /tmp/mgactivation
+          DYLIB="$(find /tmp/mgactivation -type f -name 'ModuleGlassActivation.dylib' -print -quit)"
+          FILTER="$(find /tmp/mgactivation -type f -name 'ModuleGlassActivation.plist' -print -quit)"
           test -n "$DYLIB" && test -n "$FILTER"
           cd ..
-          cp "$DYLIB" stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassModernPrefs.dylib
-          cp "$FILTER" stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassModernPrefs.plist
+          cp "$DYLIB" stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.dylib
+          cp "$FILTER" stage/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.plist
 
-      - name: Package and verify Module Glass 1.1.18 UI Test 1
+      - name: Package and validate 1.1.18 RootHide DEB
         shell: bash
         run: |
           set -euo pipefail
-          cat > stage/DEBIAN/postinst <<'SH'
-          #!/bin/sh
-          killall -9 Preferences 2>/dev/null || true
-          killall -9 SpringBoard 2>/dev/null || true
-          exit 0
-          SH
           chmod 0755 stage/DEBIAN/postinst
-          dpkg-deb -b stage output/ModuleGlass_1.1.18_ModernSettings_Test1_RootHide.deb
-          DEB=output/ModuleGlass_1.1.18_ModernSettings_Test1_RootHide.deb
+          dpkg-deb -b stage output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb
+          DEB=output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb
+          dpkg-deb -I "$DEB"
+          dpkg-deb -c "$DEB" > output/PACKAGE-CONTENTS.txt
           test "$(dpkg-deb -f "$DEB" Package)" = 'com.nextsolution.nextaura.cc-module-backgrounds'
           test "$(dpkg-deb -f "$DEB" Version)" = '1.1.18'
           test "$(dpkg-deb -f "$DEB" Architecture)" = 'iphoneos-arm64e'
           rm -rf verify && mkdir verify
           dpkg-deb -x "$DEB" verify
           RUNTIME=verify/Library/MobileSubstrate/DynamicLibraries/CCModuleBackgrounds.dylib
-          MODERN=verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassModernPrefs.dylib
+          ACTIVATION=verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.dylib
           echo "$RUNTIME_SHA  $RUNTIME" | shasum -a 256 -c -
-          strings "$RUNTIME" > output/runtime.strings
-          grep -Fq 'ModuleGlassRuntime 1.1.15 External Host Isolation Renderer' output/runtime.strings
-          test -f "$MODERN"
-          ARCHS="$(lipo -archs "$MODERN")"
-          [[ " $ARCHS " == *' arm64 '* && " $ARCHS " == *' arm64e '* ]]
-          strings -a "$MODERN" > output/modern.strings
-          grep -Fq 'Module Glass License & Device' output/modern.strings
-          grep -Fq 'licenses/moduleglass.json' output/modern.strings
-          grep -Fq 'license/moduleglass/' output/modern.strings
-          grep -Fq 'com.nextsolution.unlockvibrate' output/modern.strings
-          test -f verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib
+          echo "$PREFS_BINARY_SHA  verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/AuraPrefs" | shasum -a 256 -c -
+          echo "$STANDALONE_PREFS_SHA  verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassStandalonePrefsExtension.dylib" | shasum -a 256 -c -
+          test -f "$ACTIVATION"
+          test -f verify/Library/MobileSubstrate/DynamicLibraries/ModuleGlassActivation.plist
           test -f verify/Library/PreferenceLoader/Preferences/NextAura-cc-module-backgrounds.plist
+          ARCHS="$(lipo -archs "$ACTIVATION")"
+          [[ " $ARCHS " == *' arm64 '* && " $ARCHS " == *' arm64e '* ]]
+          strings -a "$ACTIVATION" > output/activation.strings
+          grep -Fq 'Module Glass License & Device' output/activation.strings
+          grep -Fq 'licenses/moduleglass.json' output/activation.strings
+          grep -Fq 'nextsolution-license-v1' output/activation.strings
+          grep -Fq 'openModuleGlassLicense:' output/activation.strings
+          grep -Fq 'com.nextsolution.unlockvibrate' output/activation.strings
           python3 - <<'PY'
           import plistlib
-          p='verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist'
-          x=plistlib.load(open(p,'rb'))
-          groups=[i.get('label') for i in x['items'] if i.get('cell')=='PSGroupCell']
-          expected=['APPEARANCE','MEDIA & SLIDERS','CONNECTIVITY & MEDIA','UTILITY MODULES','OTHER MODULES','MAINTENANCE','APPLY & RESTART']
-          assert groups == expected, (groups,expected)
-          labels=[i.get('label') for i in x['items']]
-          for label in ['Brightness Background','Volume Background','Volume Icon Color','Remove All Module Images','Apply Module Glass','Respring']:
-              assert label in labels, label
+          old = plistlib.load(open('/tmp/CCModuleBackgrounds.1.1.17.plist','rb'))
+          new = plistlib.load(open('verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist','rb'))
+          assert new['items'][:-3] == old['items'], 'existing 1.1.17 settings were modified'
+          tail = new['items'][-3:]
+          assert [x.get('label') for x in tail] == ['Activation', 'Status', 'License & Device'], tail
+          assert tail[2].get('action') == 'openModuleGlassLicense:'
+          assert tail[1].get('defaults') == 'com.nextsolution.moduleglass'
+          info = plistlib.load(open('verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/Info.plist','rb'))
+          assert info['CFBundleShortVersionString'] == '1.1.18'
+          assert info['CFBundleVersion'] == '1.1.18'
           PY
-          mkdir -p output/source/ModuleGlass-1.1.18-ModernSettings-Test1
-          cp .moduleglass-build/ModuleGlassModernPrefs.m output/source/ModuleGlass-1.1.18-ModernSettings-Test1/
-          cp .moduleglass-build/ModuleGlassLicenseGate.m output/source/ModuleGlass-1.1.18-ModernSettings-Test1/
-          cp .moduleglass-build/mg118_modern_prefs.py output/source/ModuleGlass-1.1.18-ModernSettings-Test1/
-          cp stage/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist output/source/ModuleGlass-1.1.18-ModernSettings-Test1/
-          cp stage/DEBIAN/control output/source/ModuleGlass-1.1.18-ModernSettings-Test1/control
-          ditto -c -k --sequesterRsrc --keepParent output/source/ModuleGlass-1.1.18-ModernSettings-Test1 output/ModuleGlass_1.1.18_ModernSettings_Test1_Source.zip
-          dpkg-deb -c "$DEB" > output/PACKAGE-CONTENTS.txt
-          shasum -a 256 "$DEB" output/ModuleGlass_1.1.18_ModernSettings_Test1_Source.zip > output/SHA256SUMS.txt
+          mkdir -p output/source/ModuleGlass-1.1.18-CurrentUI-Activation
+          cp .moduleglass-build/ModuleGlassActivation.m output/source/ModuleGlass-1.1.18-CurrentUI-Activation/
+          cp verify/Library/PreferenceBundles/ModuleGlassPrefs.bundle/CCModuleBackgrounds.plist output/source/ModuleGlass-1.1.18-CurrentUI-Activation/
+          cp verify/DEBIAN/control output/source/ModuleGlass-1.1.18-CurrentUI-Activation/control 2>/dev/null || cp stage/DEBIAN/control output/source/ModuleGlass-1.1.18-CurrentUI-Activation/control
+          ditto -c -k --sequesterRsrc --keepParent output/source/ModuleGlass-1.1.18-CurrentUI-Activation output/ModuleGlass_1.1.18_CurrentUI_Activation_Source.zip
+          shasum -a 256 "$DEB" output/ModuleGlass_1.1.18_CurrentUI_Activation_Source.zip > output/SHA256SUMS.txt
           cat output/SHA256SUMS.txt
 
-      - name: Upload test artifacts
+      - name: Upload validated artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ModuleGlass-1.1.18-ModernSettings-Test1-RootHide
+          name: ModuleGlass-1.1.18-CurrentUI-Activation-RootHide
           path: |
-            output/ModuleGlass_1.1.18_ModernSettings_Test1_RootHide.deb
-            output/ModuleGlass_1.1.18_ModernSettings_Test1_Source.zip
+            output/ModuleGlass_1.1.18_CurrentUI_Activation_RootHide.deb
+            output/ModuleGlass_1.1.18_CurrentUI_Activation_Source.zip
             output/SHA256SUMS.txt
             output/PACKAGE-CONTENTS.txt
           if-no-files-found: error

--- a/.moduleglass-build/ModuleGlassActivation.m
+++ b/.moduleglass-build/ModuleGlassActivation.m
@@ -274,3 +274,5 @@ __attribute__((constructor)) static void ModuleGlassActivationInit(void) {
         }
     }
 }
+
+// CI trigger: final old-UI activation build.

--- a/.moduleglass-build/ModuleGlassActivation.m
+++ b/.moduleglass-build/ModuleGlassActivation.m
@@ -1,3 +1,4 @@
+// Module Glass 1.1.18: preserve the current UI and append activation only.
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 #import <CoreFoundation/CoreFoundation.h>

--- a/.moduleglass-build/ModuleGlassActivation.m
+++ b/.moduleglass-build/ModuleGlassActivation.m
@@ -1,4 +1,4 @@
-// Module Glass 1.1.18: preserve the current UI and append activation only.
+// Module Glass 1.1.18 — 1.1.17 UI preserved; activation is a separate final pane.
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 #import <CoreFoundation/CoreFoundation.h>
@@ -94,9 +94,19 @@ static void MGPostLicenseChange(void) {
     CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), CFSTR("com.nextsolution.unlockvibrate/preferences.changed"), NULL, NULL, true);
 }
 
+static void MGPrepareDisplayValues(void) {
+    NSUserDefaults *d = MGLicenseDefaults();
+    [d setObject:MGDeviceID() forKey:@"deviceIDDisplay"];
+    if (![d stringForKey:@"licenseStatusDisplay"]) {
+        [d setObject:(MGStoredActive() ? @"Activated" : @"Not Activated") forKey:@"licenseStatusDisplay"];
+    }
+    [d synchronize];
+}
+
 static void MGStoreActivation(BOOL active) {
     NSUserDefaults *d = MGLicenseDefaults();
     [d setObject:MGDeviceID() forKey:@"licenseDeviceID"];
+    [d setObject:MGDeviceID() forKey:@"deviceIDDisplay"];
     [d setObject:(active ? @"Activated" : @"Not Activated") forKey:@"licenseStatusDisplay"];
     [d setBool:active forKey:@"licenseActivated"];
     [d setDouble:NSDate.date.timeIntervalSince1970 forKey:@"licenseLastCheck"];
@@ -150,6 +160,11 @@ static void MGOpenURL(NSURL *url) {
     UIApplication *app = UIApplication.sharedApplication;
     if ([app respondsToSelector:@selector(openURL:options:completionHandler:)]) {
         [app openURL:url options:@{} completionHandler:nil];
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        [app openURL:url];
+#pragma clang diagnostic pop
     }
 }
 
@@ -166,53 +181,59 @@ static UIViewController *MGPresenter(id controller) {
     return root;
 }
 
-static void MGShowResult(UIViewController *presenter, NSString *message) {
+static void MGShowResult(id controller, NSString *message) {
+    UIViewController *presenter = MGPresenter(controller);
     if (!presenter) return;
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Module Glass Activation" message:message preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
     [presenter presentViewController:alert animated:YES completion:nil];
 }
 
-static void MGOpenModuleGlassLicense(id controller, SEL _cmd, id specifier) {
-    UIViewController *presenter = MGPresenter(controller);
-    if (!presenter) return;
-    NSUserDefaults *d = MGLicenseDefaults();
-    NSString *status = [d stringForKey:@"licenseStatusDisplay"] ?: (MGStoredActive() ? @"Activated" : @"Not Activated");
-    NSString *message = [NSString stringWithFormat:@"Status: %@\nDevice ID: %@\nLicense: %@ lifetime", status, MGDeviceID(), MGPrice];
-    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Module Glass License & Device" message:message preferredStyle:UIAlertControllerStyleActionSheet];
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Copy Device ID" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        UIPasteboard.generalPasteboard.string = MGDeviceID();
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Check Activation" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        MGCheckActivation(^(BOOL active, NSError *error) {
-            MGReloadSpecifiers(controller);
-            if (error) MGShowResult(presenter, [NSString stringWithFormat:@"Could not check activation.\n%@", error.localizedDescription]);
-            else MGShowResult(presenter, active ? @"This device is activated. Module Glass is enabled." : @"This device is not activated yet. Copy the Device ID and activate it first.");
-        });
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:[NSString stringWithFormat:@"Buy / Activate — %@", MGPrice] style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        MGOpenURL(MGCheckoutURL());
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
-    if (popover) {
-        popover.sourceView = presenter.view;
-        popover.sourceRect = CGRectMake(CGRectGetMidX(presenter.view.bounds), CGRectGetMaxY(presenter.view.bounds) - 20.0, 1.0, 1.0);
-    }
-    [presenter presentViewController:sheet animated:YES completion:nil];
+static void MGCopyDeviceIDAction(id controller, SEL _cmd, id specifier) {
+    UIPasteboard.generalPasteboard.string = MGDeviceID();
+    MGShowResult(controller, @"Device ID copied.");
 }
 
-static void MGInstallPreferenceAction(NSUInteger attempt) {
+static void MGBuyActivationAction(id controller, SEL _cmd, id specifier) {
+    MGOpenURL(MGCheckoutURL());
+}
+
+static void MGCheckActivationAction(id controller, SEL _cmd, id specifier) {
+    MGCheckActivation(^(BOOL active, NSError *error) {
+        MGReloadSpecifiers(controller);
+        if (error) MGShowResult(controller, [NSString stringWithFormat:@"Could not check activation.\n%@", error.localizedDescription]);
+        else MGShowResult(controller, active ? @"This device is activated. Module Glass is enabled." : @"This device is not activated yet.");
+    });
+}
+
+static void MGRestoreActivationAction(id controller, SEL _cmd, id specifier) {
+    MGCheckActivation(^(BOOL active, NSError *error) {
+        MGReloadSpecifiers(controller);
+        if (error) MGShowResult(controller, [NSString stringWithFormat:@"Could not restore activation.\n%@", error.localizedDescription]);
+        else MGShowResult(controller, active ? @"Activation restored for this device." : @"No activation was found for this Device ID.");
+    });
+}
+
+static void MGInstallPreferenceActions(NSUInteger attempt) {
     Class cls = objc_getClass("PSListController");
-    SEL sel = NSSelectorFromString(@"openModuleGlassLicense:");
     if (cls) {
-        if (!class_getInstanceMethod(cls, sel)) class_addMethod(cls, sel, (IMP)MGOpenModuleGlassLicense, "v@:@");
+        struct { const char *name; IMP imp; } actions[] = {
+            {"moduleGlassCopyDeviceID:", (IMP)MGCopyDeviceIDAction},
+            {"moduleGlassBuyActivation:", (IMP)MGBuyActivationAction},
+            {"moduleGlassCheckActivation:", (IMP)MGCheckActivationAction},
+            {"moduleGlassRestoreActivation:", (IMP)MGRestoreActivationAction},
+        };
+        for (NSUInteger i = 0; i < sizeof(actions) / sizeof(actions[0]); i++) {
+            SEL sel = sel_registerName(actions[i].name);
+            if (!class_getInstanceMethod(cls, sel)) class_addMethod(cls, sel, actions[i].imp, "v@:@");
+        }
+        MGPrepareDisplayValues();
         NSUserDefaults *d = MGLicenseDefaults();
         NSTimeInterval last = [d doubleForKey:@"licenseLastCheck"];
         if (NSDate.date.timeIntervalSince1970 - last > 60.0) MGCheckActivation(nil);
         return;
     }
-    if (attempt < 20) dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ MGInstallPreferenceAction(attempt + 1); });
+    if (attempt < 20) dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ MGInstallPreferenceActions(attempt + 1); });
 }
 
 static BOOL MGStringEqual(CFStringRef a, CFStringRef b) {
@@ -266,7 +287,7 @@ __attribute__((constructor)) static void ModuleGlassActivationInit(void) {
     @autoreleasepool {
         NSString *bundleID = NSBundle.mainBundle.bundleIdentifier ?: @"";
         if ([bundleID isEqualToString:@"com.apple.Preferences"]) {
-            dispatch_async(dispatch_get_main_queue(), ^{ MGInstallPreferenceAction(0); });
+            dispatch_async(dispatch_get_main_queue(), ^{ MGInstallPreferenceActions(0); });
         } else if ([bundleID isEqualToString:@"com.apple.springboard"]) {
             void *symbol = dlsym(RTLD_DEFAULT, "CFPreferencesCopyAppValue");
             if (symbol) MSHookFunction(symbol, (void *)&MGCFPreferencesCopyAppValue, (void **)&MGOrigCFPreferencesCopyAppValue);
@@ -274,5 +295,3 @@ __attribute__((constructor)) static void ModuleGlassActivationInit(void) {
         }
     }
 }
-
-// CI trigger: final old-UI activation build.

--- a/.moduleglass-build/ModuleGlassActivation.m
+++ b/.moduleglass-build/ModuleGlassActivation.m
@@ -1,0 +1,275 @@
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import <substrate.h>
+#import <CommonCrypto/CommonDigest.h>
+#import <dlfcn.h>
+#import <sys/sysctl.h>
+
+static NSString * const MGPackageID = @"com.nextsolution.nextaura.cc-module-backgrounds";
+static NSString * const MGLicenseDomain = @"com.nextsolution.moduleglass";
+static NSString * const MGRegistryURL = @"https://raw.githubusercontent.com/zeshan0727/NextSolution/main/licenses/moduleglass.json";
+static NSString * const MGPrice = @"$1.00";
+static CFStringRef const MGTweakPrefsDomain = CFSTR("com.nextsolution.unlockvibrate");
+static CFStringRef const MGLicensePrefsDomain = CFSTR("com.nextsolution.moduleglass");
+
+static CFPropertyListRef (*MGOrigCFPreferencesCopyAppValue)(CFStringRef, CFStringRef) = NULL;
+
+static NSString *MGHexSHA256(NSString *input) {
+    NSData *data = [input dataUsingEncoding:NSUTF8StringEncoding];
+    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+    NSMutableString *result = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) [result appendFormat:@"%02x", digest[i]];
+    return result;
+}
+
+static NSString *MGGestaltString(CFStringRef key) {
+    typedef CFTypeRef (*MGCopyAnswerFn)(CFStringRef);
+    static MGCopyAnswerFn fn = NULL;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        void *handle = dlopen("/usr/lib/libMobileGestalt.dylib", RTLD_LAZY);
+        if (handle) fn = (MGCopyAnswerFn)dlsym(handle, "MGCopyAnswer");
+    });
+    if (!fn) return nil;
+    CFTypeRef value = fn(key);
+    if (!value) return nil;
+    NSString *result = nil;
+    if (CFGetTypeID(value) == CFStringGetTypeID()) result = [(__bridge NSString *)value copy];
+    CFRelease(value);
+    return result;
+}
+
+static NSString *MGMachine(void) {
+    size_t size = 0;
+    sysctlbyname("hw.machine", NULL, &size, NULL, 0);
+    if (!size) return @"iPhone";
+    char *machine = calloc(1, size);
+    if (!machine) return @"iPhone";
+    sysctlbyname("hw.machine", machine, &size, NULL, 0);
+    NSString *value = [NSString stringWithUTF8String:machine] ?: @"iPhone";
+    free(machine);
+    return value;
+}
+
+static NSString *MGDeviceID(void) {
+    static NSString *cached = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSString *udid = MGGestaltString(CFSTR("UniqueDeviceID"));
+        NSString *serial = MGGestaltString(CFSTR("SerialNumber"));
+        NSString *raw = [NSString stringWithFormat:@"%@|%@|%@|%@", udid ?: @"", serial ?: @"", MGMachine(), MGPackageID];
+        if (!(udid.length || serial.length)) {
+            NSString *vendor = UIDevice.currentDevice.identifierForVendor.UUIDString ?: @"unknown";
+            raw = [NSString stringWithFormat:@"%@|%@|%@", vendor, MGMachine(), MGPackageID];
+        }
+        NSString *hex = [MGHexSHA256(raw) uppercaseString];
+        cached = [NSString stringWithFormat:@"NS-%@-%@-%@-%@",
+                  [hex substringWithRange:NSMakeRange(0, 4)],
+                  [hex substringWithRange:NSMakeRange(4, 4)],
+                  [hex substringWithRange:NSMakeRange(8, 4)],
+                  [hex substringWithRange:NSMakeRange(12, 4)]];
+    });
+    return cached;
+}
+
+static NSString *MGLicenseToken(void) {
+    return MGHexSHA256([NSString stringWithFormat:@"%@|%@|nextsolution-license-v1", MGDeviceID(), MGPackageID]);
+}
+
+static NSUserDefaults *MGLicenseDefaults(void) {
+    return [[NSUserDefaults alloc] initWithSuiteName:MGLicenseDomain];
+}
+
+static BOOL MGStoredActive(void) {
+    return [MGLicenseDefaults() boolForKey:@"licenseActivated"];
+}
+
+static void MGPostLicenseChange(void) {
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), CFSTR("com.nextsolution.moduleglass/license.changed"), NULL, NULL, true);
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), CFSTR("com.nextsolution.unlockvibrate/preferences.changed"), NULL, NULL, true);
+}
+
+static void MGStoreActivation(BOOL active) {
+    NSUserDefaults *d = MGLicenseDefaults();
+    [d setObject:MGDeviceID() forKey:@"licenseDeviceID"];
+    [d setObject:(active ? @"Activated" : @"Not Activated") forKey:@"licenseStatusDisplay"];
+    [d setBool:active forKey:@"licenseActivated"];
+    [d setDouble:NSDate.date.timeIntervalSince1970 forKey:@"licenseLastCheck"];
+    [d synchronize];
+    MGPostLicenseChange();
+}
+
+static void MGCheckActivation(void (^completion)(BOOL active, NSError *error)) {
+    NSString *urlText = [NSString stringWithFormat:@"%@?t=%.0f", MGRegistryURL, NSDate.date.timeIntervalSince1970];
+    NSURL *url = [NSURL URLWithString:urlText];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:15.0];
+    [request setValue:@"ModuleGlass/1.1.18" forHTTPHeaderField:@"User-Agent"];
+    [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSError *finalError = error;
+        BOOL active = MGStoredActive();
+        BOOL validRegistry = NO;
+        if (!finalError && data.length) {
+            id json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&finalError];
+            NSArray *list = [json isKindOfClass:NSDictionary.class] ? ((NSDictionary *)json)[@"active"] : nil;
+            if ([list isKindOfClass:NSArray.class]) {
+                validRegistry = YES;
+                active = NO;
+                NSString *wanted = MGLicenseToken().lowercaseString;
+                for (id entry in list) {
+                    if ([entry isKindOfClass:NSString.class] && [((NSString *)entry).lowercaseString isEqualToString:wanted]) {
+                        active = YES;
+                        break;
+                    }
+                }
+            } else if (!finalError) {
+                finalError = [NSError errorWithDomain:@"ModuleGlassLicense" code:2 userInfo:@{NSLocalizedDescriptionKey:@"Invalid activation registry."}];
+            }
+        }
+        if (validRegistry && !finalError) MGStoreActivation(active);
+        dispatch_async(dispatch_get_main_queue(), ^{ if (completion) completion(active, finalError); });
+    }] resume];
+}
+
+static NSString *MGQueryEscape(NSString *value) {
+    return [value stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet] ?: @"";
+}
+
+static NSURL *MGCheckoutURL(void) {
+    NSString *url = [NSString stringWithFormat:@"https://nextsolution.cc/license/moduleglass/?device=%@&model=%@&ios=%@",
+                     MGQueryEscape(MGDeviceID()), MGQueryEscape(MGMachine()), MGQueryEscape(UIDevice.currentDevice.systemVersion ?: @"")];
+    return [NSURL URLWithString:url];
+}
+
+static void MGOpenURL(NSURL *url) {
+    if (!url) return;
+    UIApplication *app = UIApplication.sharedApplication;
+    if ([app respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+        [app openURL:url options:@{} completionHandler:nil];
+    }
+}
+
+static void MGReloadSpecifiers(id controller) {
+    SEL selector = NSSelectorFromString(@"reloadSpecifiers");
+    if ([controller respondsToSelector:selector]) ((void(*)(id, SEL))objc_msgSend)(controller, selector);
+}
+
+static UIViewController *MGPresenter(id controller) {
+    if ([controller isKindOfClass:UIViewController.class]) return controller;
+    UIWindow *window = UIApplication.sharedApplication.keyWindow;
+    UIViewController *root = window.rootViewController;
+    while (root.presentedViewController) root = root.presentedViewController;
+    return root;
+}
+
+static void MGShowResult(UIViewController *presenter, NSString *message) {
+    if (!presenter) return;
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Module Glass Activation" message:message preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [presenter presentViewController:alert animated:YES completion:nil];
+}
+
+static void MGOpenModuleGlassLicense(id controller, SEL _cmd, id specifier) {
+    UIViewController *presenter = MGPresenter(controller);
+    if (!presenter) return;
+    NSUserDefaults *d = MGLicenseDefaults();
+    NSString *status = [d stringForKey:@"licenseStatusDisplay"] ?: (MGStoredActive() ? @"Activated" : @"Not Activated");
+    NSString *message = [NSString stringWithFormat:@"Status: %@\nDevice ID: %@\nLicense: %@ lifetime", status, MGDeviceID(), MGPrice];
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Module Glass License & Device" message:message preferredStyle:UIAlertControllerStyleActionSheet];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Copy Device ID" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        UIPasteboard.generalPasteboard.string = MGDeviceID();
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Check Activation" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        MGCheckActivation(^(BOOL active, NSError *error) {
+            MGReloadSpecifiers(controller);
+            if (error) MGShowResult(presenter, [NSString stringWithFormat:@"Could not check activation.\n%@", error.localizedDescription]);
+            else MGShowResult(presenter, active ? @"This device is activated. Module Glass is enabled." : @"This device is not activated yet. Copy the Device ID and activate it first.");
+        });
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:[NSString stringWithFormat:@"Buy / Activate — %@", MGPrice] style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        MGOpenURL(MGCheckoutURL());
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover) {
+        popover.sourceView = presenter.view;
+        popover.sourceRect = CGRectMake(CGRectGetMidX(presenter.view.bounds), CGRectGetMaxY(presenter.view.bounds) - 20.0, 1.0, 1.0);
+    }
+    [presenter presentViewController:sheet animated:YES completion:nil];
+}
+
+static void MGInstallPreferenceAction(NSUInteger attempt) {
+    Class cls = objc_getClass("PSListController");
+    SEL sel = NSSelectorFromString(@"openModuleGlassLicense:");
+    if (cls) {
+        if (!class_getInstanceMethod(cls, sel)) class_addMethod(cls, sel, (IMP)MGOpenModuleGlassLicense, "v@:@");
+        NSUserDefaults *d = MGLicenseDefaults();
+        NSTimeInterval last = [d doubleForKey:@"licenseLastCheck"];
+        if (NSDate.date.timeIntervalSince1970 - last > 60.0) MGCheckActivation(nil);
+        return;
+    }
+    if (attempt < 20) dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ MGInstallPreferenceAction(attempt + 1); });
+}
+
+static BOOL MGStringEqual(CFStringRef a, CFStringRef b) {
+    return a && b && CFStringCompare(a, b, 0) == kCFCompareEqualTo;
+}
+
+static BOOL MGIsGatedKey(CFStringRef key) {
+    static CFStringRef keys[] = {
+        CFSTR("CCModuleBackgroundsEnabled"),
+        CFSTR("CCModuleRemoveBlur"),
+        CFSTR("CCModuleControlGlowEnabled"),
+        CFSTR("CCModuleVolumeIconColorEnabled")
+    };
+    for (NSUInteger i = 0; i < sizeof(keys) / sizeof(keys[0]); i++) if (MGStringEqual(key, keys[i])) return YES;
+    return NO;
+}
+
+static BOOL MGLicenseIsActiveForRuntime(void) {
+    if (!MGOrigCFPreferencesCopyAppValue) return NO;
+    CFPreferencesAppSynchronize(MGLicensePrefsDomain);
+    CFPropertyListRef value = MGOrigCFPreferencesCopyAppValue(CFSTR("licenseActivated"), MGLicensePrefsDomain);
+    BOOL active = NO;
+    if (value) {
+        if (CFGetTypeID(value) == CFBooleanGetTypeID()) active = CFBooleanGetValue((CFBooleanRef)value);
+        else if (CFGetTypeID(value) == CFNumberGetTypeID()) {
+            int numeric = 0;
+            CFNumberGetValue((CFNumberRef)value, kCFNumberIntType, &numeric);
+            active = numeric != 0;
+        }
+        CFRelease(value);
+    }
+    return active;
+}
+
+static CFPropertyListRef MGCFPreferencesCopyAppValue(CFStringRef key, CFStringRef applicationID) {
+    if (MGOrigCFPreferencesCopyAppValue && MGStringEqual(applicationID, MGTweakPrefsDomain) && MGIsGatedKey(key) && !MGLicenseIsActiveForRuntime()) {
+        return CFRetain(kCFBooleanFalse);
+    }
+    return MGOrigCFPreferencesCopyAppValue ? MGOrigCFPreferencesCopyAppValue(key, applicationID) : NULL;
+}
+
+static void MGScheduleRuntimeRefresh(NSTimeInterval delay) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        MGCheckActivation(^(__unused BOOL active, __unused NSError *error) {
+            MGScheduleRuntimeRefresh(20.0 * 60.0);
+        });
+    });
+}
+
+__attribute__((constructor)) static void ModuleGlassActivationInit(void) {
+    @autoreleasepool {
+        NSString *bundleID = NSBundle.mainBundle.bundleIdentifier ?: @"";
+        if ([bundleID isEqualToString:@"com.apple.Preferences"]) {
+            dispatch_async(dispatch_get_main_queue(), ^{ MGInstallPreferenceAction(0); });
+        } else if ([bundleID isEqualToString:@"com.apple.springboard"]) {
+            void *symbol = dlsym(RTLD_DEFAULT, "CFPreferencesCopyAppValue");
+            if (symbol) MSHookFunction(symbol, (void *)&MGCFPreferencesCopyAppValue, (void **)&MGOrigCFPreferencesCopyAppValue);
+            MGScheduleRuntimeRefresh(8.0);
+        }
+    }
+}


### PR DESCRIPTION
Build-only final candidate for Module Glass 1.1.18. Preserves every 1.1.17 pane/specifier and validated runtime binary. Adds exactly one Activation pane at the end with Status, Device ID/Copy, $1 Buy, Check/Refresh, and Restore. Do not merge until on-device test passes.