### PR TITLE
Inspect NQR 1.0.15 scheduler for persistent wake timer

### DIFF
--- a/.github/workflows/temp-next-reminder-1322-build.yml
+++ b/.github/workflows/temp-next-reminder-1322-build.yml
@@ -1,4 +1,4 @@
-name: Temp NQR 1.0.16 Persistent Timer Inspector
+name: Temp NQR 1.0.16 Persistent Wake Builder
 on:
   pull_request:
     branches: [main]
@@ -7,10 +7,10 @@ on:
 permissions:
   contents: read
 jobs:
-  inspect:
+  build:
     if: github.head_ref == 'build-next-reminder-1331-working'
     runs-on: macos-15
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: Import verified tweak source payloads
@@ -22,12 +22,14 @@ jobs:
           git checkout FETCH_HEAD -- tmp-build-1325/patch
           git fetch --depth 1 origin build-next-reminder-1330-working
           git checkout FETCH_HEAD -- tmp-build-1330/tweak1015.patch.xz.b64
-      - name: Reconstruct current 1.0.15 source
+      - name: Build and validate RootHide tweak
         shell: bash
-        run: bash tmp-build-1331/inspect.sh
+        run: bash tmp-build-1331/build.sh
       - uses: actions/upload-artifact@v4
         with:
-          name: NQR-1.0.15-Persistent-Timer-Inspection
-          path: ${{ runner.temp }}/inspect/
+          name: NextQuickReminder-1.0.16-Persistent-Wake-RootHide
+          path: |
+            ${{ runner.temp }}/out/NextQuickReminder_1.0.16_RootHide.deb
+            ${{ runner.temp }}/out/SHA256SUMS.txt
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7

--- a/.github/workflows/temp-next-reminder-1322-build.yml
+++ b/.github/workflows/temp-next-reminder-1322-build.yml
@@ -1,35 +1,33 @@
-name: Temp Next Reminder 1.3.28 Builder
+name: Temp NQR 1.0.16 Persistent Timer Inspector
 on:
   pull_request:
     branches: [main]
     paths:
-      - 'tmp-build-1328/**'
+      - 'tmp-build-1331/**'
 permissions:
   contents: read
 jobs:
-  build:
-    if: github.head_ref == 'build-next-reminder-1328-working'
+  inspect:
+    if: github.head_ref == 'build-next-reminder-1331-working'
     runs-on: macos-15
-    timeout-minutes: 45
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-      - name: Import verified source payloads and prior patches
+      - name: Import verified tweak source payloads
         shell: bash
         run: |
           git fetch --depth 1 origin build-next-reminder-1322-working
           git checkout FETCH_HEAD -- tmp-build
           git fetch --depth 1 origin build-next-reminder-1325-working
           git checkout FETCH_HEAD -- tmp-build-1325/patch
-          git fetch --depth 1 origin build-next-reminder-1326-working
-          git checkout FETCH_HEAD -- tmp-build-1326/app1326.patch.xz.b64
-      - name: Build and validate app
+          git fetch --depth 1 origin build-next-reminder-1330-working
+          git checkout FETCH_HEAD -- tmp-build-1330/tweak1015.patch.xz.b64
+      - name: Reconstruct current 1.0.15 source
         shell: bash
-        run: bash tmp-build-1328/build.sh
+        run: bash tmp-build-1331/inspect.sh
       - uses: actions/upload-artifact@v4
         with:
-          name: NextReminder-1.3.28-Stable-Files-Rollback
-          path: |
-            ${{ runner.temp }}/out/NextReminder_1.3.28_Unsigned.tipa
-            ${{ runner.temp }}/out/SHA256SUMS.txt
+          name: NQR-1.0.15-Persistent-Timer-Inspection
+          path: ${{ runner.temp }}/inspect/
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1

