### PR TITLE
Inspect stable Next Reminder source for 1.3.29 manual reports

### DIFF
--- a/.github/workflows/temp-next-reminder-1322-build.yml
+++ b/.github/workflows/temp-next-reminder-1322-build.yml
@@ -26,7 +26,7 @@ jobs:
           git checkout FETCH_HEAD -- tmp-build-1328/build.sh
       - name: Build and validate app
         shell: bash
-        run: bash tmp-build-1329/build.sh
+        run: bash tmp-build-1329/build-final.sh
       - uses: actions/upload-artifact@v4
         with:
           name: NextReminder-1.3.29-Manual-Pending-Reports

--- a/.github/workflows/temp-next-reminder-1322-build.yml
+++ b/.github/workflows/temp-next-reminder-1322-build.yml
@@ -1,4 +1,4 @@
-name: Temp Next Reminder 1.3.29 Inspector
+name: Temp Next Reminder 1.3.29 Builder
 on:
   pull_request:
     branches: [main]
@@ -7,10 +7,10 @@ on:
 permissions:
   contents: read
 jobs:
-  inspect:
+  build:
     if: github.head_ref == 'build-next-reminder-1329-working'
     runs-on: macos-15
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: Import verified source payloads and prior patches
@@ -24,12 +24,14 @@ jobs:
           git checkout FETCH_HEAD -- tmp-build-1326/app1326.patch.xz.b64
           git fetch --depth 1 origin build-next-reminder-1328-working
           git checkout FETCH_HEAD -- tmp-build-1328/build.sh
-      - name: Reconstruct current stable source
+      - name: Build and validate app
         shell: bash
-        run: bash tmp-build-1329/inspect.sh
+        run: bash tmp-build-1329/build.sh
       - uses: actions/upload-artifact@v4
         with:
-          name: NextReminder-1.3.28-Stable-Source-Inspection
-          path: ${{ runner.temp }}/inspect/
+          name: NextReminder-1.3.29-Manual-Pending-Reports
+          path: |
+            ${{ runner.temp }}/out/NextReminder_1.3.29_Unsigned.tipa
+            ${{ runner.temp }}/out/SHA256SUMS.txt
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7

--- a/.github/workflows/temp-next-reminder-1322-build.yml
+++ b/.github/workflows/temp-next-reminder-1322-build.yml
@@ -1,16 +1,16 @@
-name: Temp Next Reminder 1.3.28 Builder
+name: Temp Next Reminder 1.3.29 Inspector
 on:
   pull_request:
     branches: [main]
     paths:
-      - 'tmp-build-1328/**'
+      - 'tmp-build-1329/**'
 permissions:
   contents: read
 jobs:
-  build:
-    if: github.head_ref == 'build-next-reminder-1328-working'
+  inspect:
+    if: github.head_ref == 'build-next-reminder-1329-working'
     runs-on: macos-15
-    timeout-minutes: 45
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Import verified source payloads and prior patches
@@ -22,14 +22,14 @@ jobs:
           git checkout FETCH_HEAD -- tmp-build-1325/patch
           git fetch --depth 1 origin build-next-reminder-1326-working
           git checkout FETCH_HEAD -- tmp-build-1326/app1326.patch.xz.b64
-      - name: Build and validate app
+          git fetch --depth 1 origin build-next-reminder-1328-working
+          git checkout FETCH_HEAD -- tmp-build-1328/build.sh
+      - name: Reconstruct current stable source
         shell: bash
-        run: bash tmp-build-1328/build.sh
+        run: bash tmp-build-1329/inspect.sh
       - uses: actions/upload-artifact@v4
         with:
-          name: NextReminder-1.3.28-Stable-Files-Rollback
-          path: |
-            ${{ runner.temp }}/out/NextReminder_1.3.28_Unsigned.tipa
-            ${{ runner.temp }}/out/SHA256SUMS.txt
+          name: NextReminder-1.3.28-Stable-Source-Inspection
+          path: ${{ runner.temp }}/inspect/
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1