--- a/tmp-build-1331/PersistentReportScheduler.m
+++ b/tmp-build-1331/PersistentReportScheduler.m
@@ -1,0 +1,153 @@
+#import <Foundation/Foundation.h>
+#import <objc/message.h>
+#import <dlfcn.h>
+#import "PendingReportSender.h"
+
+static NSString * const NQRAutomationEnabledKey = @"NextReminder.PendingReportAutomationEnabled.v1";
+static NSString * const NQRAutomationHourKey = @"NextReminder.PendingReportAutomationHour.v1";
+static NSString * const NQRAutomationMinuteKey = @"NextReminder.PendingReportAutomationMinute.v1";
+static NSString * const NQRAutomationWeekdaysKey = @"NextReminder.PendingReportAutomationWeekdays.v1";
+static CFStringRef const NQRAutomationChanged = CFSTR("com.nextsolution.nextreminder.reportAutomationChanged");
+
+static id NQRPersistentTimer = nil;
+static id NQRSchedulerTarget = nil;
+
+static NSString *NQRAppContainerPath(void) {
+    @try {
+        Class c = NSClassFromString(@"LSApplicationProxy");
+        SEL s = NSSelectorFromString(@"applicationProxyForIdentifier:");
+        if (!c || ![c respondsToSelector:s]) return nil;
+        id proxy = ((id (*)(id, SEL, id))objc_msgSend)(c, s, @"com.nextsolution.nextreminder");
+        SEL d = NSSelectorFromString(@"dataContainerURL");
+        if (!proxy || ![proxy respondsToSelector:d]) return nil;
+        NSURL *url = ((id (*)(id, SEL))objc_msgSend)(proxy, d);
+        return [url isKindOfClass:NSURL.class] ? url.path : nil;
+    } @catch (__unused NSException *e) { return nil; }
+}
+
+static NSDictionary *NQRAutomationPrefs(void) {
+    NSString *container = NQRAppContainerPath();
+    if (!container.length) return @{};
+    NSString *p = [container stringByAppendingPathComponent:@"Library/Preferences/com.nextsolution.nextreminder.plist"];
+    NSDictionary *d = [NSDictionary dictionaryWithContentsOfFile:p];
+    return [d isKindOfClass:NSDictionary.class] ? d : @{};
+}
+
+static NSSet<NSNumber *> *NQRSelectedWeekdays(NSDictionary *prefs) {
+    id raw = prefs[NQRAutomationWeekdaysKey];
+    NSMutableSet *out = [NSMutableSet set];
+    if ([raw isKindOfClass:NSArray.class]) {
+        for (id v in (NSArray *)raw) if ([v respondsToSelector:@selector(integerValue)]) [out addObject:@([v integerValue])];
+    } else if ([raw isKindOfClass:NSSet.class]) {
+        for (id v in (NSSet *)raw) if ([v respondsToSelector:@selector(integerValue)]) [out addObject:@([v integerValue])];
+    } else if ([raw isKindOfClass:NSData.class]) {
+        id obj = [NSJSONSerialization JSONObjectWithData:raw options:0 error:nil];
+        if ([obj isKindOfClass:NSArray.class]) for (id v in obj) if ([v respondsToSelector:@selector(integerValue)]) [out addObject:@([v integerValue])];
+    }
+    return out;
+}
+
+static BOOL NQRWeekdaySelected(NSSet<NSNumber *> *set, NSInteger appleWeekday) {
+    if (set.count == 0) return YES;
+    if ([set containsObject:@(appleWeekday)]) return YES; // 1=Sun ... 7=Sat
+    NSInteger zeroBased = appleWeekday - 1;
+    if (zeroBased == 0 && [set containsObject:@0]) return YES; // support 0-based Sunday
+    return NO;
+}
+
+static NSDate *NQRNextAutomationDate(void) {
+    NSDictionary *prefs = NQRAutomationPrefs();
+    if (![prefs[NQRAutomationEnabledKey] boolValue]) return nil;
+    NSInteger hour = [prefs[NQRAutomationHourKey] respondsToSelector:@selector(integerValue)] ? [prefs[NQRAutomationHourKey] integerValue] : 9;
+    NSInteger minute = [prefs[NQRAutomationMinuteKey] respondsToSelector:@selector(integerValue)] ? [prefs[NQRAutomationMinuteKey] integerValue] : 0;
+    hour = MAX(0, MIN(23, hour)); minute = MAX(0, MIN(59, minute));
+    NSSet *weekdays = NQRSelectedWeekdays(prefs);
+    NSCalendar *cal = NSCalendar.currentCalendar;
+    NSDate *now = NSDate.date;
+    NSDate *start = [cal startOfDayForDate:now];
+    for (NSInteger offset = 0; offset < 8; offset++) {
+        NSDate *day = [cal dateByAddingUnit:NSCalendarUnitDay value:offset toDate:start options:0];
+        NSDateComponents *parts = [cal components:(NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay) fromDate:day];
+        parts.hour = hour; parts.minute = minute; parts.second = 0;
+        NSDate *candidate = [cal dateFromComponents:parts];
+        if (!candidate || [candidate timeIntervalSinceDate:now] < 2.0) continue;
+        NSInteger wd = [cal component:NSCalendarUnitWeekday fromDate:candidate];
+        if (NQRWeekdaySelected(weekdays, wd)) return candidate;
+    }
+    return nil;
+}
+
+static void NQRInvalidatePersistentTimer(void) {
+    if (NQRPersistentTimer && [NQRPersistentTimer respondsToSelector:NSSelectorFromString(@"invalidate")]) {
+        ((void (*)(id, SEL))objc_msgSend)(NQRPersistentTimer, NSSelectorFromString(@"invalidate"));
+    }
+    NQRPersistentTimer = nil;
+}
+
+@class NQRPersistentScheduleTarget;
+static void NQRScheduleNextPersistentReport(void);
+
+@interface NQRPersistentScheduleTarget : NSObject
+- (void)nqrPersistentTimerFired:(id)timer;
+@end
+@implementation NQRPersistentScheduleTarget
+- (void)nqrPersistentTimerFired:(id)timer {
+    NSLog(@"[NextQuickReminder] Persistent report timer fired while locked/waking");
+    NQRInvalidatePersistentTimer();
+    NQRSendPendingReportInBackground();
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ NQRScheduleNextPersistentReport(); });
+}
+@end
+
+static void NQRScheduleNextPersistentReport(void) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NQRInvalidatePersistentTimer();
+        NSDate *fireDate = NQRNextAutomationDate();
+        if (!fireDate) {
+            NSLog(@"[NextQuickReminder] Persistent report automation disabled or no eligible day");
+            return;
+        }
+        if (!NSClassFromString(@"PCPersistentTimer")) {
+            dlopen("/System/Library/PrivateFrameworks/PersistentConnection.framework/PersistentConnection", RTLD_LAZY | RTLD_LOCAL);
+        }
+        Class timerClass = NSClassFromString(@"PCPersistentTimer");
+        if (!timerClass) {
+            NSLog(@"[NextQuickReminder] ERROR PCPersistentTimer unavailable; cannot wake locked device");
+            return;
+        }
+        if (!NQRSchedulerTarget) NQRSchedulerTarget = [NQRPersistentScheduleTarget new];
+        SEL initSel = NSSelectorFromString(@"initWithFireDate:serviceIdentifier:target:selector:userInfo:");
+        id obj = [timerClass alloc];
+        if (![obj respondsToSelector:initSel]) {
+            NSLog(@"[NextQuickReminder] ERROR PCPersistentTimer initializer unavailable");
+            return;
+        }
+        obj = ((id (*)(id, SEL, id, id, id, SEL, id))objc_msgSend)(obj, initSel, fireDate, @"com.nextsolution.nextquickreminder.pendingreport", NQRSchedulerTarget, @selector(nqrPersistentTimerFired:), nil);
+        if (!obj) return;
+        SEL wakeSel = NSSelectorFromString(@"setDisableSystemWaking:");
+        if ([obj respondsToSelector:wakeSel]) ((void (*)(id, SEL, BOOL))objc_msgSend)(obj, wakeSel, NO);
+        SEL earlySel = NSSelectorFromString(@"setMinimumEarlyFireProportion:");
+        if ([obj respondsToSelector:earlySel]) ((void (*)(id, SEL, double))objc_msgSend)(obj, earlySel, 1.0);
+        SEL scheduleSel = NSSelectorFromString(@"scheduleInRunLoop:");
+        if ([obj respondsToSelector:scheduleSel]) {
+            ((void (*)(id, SEL, id))objc_msgSend)(obj, scheduleSel, NSRunLoop.mainRunLoop);
+            NQRPersistentTimer = obj;
+            NSLog(@"[NextQuickReminder] PCPersistentTimer scheduled %@ (system waking enabled)", fireDate);
+        } else {
+            NSLog(@"[NextQuickReminder] ERROR PCPersistentTimer scheduleInRunLoop unavailable");
+        }
+    });
+}
+
+static void NQRAutomationChangedCallback(CFNotificationCenterRef c, void *o, CFStringRef n, const void *obj, CFDictionaryRef u) {
+    NQRScheduleNextPersistentReport();
+}
+
+void NQRStartPersistentReportScheduler(void) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, NQRAutomationChangedCallback, NQRAutomationChanged, NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
+    });
+    NSLog(@"[NextQuickReminder] Starting PCPersistentTimer report scheduler");
+    NQRScheduleNextPersistentReport();
+}

--- a/tmp-build-1331/build.sh
+++ b/tmp-build-1331/build.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -euo pipefail
+R="$RUNNER_TEMP"
+rm -rf "$R/nqrsrc" "$R/out" "$R/theos-rh"
+mkdir -p "$R/nqrsrc" "$R/out"
+cat tmp-build/nqr1012/part-* > "$R/nqr.b64"
+python3 - <<'PY'
+import base64,os,pathlib
+r=pathlib.Path(os.environ['RUNNER_TEMP'])
+(r/'nqr.tar.xz').write_bytes(base64.b64decode((r/'nqr.b64').read_bytes()))
+PY
+echo 'eba18cc3ee4117e3e190441ce3533e10613a182aa610a3c92756c72a84cfd757  '"$R/nqr.tar.xz" | shasum -a 256 -c -
+tar -xJf "$R/nqr.tar.xz" -C "$R/nqrsrc"
+cat tmp-build-1325/patch/tweak-* > "$R/tweak1014.patch.xz.b64"
+base64 -D < "$R/tweak1014.patch.xz.b64" > "$R/tweak1014.patch.xz"
+xz -dc "$R/tweak1014.patch.xz" > "$R/tweak1014.patch"
+patch -d "$R/nqrsrc" -p4 < "$R/tweak1014.patch"
+base64 -D < tmp-build-1330/tweak1015.patch.xz.b64 > "$R/tweak1015.patch.xz"
+xz -dc "$R/tweak1015.patch.xz" > "$R/tweak1015.patch"
+patch -d "$R/nqrsrc" -p1 < "$R/tweak1015.patch"
+cp tmp-build-1331/PersistentReportScheduler.m "$R/nqrsrc/PersistentReportScheduler.m"
+python3 - <<'PYMOD'
+from pathlib import Path
+import os,re
+root=Path(os.environ['RUNNER_TEMP'])/'nqrsrc'
+# Add new scheduler source to tweak target.
+p=root/'Makefile'; s=p.read_text()
+old='NextQuickReminder_FILES = Tweak.xm PendingReportSender.m ConsoleBridge.m BackgroundLockscreen.xm MultiTriggersSettings.xm SystemApertureReminderV109.xm'
+new='NextQuickReminder_FILES = Tweak.xm PendingReportSender.m PersistentReportScheduler.m ConsoleBridge.m BackgroundLockscreen.xm MultiTriggersSettings.xm SystemApertureReminderV109.xm'
+if old not in s: raise SystemExit('Makefile source list not found')
+p.write_text(s.replace(old,new,1))
+# Switch startup from polling scheduler to wake-capable persistent scheduler.
+p=root/'Tweak.xm'; s=p.read_text()
+if 'NQRStartPendingReportAutomationScheduler();' not in s: raise SystemExit('Old scheduler start call not found')
+s=s.replace('NQRStartPendingReportAutomationScheduler();','NQRStartPersistentReportScheduler();',1)
+insert='extern void NQRStartPersistentReportScheduler(void);\n'
+if insert not in s:
+    first=s.find('\n')
+    s=s[:first+1]+insert+s[first+1:]
+p.write_text(s)
+# Bump package version.
+p=root/'control'; s=p.read_text(); s=re.sub(r'^Version:\s*1\.0\.15\s*$','Version: 1.0.16',s,flags=re.M); p.write_text(s)
+PYMOD
+
+grep -q 'Version: 1.0.16' "$R/nqrsrc/control"
+grep -q 'PersistentReportScheduler.m' "$R/nqrsrc/Makefile"
+grep -q 'NQRStartPersistentReportScheduler();' "$R/nqrsrc/Tweak.xm"
+! grep -q 'NQRStartPendingReportAutomationScheduler();' "$R/nqrsrc/Tweak.xm"
+grep -q 'PCPersistentTimer' "$R/nqrsrc/PersistentReportScheduler.m"
+grep -q 'setDisableSystemWaking' "$R/nqrsrc/PersistentReportScheduler.m"
+grep -q 'PersistentConnection.framework' "$R/nqrsrc/PersistentReportScheduler.m"
+grep -q 'NextReminder.PendingReportAutomationHour.v1' "$R/nqrsrc/PersistentReportScheduler.m"
+grep -q 'NextReminder.PendingReportAutomationWeekdays.v1' "$R/nqrsrc/PersistentReportScheduler.m"
+grep -q 'NextReminderDatabase.json' "$R/nqrsrc/PendingReportSender.m"
+grep -q 'v1/file-shares' "$R/nqrsrc/PendingReportSender.m"
+
+brew install dpkg ldid
+T="$R/theos-rh"
+git init "$T"
+git -C "$T" remote add origin https://github.com/roothide/theos.git
+git -C "$T" fetch --depth 1 origin 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+git -C "$T" checkout --detach 88506b2c22e9e07dd4ed055f23c9e398a117a2c7
+git -C "$T" submodule update --init --recursive --depth 1
+export THEOS="$T" THEOS_PACKAGE_SCHEME=roothide
+make -C "$R/nqrsrc" clean package FINALPACKAGE=1
+D=$(find "$R/nqrsrc/packages" -name '*.deb' -print -quit)
+test -n "$D"
+test "$(dpkg-deb -f "$D" Package)" = 'com.nextsolution.nextquickreminder'
+test "$(dpkg-deb -f "$D" Version)" = '1.0.16'
+X=$(mktemp -d); dpkg-deb -x "$D" "$X"
+F=$(find "$X" -name NextQuickReminder.dylib -print -quit); test -n "$F"
+strings -a "$F" > "$R/tweak.strings"
+grep -q 'PCPersistentTimer' "$R/tweak.strings"
+grep -q 'Starting PCPersistentTimer report scheduler' "$R/tweak.strings"
+grep -q 'system waking enabled' "$R/tweak.strings"
+grep -q 'NextReminder.PendingReportAutomationHour.v1' "$R/tweak.strings"
+grep -q 'NextReminderDatabase.json' "$R/tweak.strings"
+grep -q 'v1/file-shares' "$R/tweak.strings"
+cp "$D" "$R/out/NextQuickReminder_1.0.16_RootHide.deb"
+cd "$R/out"
+shasum -a 256 NextQuickReminder_1.0.16_RootHide.deb > SHA256SUMS.txt
+ls -lh
+cat SHA256SUMS.txt