--- a/tmp-build-1329/PendingReports.swift
+++ b/tmp-build-1329/PendingReports.swift
@@ -1,0 +1,909 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+// MARK: - Manual Pending Reminder PDF Reports
+
+struct PendingReminderPDFReport: Identifiable, Hashable {
+    let id: UUID
+    let url: URL
+    let fileName: String
+    let createdAt: Date
+    let reminderCount: Int
+    let byteCount: Int
+
+    var sizeText: String {
+        ByteCountFormatter.string(fromByteCount: Int64(byteCount), countStyle: .file)
+    }
+}
+
+enum PendingReminderPDFReportError: LocalizedError {
+    case noPendingReminders
+    case reportsDirectoryUnavailable
+    case pdfCreationFailed
+    case saveFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noPendingReminders:
+            return "There are no pending reminders to include in the PDF report."
+        case .reportsDirectoryUnavailable:
+            return "Next Reminder could not create its local Pending Reminder Reports folder."
+        case .pdfCreationFailed:
+            return "The pending-reminders PDF could not be generated."
+        case .saveFailed(let message):
+            return "The PDF could not be saved locally: \(message)"
+        }
+    }
+}
+
+enum PendingReminderPDFReportService {
+    private static let folderName = "Pending Reminder Reports"
+    private static let pageBounds = CGRect(x: 0, y: 0, width: 612, height: 792)
+    private static let margin: CGFloat = 42
+
+    static func generate(
+        reminders: [ReminderItem],
+        defaultRecipient: String
+    ) throws -> PendingReminderPDFReport {
+        let pending = reminders
+            .filter { !$0.isCompleted }
+            .sorted { $0.effectiveDeadline < $1.effectiveDeadline }
+        guard !pending.isEmpty else { throw PendingReminderPDFReportError.noPendingReminders }
+
+        let now = Date()
+        let data = renderPDF(reminders: pending, generatedAt: now, defaultRecipient: defaultRecipient)
+        guard !data.isEmpty else { throw PendingReminderPDFReportError.pdfCreationFailed }
+
+        let directory = try reportsDirectory()
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        let fileName = "Pending-Reminders-\(formatter.string(from: now))-\(pending.count).pdf"
+        let url = directory.appendingPathComponent(fileName, isDirectory: false)
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            throw PendingReminderPDFReportError.saveFailed(error.localizedDescription)
+        }
+
+        let report = PendingReminderPDFReport(
+            id: stableID(for: url),
+            url: url,
+            fileName: fileName,
+            createdAt: now,
+            reminderCount: pending.count,
+            byteCount: data.count
+        )
+        pruneToLatestThree()
+        return report
+    }
+
+    static func savedReports() -> [PendingReminderPDFReport] {
+        guard let directory = try? reportsDirectory() else { return [] }
+        let keys: Set<URLResourceKey> = [.creationDateKey, .contentModificationDateKey, .fileSizeKey]
+        guard let urls = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: Array(keys),
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        let reports = urls
+            .filter { $0.pathExtension.lowercased() == "pdf" }
+            .compactMap { url -> PendingReminderPDFReport? in
+                let values = try? url.resourceValues(forKeys: keys)
+                let created = values?.creationDate ?? values?.contentModificationDate ?? Date.distantPast
+                return PendingReminderPDFReport(
+                    id: stableID(for: url),
+                    url: url,
+                    fileName: url.lastPathComponent,
+                    createdAt: created,
+                    reminderCount: reminderCount(from: url.lastPathComponent),
+                    byteCount: values?.fileSize ?? 0
+                )
+            }
+            .sorted { $0.createdAt > $1.createdAt }
+
+        return Array(reports.prefix(3))
+    }
+
+    private static func pruneToLatestThree() {
+        guard let directory = try? reportsDirectory() else { return }
+        let keys: Set<URLResourceKey> = [.creationDateKey, .contentModificationDateKey]
+        guard let urls = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: Array(keys),
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        let sortedPDFs = urls
+            .filter { $0.pathExtension.lowercased() == "pdf" }
+            .sorted { left, right in
+                let lv = try? left.resourceValues(forKeys: keys)
+                let rv = try? right.resourceValues(forKeys: keys)
+                let ld = lv?.creationDate ?? lv?.contentModificationDate ?? .distantPast
+                let rd = rv?.creationDate ?? rv?.contentModificationDate ?? .distantPast
+                return ld > rd
+            }
+
+        for url in sortedPDFs.dropFirst(3) {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private static func reportsDirectory() throws -> URL {
+        guard let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw PendingReminderPDFReportError.reportsDirectoryUnavailable
+        }
+        let directory = documents.appendingPathComponent(folderName, isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            throw PendingReminderPDFReportError.saveFailed(error.localizedDescription)
+        }
+        return directory
+    }
+
+    private static func reminderCount(from fileName: String) -> Int {
+        let base = (fileName as NSString).deletingPathExtension
+        guard let suffix = base.split(separator: "-").last else { return 0 }
+        return Int(suffix) ?? 0
+    }
+
+    private static func stableID(for url: URL) -> UUID {
+        let bytes = Array(url.path.utf8)
+        var a: UInt64 = 0xcbf29ce484222325
+        var b: UInt64 = 0x84222325cbf29ce4
+        for byte in bytes {
+            a ^= UInt64(byte)
+            a &*= 0x100000001b3
+            b ^= UInt64(byte &+ 31)
+            b &*= 0x100000001b3
+        }
+        let raw = String(
+            format: "%08X-%04X-%04X-%04X-%012llX",
+            UInt32(truncatingIfNeeded: a >> 32),
+            UInt16(truncatingIfNeeded: a >> 16),
+            UInt16(truncatingIfNeeded: a),
+            UInt16(truncatingIfNeeded: b >> 48),
+            b & 0x0000FFFFFFFFFFFF
+        )
+        return UUID(uuidString: raw) ?? UUID()
+    }
+
+    private static func renderPDF(
+        reminders: [ReminderItem],
+        generatedAt: Date,
+        defaultRecipient: String
+    ) -> Data {
+        let renderer = UIGraphicsPDFRenderer(bounds: pageBounds)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .short
+
+        return renderer.pdfData { context in
+            var pageNumber = 0
+            var y: CGFloat = 0
+
+            func beginPage() {
+                context.beginPage()
+                pageNumber += 1
+                y = margin
+                drawText(
+                    "NEXT REMINDER",
+                    in: CGRect(x: margin, y: y, width: pageBounds.width - margin * 2, height: 22),
+                    font: .systemFont(ofSize: 11, weight: .bold),
+                    color: .secondaryLabel,
+                    alignment: .left
+                )
+                drawText(
+                    "Page \(pageNumber)",
+                    in: CGRect(x: margin, y: y, width: pageBounds.width - margin * 2, height: 22),
+                    font: .systemFont(ofSize: 10, weight: .medium),
+                    color: .secondaryLabel,
+                    alignment: .right
+                )
+                y += 27
+            }
+
+            func ensureSpace(_ height: CGFloat) {
+                if y + height > pageBounds.height - margin - 24 { beginPage() }
+            }
+
+            beginPage()
+            drawText(
+                "Pending Reminders Report",
+                in: CGRect(x: margin, y: y, width: pageBounds.width - margin * 2, height: 38),
+                font: .systemFont(ofSize: 25, weight: .bold),
+                color: .label,
+                alignment: .left
+            )
+            y += 42
+
+            drawText(
+                "Generated \(dateFormatter.string(from: generatedAt))",
+                in: CGRect(x: margin, y: y, width: pageBounds.width - margin * 2, height: 20),
+                font: .systemFont(ofSize: 11),
+                color: .secondaryLabel,
+                alignment: .left
+            )
+            y += 23
+
+            let recipientText = validEmail(defaultRecipient)
+                ? "Preset recipient: \(defaultRecipient)"
+                : "Preset recipient: Not configured"
+            drawText(
+                recipientText,
+                in: CGRect(x: margin, y: y, width: pageBounds.width - margin * 2, height: 20),
+                font: .systemFont(ofSize: 11, weight: .medium),
+                color: .secondaryLabel,
+                alignment: .left
+            )
+            y += 30
+
+            let summaryRect = CGRect(x: margin, y: y, width: pageBounds.width - margin * 2, height: 54)
+            UIColor.secondarySystemBackground.setFill()
+            UIBezierPath(roundedRect: summaryRect, cornerRadius: 12).fill()
+            drawText(
+                "\(reminders.count)",
+                in: CGRect(x: summaryRect.minX + 16, y: summaryRect.minY + 8, width: 70, height: 27),
+                font: .systemFont(ofSize: 22, weight: .bold),
+                color: .label,
+                alignment: .left
+            )
+            drawText(
+                "pending reminders",
+                in: CGRect(x: summaryRect.minX + 16, y: summaryRect.minY + 32, width: 180, height: 16),
+                font: .systemFont(ofSize: 10, weight: .medium),
+                color: .secondaryLabel,
+                alignment: .left
+            )
+            let overdueCount = reminders.filter { $0.dueDate <= generatedAt }.count
+            drawText(
+                "\(overdueCount) overdue",
+                in: CGRect(x: summaryRect.maxX - 155, y: summaryRect.minY + 17, width: 135, height: 20),
+                font: .systemFont(ofSize: 12, weight: .semibold),
+                color: overdueCount > 0 ? .systemRed : .systemGreen,
+                alignment: .right
+            )
+            y += 72
+
+            for (index, reminder) in reminders.enumerated() {
+                let notes = reminder.notes.trimmingCharacters(in: .whitespacesAndNewlines)
+                let noteHeight = notes.isEmpty ? CGFloat(0) : textHeight(
+                    notes,
+                    width: pageBounds.width - margin * 2 - 28,
+                    font: .systemFont(ofSize: 10.5)
+                ) + 9
+                ensureSpace(CGFloat(76) + noteHeight)
+
+                let overdue = reminder.dueDate <= generatedAt
+                drawText(
+                    "\(index + 1). \(reminder.title)\(overdue ? "  •  OVERDUE" : "")",
+                    in: CGRect(x: margin, y: y, width: pageBounds.width - margin * 2, height: 24),
+                    font: .systemFont(ofSize: 13.5, weight: .semibold),
+                    color: overdue ? .systemRed : .label,
+                    alignment: .left
+                )
+                y += 25
+
+                drawText(
+                    "Due: \(dateFormatter.string(from: reminder.dueDate))",
+                    in: CGRect(x: margin + 18, y: y, width: pageBounds.width - margin * 2 - 18, height: 18),
+                    font: .systemFont(ofSize: 10.5),
+                    color: .secondaryLabel,
+                    alignment: .left
+                )
+                y += 18
+
+                if let deadline = reminder.deadlineDate {
+                    drawText(
+                        "Deadline: \(dateFormatter.string(from: deadline))",
+                        in: CGRect(x: margin + 18, y: y, width: pageBounds.width - margin * 2 - 18, height: 18),
+                        font: .systemFont(ofSize: 10.5),
+                        color: .secondaryLabel,
+                        alignment: .left
+                    )
+                    y += 18
+                }
+
+                drawText(
+                    "Priority: \(reminder.priority.title)",
+                    in: CGRect(x: margin + 18, y: y, width: pageBounds.width - margin * 2 - 18, height: 18),
+                    font: .systemFont(ofSize: 10.5, weight: .medium),
+                    color: .secondaryLabel,
+                    alignment: .left
+                )
+                y += 19
+
+                if !notes.isEmpty {
+                    let height = textHeight(
+                        notes,
+                        width: pageBounds.width - margin * 2 - 28,
+                        font: .systemFont(ofSize: 10.5)
+                    )
+                    drawText(
+                        notes,
+                        in: CGRect(x: margin + 18, y: y, width: pageBounds.width - margin * 2 - 28, height: height + 3),
+                        font: .systemFont(ofSize: 10.5),
+                        color: .label,
+                        alignment: .left
+                    )
+                    y += height + 7
+                }
+
+                UIColor.separator.setStroke()
+                let path = UIBezierPath()
+                path.move(to: CGPoint(x: margin, y: y + 4))
+                path.addLine(to: CGPoint(x: pageBounds.width - margin, y: y + 4))
+                path.lineWidth = 0.5
+                path.stroke()
+                y += 14
+            }
+
+            ensureSpace(34)
+            drawText(
+                "Generated and saved locally by Next Reminder",
+                in: CGRect(x: margin, y: y, width: pageBounds.width - margin * 2, height: 22),
+                font: .systemFont(ofSize: 9.5),
+                color: .tertiaryLabel,
+                alignment: .center
+            )
+        }
+    }
+
+    private static func validEmail(_ value: String) -> Bool {
+        let cleaned = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let at = cleaned.firstIndex(of: "@"), cleaned[cleaned.index(after: at)...].contains(".") else {
+            return false
+        }
+        return !cleaned.contains(" ") && cleaned.count <= 254
+    }
+
+    private static func drawText(
+        _ text: String,
+        in rect: CGRect,
+        font: UIFont,
+        color: UIColor,
+        alignment: NSTextAlignment
+    ) {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = alignment
+        paragraph.lineBreakMode = .byWordWrapping
+        (text as NSString).draw(
+            with: rect,
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font, .foregroundColor: color, .paragraphStyle: paragraph],
+            context: nil
+        )
+    }
+
+    private static func textHeight(_ text: String, width: CGFloat, font: UIFont) -> CGFloat {
+        let rect = (text as NSString).boundingRect(
+            with: CGSize(width: width, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font],
+            context: nil
+        )
+        return ceil(rect.height)
+    }
+}
+
+private struct PendingReportEmailAttachment: Encodable {
+    let fileName: String
+    let mimeType: String
+    let base64: String
+}
+
+private struct PendingReportEmailPayload: Encodable {
+    let recipients: [String]
+    let subject: String
+    let body: String
+    let remoteConnectorID: String
+    let senderLabel: String
+    let attachments: [PendingReportEmailAttachment]
+}
+
+private struct PendingReportEmailResponse: Decodable {
+    let message: String?
+}
+
+enum PendingReportEmailError: LocalizedError {
+    case invalidRecipient
+    case gmailNotConnected
+    case schedulerNotConfigured
+    case invalidEndpoint
+    case unreadablePDF
+    case attachmentTooLarge
+    case invalidResponse
+    case connectorExpired
+    case server(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRecipient:
+            return "Set a valid preset recipient in Settings → Email Reminder Automations first."
+        case .gmailNotConnected:
+            return "Connect Gmail in Next Reminder before sending the PDF."
+        case .schedulerNotConfigured:
+            return "Configure the HTTPS scheduler in Automation Connections first."
+        case .invalidEndpoint:
+            return "The scheduler URL is invalid."
+        case .unreadablePDF:
+            return "The saved PDF could not be read. Generate a new report and try again."
+        case .attachmentTooLarge:
+            return "The PDF is larger than the 8 MB attachment limit."
+        case .invalidResponse:
+            return "The Gmail scheduler returned an invalid response."
+        case .connectorExpired:
+            return "The saved Gmail connector is unavailable. Reconnect Gmail and try again; the PDF remains saved locally."
+        case .server(let message):
+            return message
+        }
+    }
+}
+
+struct PendingReportEmailService {
+    static func isValidEmail(_ value: String) -> Bool {
+        let cleaned = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let at = cleaned.firstIndex(of: "@"), cleaned[cleaned.index(after: at)...].contains(".") else {
+            return false
+        }
+        return !cleaned.contains(" ") && cleaned.count <= 254
+    }
+
+    func send(
+        report: PendingReminderPDFReport,
+        recipient: String,
+        gmail: GmailConnectionRecord,
+        endpoint: String,
+        apiKey: String
+    ) async throws -> String {
+        let recipient = recipient.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isValidEmail(recipient) else { throw PendingReportEmailError.invalidRecipient }
+        guard !gmail.connectorID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw PendingReportEmailError.gmailNotConnected
+        }
+        guard !endpoint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw PendingReportEmailError.schedulerNotConfigured
+        }
+
+        let normalized = endpoint.hasSuffix("/") ? endpoint : endpoint + "/"
+        guard let baseURL = URL(string: normalized),
+              baseURL.scheme?.lowercased() == "https",
+              let url = URL(string: "v1/file-shares", relativeTo: baseURL)?.absoluteURL else {
+            throw PendingReportEmailError.invalidEndpoint
+        }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: report.url)
+        } catch {
+            throw PendingReportEmailError.unreadablePDF
+        }
+        guard !data.isEmpty else { throw PendingReportEmailError.unreadablePDF }
+        guard data.count <= 8_000_000 else { throw PendingReportEmailError.attachmentTooLarge }
+
+        let payload = PendingReportEmailPayload(
+            recipients: [recipient],
+            subject: "Pending Reminders Report — \(report.reminderCount)",
+            body: "Please find attached the pending reminders report generated by Next Reminder on \(report.createdAt.formatted(date: .long, time: .shortened)).",
+            remoteConnectorID: gmail.connectorID,
+            senderLabel: gmail.emailAddress,
+            attachments: [
+                PendingReportEmailAttachment(
+                    fileName: report.fileName,
+                    mimeType: "application/pdf",
+                    base64: data.base64EncodedString()
+                )
+            ]
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 180
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("NextReminder-iOS/1.3.29.39", forHTTPHeaderField: "User-Agent")
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (responseData, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw PendingReportEmailError.invalidResponse }
+        guard (200...299).contains(http.statusCode) else {
+            let message = (try? JSONDecoder().decode(PendingReportEmailResponse.self, from: responseData).message)
+                ?? "PDF email failed (\(http.statusCode))."
+            let lowered = message.lowercased()
+            if lowered.contains("gmail connector not found")
+                || lowered.contains("reconnect gmail")
+                || lowered.contains("reconnect the gmail account") {
+                throw PendingReportEmailError.connectorExpired
+            }
+            throw PendingReportEmailError.server(message)
+        }
+
+        return (try? JSONDecoder().decode(PendingReportEmailResponse.self, from: responseData).message)
+            ?? "PDF sent successfully."
+    }
+}
+
+struct PendingReportsView: View {
+    @EnvironmentObject private var reminderStore: ReminderStore
+    @EnvironmentObject private var automationStore: AutomationStore
+    @EnvironmentObject private var emailStore: EmailAutomationStore
+
+    @State private var savedReports: [PendingReminderPDFReport] = []
+    @State private var isLoading = true
+    @State private var isGenerating = false
+    @State private var sendingID: UUID?
+    @State private var statusMessage: String?
+    @State private var errorMessage: String?
+    @State private var gmailRecord: GmailConnectionRecord? = GmailConnectionStore.shared.load()
+
+    private var recipient: String {
+        emailStore.settings.recipient.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var pendingCount: Int {
+        reminderStore.pendingReminders.count
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                summaryCard
+                connectionCard
+                generateButton
+
+                if let statusMessage {
+                    statusCard(statusMessage)
+                }
+
+                savedReportsSection
+            }
+            .padding(16)
+            .padding(.bottom, 24)
+        }
+        .background(Color.nextBackground.ignoresSafeArea())
+        .navigationTitle("Pending Reports")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await reloadReports() }
+        .onReceive(NotificationCenter.default.publisher(for: .nextEmailAutomationSettingsChanged)) { _ in
+            gmailRecord = GmailConnectionStore.shared.load()
+        }
+        .alert("Pending Reports", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 15, style: .continuous)
+                        .fill(Color.white.opacity(0.16))
+                    Image(systemName: "doc.text.fill")
+                        .font(.title2.bold())
+                        .foregroundStyle(.white)
+                }
+                .frame(width: 52, height: 52)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Pending Reminders PDF")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    Text("Manual generation & email")
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.84))
+                }
+                Spacer()
+            }
+
+            HStack(spacing: 10) {
+                metricChip("\(pendingCount) pending", icon: "clock.fill")
+                metricChip("Max 3 saved", icon: "tray.full.fill")
+            }
+        }
+        .padding(16)
+        .background(
+            LinearGradient(
+                colors: [Color.nextOrange, Color.orange],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            ),
+            in: RoundedRectangle(cornerRadius: 22, style: .continuous)
+        )
+    }
+
+    private var connectionCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: PendingReportEmailService.isValidEmail(recipient) ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
+                    .foregroundStyle(PendingReportEmailService.isValidEmail(recipient) ? Color.green : Color.orange)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Preset email")
+                        .font(.subheadline.weight(.semibold))
+                    Text(PendingReportEmailService.isValidEmail(recipient) ? recipient : "Not configured")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+
+            Divider()
+
+            HStack(spacing: 10) {
+                Image(systemName: gmailRecord == nil ? "envelope.badge.fill" : "checkmark.seal.fill")
+                    .foregroundStyle(gmailRecord == nil ? Color.orange : Color.green)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(gmailRecord == nil ? "Gmail not connected" : "Gmail connected")
+                        .font(.subheadline.weight(.semibold))
+                    Text(gmailRecord?.emailAddress ?? "Connect Gmail before using Send Email")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+
+            if !PendingReportEmailService.isValidEmail(recipient) {
+                NavigationLink {
+                    EmailAutomationSettingsView()
+                } label: {
+                    Label("Set preset email", systemImage: "gearshape.fill")
+                        .font(.subheadline.weight(.semibold))
+                }
+            }
+        }
+        .padding(14)
+        .background(Color.nextCard, in: RoundedRectangle(cornerRadius: 17, style: .continuous))
+    }
+
+    private var generateButton: some View {
+        Button {
+            generateReport()
+        } label: {
+            HStack(spacing: 12) {
+                if isGenerating {
+                    ProgressView().tint(.white)
+                } else {
+                    Image(systemName: "doc.badge.plus")
+                        .font(.title3.bold())
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(isGenerating ? "Generating PDF…" : "Generate Pending Report")
+                        .font(.headline)
+                    Text(pendingCount == 0 ? "No pending reminders" : "Create PDF from \(pendingCount) reminders")
+                        .font(.caption2)
+                        .opacity(0.85)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+            }
+            .foregroundStyle(.white)
+            .padding(14)
+            .background(Color.nextOrange, in: RoundedRectangle(cornerRadius: 17, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(isGenerating || pendingCount == 0)
+        .opacity((isGenerating || pendingCount == 0) ? 0.55 : 1)
+    }
+
+    @ViewBuilder
+    private var savedReportsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Saved Reports")
+                    .font(.headline)
+                Spacer()
+                Text("\(savedReports.count)/3")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+            }
+
+            if isLoading {
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text("Loading reports…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 20)
+                .background(Color.nextCard, in: RoundedRectangle(cornerRadius: 17, style: .continuous))
+            } else if savedReports.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "doc.text.magnifyingglass")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                    Text("No reports saved yet")
+                        .font(.subheadline.weight(.semibold))
+                    Text("Generate a PDF above. Only the newest three reports are kept.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 22)
+                .background(Color.nextCard, in: RoundedRectangle(cornerRadius: 17, style: .continuous))
+            } else {
+                ForEach(savedReports) { report in
+                    reportRow(report)
+                }
+            }
+        }
+    }
+
+    private func reportRow(_ report: PendingReminderPDFReport) -> some View {
+        VStack(alignment: .leading, spacing: 11) {
+            HStack(alignment: .top, spacing: 11) {
+                Image(systemName: "doc.richtext.fill")
+                    .font(.title3)
+                    .foregroundStyle(.nextOrange)
+                    .frame(width: 30)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(report.fileName)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(2)
+                    Text("\(report.reminderCount) reminders • \(report.sizeText)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(report.createdAt.formatted(date: .abbreviated, time: .shortened))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+
+                if savedReports.first?.id == report.id {
+                    Text("LATEST")
+                        .font(.caption2.bold())
+                        .foregroundStyle(.nextOrange)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 4)
+                        .background(Color.nextOrange.opacity(0.12), in: Capsule())
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    sendReport(report)
+                } label: {
+                    HStack(spacing: 7) {
+                        if sendingID == report.id {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Image(systemName: "paperplane.fill")
+                        }
+                        Text(sendingID == report.id ? "Sending…" : "Send Email")
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background(Color.nextOrange.opacity(0.13), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .disabled(sendingID != nil)
+
+                ShareLink(item: report.url) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                        .font(.subheadline.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(14)
+        .background(Color.nextCard, in: RoundedRectangle(cornerRadius: 17, style: .continuous))
+    }
+
+    private func metricChip(_ text: String, icon: String) -> some View {
+        Label(text, systemImage: icon)
+            .font(.caption.bold())
+            .foregroundStyle(.white)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(.white.opacity(0.16), in: Capsule())
+    }
+
+    private func statusCard(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 9) {
+            Image(systemName: "info.circle.fill")
+                .foregroundStyle(.nextOrange)
+            Text(text)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.nextCard, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    @MainActor
+    private func reloadReports() async {
+        isLoading = true
+        let reports = await Task.detached(priority: .utility) {
+            PendingReminderPDFReportService.savedReports()
+        }.value
+        savedReports = reports
+        gmailRecord = GmailConnectionStore.shared.load()
+        isLoading = false
+    }
+
+    private func generateReport() {
+        guard !isGenerating else { return }
+        let snapshot = reminderStore.pendingReminders
+        let destination = recipient
+        isGenerating = true
+        statusMessage = "Generating pending-reminders PDF…"
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let report = try PendingReminderPDFReportService.generate(
+                    reminders: snapshot,
+                    defaultRecipient: destination
+                )
+                let reports = PendingReminderPDFReportService.savedReports()
+                DispatchQueue.main.async {
+                    isGenerating = false
+                    savedReports = reports
+                    statusMessage = "PDF saved: \(report.fileName). Latest \(reports.count) of 3 retained."
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    isGenerating = false
+                    errorMessage = error.localizedDescription
+                    statusMessage = nil
+                }
+            }
+        }
+    }
+
+    private func sendReport(_ report: PendingReminderPDFReport) {
+        guard PendingReportEmailService.isValidEmail(recipient) else {
+            errorMessage = PendingReportEmailError.invalidRecipient.localizedDescription
+            return
+        }
+        guard let gmail = GmailConnectionStore.shared.load() else {
+            errorMessage = PendingReportEmailError.gmailNotConnected.localizedDescription
+            return
+        }
+
+        let endpoint = automationStore.cloudEndpoint
+        let apiKey = automationStore.cloudAPIKey
+        guard !endpoint.isEmpty, !apiKey.isEmpty else {
+            errorMessage = PendingReportEmailError.schedulerNotConfigured.localizedDescription
+            return
+        }
+
+        sendingID = report.id
+        statusMessage = "Sending \(report.fileName) to \(recipient)…"
+        let destination = recipient
+
+        Task {
+            defer { sendingID = nil }
+            do {
+                let message = try await PendingReportEmailService().send(
+                    report: report,
+                    recipient: destination,
+                    gmail: gmail,
+                    endpoint: endpoint,
+                    apiKey: apiKey
+                )
+                statusMessage = "Sent successfully to \(destination). \(message)"
+                gmailRecord = GmailConnectionStore.shared.load() ?? gmail
+            } catch {
+                errorMessage = error.localizedDescription
+                statusMessage = "Send failed. The PDF remains saved locally."
+                gmailRecord = GmailConnectionStore.shared.load() ?? gmail
+            }
+        }
+    }
+}

--- a/tmp-build-1329/build-final.sh
+++ b/tmp-build-1329/build-final.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+R="$RUNNER_TEMP"
+cp tmp-build-1329/build.sh "$R/build-1329-final.sh"
+python3 - <<'PY'
+from pathlib import Path
+import os
+p=Path(os.environ['RUNNER_TEMP'])/'build-1329-final.sh'
+s=p.read_text()
+old='''strings "$APP/NextReminder" > "$R/app.strings"\ngrep -q 'Pending Reports' "$R/app.strings"\ngrep -q 'Generate Pending Report' "$R/app.strings"\ngrep -q 'Max 3 saved' "$R/app.strings"\n'''
+if old not in s:
+    raise SystemExit('Expected optimized-binary string checks not found')
+s=s.replace(old,'''# Optimized Swift binaries do not guarantee human-readable string literals.\n# Feature presence is already validated against source before compilation.\n''',1)
+p.write_text(s)
+PY
+exec bash "$R/build-1329-final.sh"

--- a/tmp-build-1329/build.sh
+++ b/tmp-build-1329/build.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -euo pipefail
+R="$RUNNER_TEMP"
+rm -rf "$R/appsrc" "$R/out" "$R/DD" "$R/iconvenv"
+mkdir -p "$R/appsrc" "$R/out"
+
+awk '/# Restore\/compile a complete icon catalog/{exit} {print}' tmp-build-1328/build.sh > "$R/reconstruct-1328.sh"
+bash "$R/reconstruct-1328.sh"
+P="$R/appsrc"
+FILES_SHA=$(shasum -a 256 "$P/NextReminder/Sources/FileSharing.swift" | awk '{print $1}')
+
+cp tmp-build-1329/PendingReports.swift "$P/NextReminder/Sources/PendingReports.swift"
+python3 - <<'PYREPORT'
+from pathlib import Path
+import os
+p=Path(os.environ['RUNNER_TEMP'])/'appsrc/NextReminder/Sources/PendingReports.swift'
+s=p.read_text()
+old='''            if !PendingReportEmailService.isValidEmail(recipient) {\n                NavigationLink {\n                    EmailAutomationSettingsView()\n                } label: {\n                    Label("Set preset email", systemImage: "gearshape.fill")\n                        .font(.subheadline.weight(.semibold))\n                }\n            }\n'''
+new='''            if !PendingReportEmailService.isValidEmail(recipient) {\n                Text("Set the default address in Settings → Email Reminder Automations.")\n                    .font(.caption.weight(.medium))\n                    .foregroundStyle(Color.nextOrange)\n            }\n'''
+if old in s:
+    s=s.replace(old,new,1)
+p.write_text(s)
+PYREPORT
+
+python3 - <<'PYROOT'
+from pathlib import Path
+import os
+p=Path(os.environ['RUNNER_TEMP'])/'appsrc/NextReminder/Sources/RootReminders.swift'
+s=p.read_text()
+old='''                emailSchedulesSummary\n                WorkweekPerformanceCard()'''
+new='''                emailSchedulesSummary\n                pendingReportsSummary\n                WorkweekPerformanceCard()'''
+if old not in s:
+    raise SystemExit('Could not insert Pending Reports card')
+s=s.replace(old,new,1)
+marker='''    private var header: some View {'''
+card='''    private var pendingReportsSummary: some View {\n        NavigationLink {\n            PendingReportsView()\n        } label: {\n            HStack(spacing: 13) {\n                ZStack {\n                    RoundedRectangle(cornerRadius: 14, style: .continuous)\n                        .fill(Color.nextOrange.opacity(0.14))\n                    Image(systemName: "doc.text.fill")\n                        .font(.title3.bold())\n                        .foregroundStyle(.nextOrange)\n                }\n                .frame(width: 50, height: 50)\n\n                VStack(alignment: .leading, spacing: 4) {\n                    Text("Pending Reports")\n                        .font(.headline)\n                        .foregroundStyle(.primary)\n                    Text("Generate PDF • Keep latest 3 • Send to preset email")\n                        .font(.caption)\n                        .foregroundStyle(.secondary)\n                }\n                Spacer()\n                Image(systemName: "chevron.right")\n                    .font(.caption.bold())\n                    .foregroundStyle(.secondary)\n            }\n            .padding(14)\n            .background(Color.nextCard, in: RoundedRectangle(cornerRadius: 17, style: .continuous))\n            .overlay(\n                RoundedRectangle(cornerRadius: 17, style: .continuous)\n                    .stroke(Color.nextOrange.opacity(0.18), lineWidth: 1)\n            )\n        }\n        .buttonStyle(.plain)\n    }\n\n'''
+if marker not in s:
+    raise SystemExit('Could not locate RootReminders header marker')
+s=s.replace(marker,card+marker,1)
+p.write_text(s)
+PYROOT
+
+python3 - <<'PYPBX'
+from pathlib import Path
+import os
+p=Path(os.environ['RUNNER_TEMP'])/'appsrc/NextReminder.xcodeproj/project.pbxproj'
+s=p.read_text()
+build='A12900000000000000000001'
+ref='A12900000000000000000002'
+assert build not in s and ref not in s
+needle='\t\t5F6B7FEA659424E5D3A21C80 /* FileSharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF199847B7956FCE30860684 /* FileSharing.swift */; };\n'
+assert needle in s
+s=s.replace(needle,needle+f'\t\t{build} /* PendingReports.swift in Sources */ = {{isa = PBXBuildFile; fileRef = {ref} /* PendingReports.swift */; }};\n',1)
+needle='\t\tEF199847B7956FCE30860684 /* FileSharing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSharing.swift; sourceTree = "<group>"; };\n'
+assert needle in s
+s=s.replace(needle,needle+f'\t\t{ref} /* PendingReports.swift */ = {{isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingReports.swift; sourceTree = "<group>"; }};\n',1)
+needle='\t\t\t\tEF199847B7956FCE30860684 /* FileSharing.swift */,\n'
+assert needle in s
+s=s.replace(needle,needle+f'\t\t\t\t{ref} /* PendingReports.swift */,\n',1)
+needle='\t\t\t\t5F6B7FEA659424E5D3A21C80 /* FileSharing.swift in Sources */,\n'
+assert needle in s
+s=s.replace(needle,needle+f'\t\t\t\t{build} /* PendingReports.swift in Sources */,\n',1)
+p.write_text(s)
+PYPBX
+
+python3 - <<'PYVER'
+from pathlib import Path
+import os,re
+root=Path(os.environ['RUNNER_TEMP'])/'appsrc'
+pbx=root/'NextReminder.xcodeproj/project.pbxproj'
+s=pbx.read_text()
+s=re.sub(r'CURRENT_PROJECT_VERSION = 38;', 'CURRENT_PROJECT_VERSION = 39;', s)
+s=re.sub(r'MARKETING_VERSION = 1\.3\.28;', 'MARKETING_VERSION = 1.3.29;', s)
+pbx.write_text(s)
+for rel in ['NextReminder/Resources/Info.plist','NextReminderLiveActivity/Info.plist']:
+    p=root/rel
+    if not p.exists():
+        continue
+    t=p.read_text().replace('<string>1.3.28</string>','<string>1.3.29</string>').replace('<string>38</string>','<string>39</string>')
+    p.write_text(t)
+PYVER
+
+test "$(shasum -a 256 "$P/NextReminder/Sources/FileSharing.swift" | awk '{print $1}')" = "$FILES_SHA"
+! grep -q 'PendingReminderPDFReport' "$P/NextReminder/Sources/FileSharing.swift"
+grep -q 'struct PendingReportsView' "$P/NextReminder/Sources/PendingReports.swift"
+grep -q 'Max 3 saved' "$P/NextReminder/Sources/PendingReports.swift"
+grep -q 'Pending Reports' "$P/NextReminder/Sources/RootReminders.swift"
+
+ASSETS="$P/NextReminder/Resources/Assets.xcassets"
+ICONSET="$ASSETS/AppIcon.appiconset"
+mkdir -p "$ICONSET" "$ASSETS/AccentColor.colorset" "$ASSETS/LaunchBackground.colorset"
+python3 -m venv "$R/iconvenv"
+"$R/iconvenv/bin/pip" install --quiet pillow
+"$R/iconvenv/bin/python" - <<'PYICON'
+from PIL import Image, ImageDraw
+from pathlib import Path
+import os,json
+root=Path(os.environ['RUNNER_TEMP'])/'appsrc/NextReminder/Resources/Assets.xcassets/AppIcon.appiconset'
+root.mkdir(parents=True,exist_ok=True)
+S=1024
+img=Image.new('RGB',(S,S),(18,18,22)); d=ImageDraw.Draw(img)
+for r in range(720,0,-8):
+    t=r/720
+    col=(int(255-(45*t)), int(103-(45*t)), int(28-(12*t)))
+    d.ellipse((S/2-r,S/2-r,S/2+r,S/2+r),fill=col)
+d.rounded_rectangle((190,205,834,820),radius=145,fill=(25,25,30),outline=(255,255,255),width=10)
+d.ellipse((410,330,614,534),fill=(255,255,255)); d.rounded_rectangle((390,430,634,625),radius=80,fill=(255,255,255)); d.rectangle((365,575,659,625),fill=(255,255,255)); d.ellipse((474,630,550,706),fill=(255,255,255)); d.ellipse((585,560,755,730),fill=(255,116,38),outline=(25,25,30),width=12); d.line((625,645,665,683),fill='white',width=22); d.line((665,683,724,616),fill='white',width=22)
+img.save(root/'AppIcon-1024.png',optimize=True)
+for size in [40,58,60,80,87,120,180]: img.resize((size,size),Image.Resampling.LANCZOS).save(root/f'AppIcon-{size}.png',optimize=True)
+contents={"images":[{"filename":"AppIcon-40.png","idiom":"iphone","scale":"2x","size":"20x20"},{"filename":"AppIcon-60.png","idiom":"iphone","scale":"3x","size":"20x20"},{"filename":"AppIcon-58.png","idiom":"iphone","scale":"2x","size":"29x29"},{"filename":"AppIcon-87.png","idiom":"iphone","scale":"3x","size":"29x29"},{"filename":"AppIcon-80.png","idiom":"iphone","scale":"2x","size":"40x40"},{"filename":"AppIcon-120.png","idiom":"iphone","scale":"3x","size":"40x40"},{"filename":"AppIcon-120.png","idiom":"iphone","scale":"2x","size":"60x60"},{"filename":"AppIcon-180.png","idiom":"iphone","scale":"3x","size":"60x60"},{"filename":"AppIcon-1024.png","idiom":"ios-marketing","scale":"1x","size":"1024x1024"}],"info":{"author":"xcode","version":1}}
+(root/'Contents.json').write_text(json.dumps(contents,indent=2)+'\n')
+(root.parent/'Contents.json').write_text('{"info":{"author":"xcode","version":1}}\n')
+PYICON
+cat > "$ASSETS/AccentColor.colorset/Contents.json" <<'EOF'
+{"colors":[],"info":{"author":"xcode","version":1}}
+EOF
+cat > "$ASSETS/LaunchBackground.colorset/Contents.json" <<'EOF'
+{"colors":[],"info":{"author":"xcode","version":1}}
+EOF
+
+grep -q 'ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;' "$P/NextReminder.xcodeproj/project.pbxproj"
+
+xcodebuild -project "$P/NextReminder.xcodeproj" -scheme NextReminder \
+  -configuration Release -sdk iphoneos -destination 'generic/platform=iOS' \
+  -derivedDataPath "$R/DD" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' build
+
+APP=$(find "$R/DD/Build/Products/Release-iphoneos" -maxdepth 1 -name NextReminder.app -print -quit)
+test -n "$APP"
+test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Info.plist")" = '1.3.29'
+test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP/Info.plist")" = '39'
+EXT="$APP/PlugIns/NextReminderLiveActivity.appex/Info.plist"
+test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$EXT")" = '1.3.29'
+test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$EXT")" = '39'
+test -f "$APP/Assets.car"
+/usr/libexec/PlistBuddy -c 'Print :CFBundleIcons' "$APP/Info.plist" >/dev/null
+strings "$APP/NextReminder" > "$R/app.strings"
+grep -q 'Pending Reports' "$R/app.strings"
+grep -q 'Generate Pending Report' "$R/app.strings"
+grep -q 'Max 3 saved' "$R/app.strings"
+
+mkdir -p "$R/out/Payload"
+cp -R "$APP" "$R/out/Payload/"
+(cd "$R/out" && zip -qry NextReminder_1.3.29_Unsigned.tipa Payload)
+rm -rf "$R/out/Payload"
+cd "$R/out"
+shasum -a 256 NextReminder_1.3.29_Unsigned.tipa > SHA256SUMS.txt
+ls -lh

--- a/tmp-build-1329/inspect.sh
+++ b/tmp-build-1329/inspect.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+R="$RUNNER_TEMP"
+# Reuse the exact 1.3.28 reconstruction/rollback logic, but stop before icon/build work.
+awk '/# Restore\/compile a complete icon catalog/{exit} {print}' tmp-build-1328/build.sh > "$R/reconstruct-1328.sh"
+bash "$R/reconstruct-1328.sh"
+mkdir -p "$R/inspect"
+for f in App.swift RootReminders.swift Settings.swift EmailAutomationCore.swift GmailConnection.swift AutomationServices.swift FileSharing.swift ModelsUtilities.swift; do
+  cp "$R/appsrc/NextReminder/Sources/$f" "$R/inspect/$f"
+done
+cp "$R/appsrc/NextReminder.xcodeproj/project.pbxproj" "$R/inspect/project.pbxproj"
+ls -lh "$R/inspect"


### PR DESCRIPTION
Temporary inspection/build PR. Keeps the confirmed-stable 1.3.28 Files implementation untouched and inspects the surrounding app/navigation/email code so manual pending-reminder PDF reports can be added outside Files. Do not merge.