--- a/tmp-build-1331/inspect.sh
+++ b/tmp-build-1331/inspect.sh
@@ -1,1 +1,25 @@
 #!/bin/bash
+set -euo pipefail
+R="$RUNNER_TEMP"
+rm -rf "$R/nqrsrc" "$R/inspect"
+mkdir -p "$R/nqrsrc" "$R/inspect"
+cat tmp-build/nqr1012/part-* > "$R/nqr.b64"
+python3 - <<'PY'
+import base64,os,pathlib
+r=pathlib.Path(os.environ['RUNNER_TEMP'])
+(r/'nqr.tar.xz').write_bytes(base64.b64decode((r/'nqr.b64').read_bytes()))
+PY
+tar -xJf "$R/nqr.tar.xz" -C "$R/nqrsrc"
+cat tmp-build-1325/patch/tweak-* > "$R/tweak1014.patch.xz.b64"
+base64 -D < "$R/tweak1014.patch.xz.b64" > "$R/tweak1014.patch.xz"
+xz -dc "$R/tweak1014.patch.xz" > "$R/tweak1014.patch"
+patch -d "$R/nqrsrc" -p4 < "$R/tweak1014.patch"
+base64 -D < tmp-build-1330/tweak1015.patch.xz.b64 > "$R/tweak1015.patch.xz"
+xz -dc "$R/tweak1015.patch.xz" > "$R/tweak1015.patch"
+patch -d "$R/nqrsrc" -p1 < "$R/tweak1015.patch"
+cp "$R/nqrsrc/PendingReportSender.m" "$R/inspect/"
+cp "$R/nqrsrc/PendingReportSender.h" "$R/inspect/"
+cp "$R/nqrsrc/Tweak.xm" "$R/inspect/"
+cp "$R/nqrsrc/Makefile" "$R/inspect/"
+cp "$R/nqrsrc/control" "$R/inspect/"
+grep -n -E 'Automation|Scheduler|Timer|schedule|NQRStartPending|NQRCheck|LastSuccess|Weekday' "$R/nqrsrc/PendingReportSender.m" > "$R/inspect/scheduler-lines.txt" || true

--- a/tmp-build-1331/trigger.txt
+++ b/tmp-build-1331/trigger.txt
@@ -1,0 +1,1 @@
+Trigger NQR 1.0.16 persistent timer inspection.


### PR DESCRIPTION
Temporary inspection/build PR. Reconstructs the validated Next Quick Reminder 1.0.15 source so the unreliable polling scheduler can be replaced by PCPersistentTimer while preserving the existing fresh-PDF and Gmail send path. Do not merge.