### PR TITLE
Next Post 1.0.9 fix X link card previews

### DIFF
--- a/.github/workflows/build-nextpost.yml
+++ b/.github/workflows/build-nextpost.yml
@@ -67,8 +67,8 @@ jobs:
           rm -rf Payload
           mkdir -p Payload
           cp -R "$APP_PATH" Payload/
-          ditto -c -k --sequesterRsrc --keepParent Payload NextPost-1.0.8-UnityAds-Mediation.tipa
-          shasum -a 256 NextPost-1.0.8-UnityAds-Mediation.tipa > NextPost-1.0.8-UnityAds-Mediation.sha256
+          ditto -c -k --sequesterRsrc --keepParent Payload NextPost-1.0.9-X-Preview-Fix.tipa
+          shasum -a 256 NextPost-1.0.9-X-Preview-Fix.tipa > NextPost-1.0.9-X-Preview-Fix.sha256
 
           /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$APP_PATH/Info.plist"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$APP_PATH/Info.plist"
@@ -82,28 +82,28 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: NextPost-1.0.8-UnityAds-Mediation
+          name: NextPost-1.0.9-X-Preview-Fix
           path: |
-            NextPost-1.0.8-UnityAds-Mediation.tipa
-            NextPost-1.0.8-UnityAds-Mediation.sha256
+            NextPost-1.0.9-X-Preview-Fix.tipa
+            NextPost-1.0.9-X-Preview-Fix.sha256
           if-no-files-found: error
 
       - name: Publish TIPA to repository
         if: github.event_name != 'pull_request'
         run: |
           mkdir -p applications
-          cp NextPost-1.0.8-UnityAds-Mediation.tipa applications/NextPost-1.0.8-UnityAds-Mediation.tipa
-          cp NextPost-1.0.8-UnityAds-Mediation.sha256 applications/NextPost-1.0.8-UnityAds-Mediation.sha256
+          cp NextPost-1.0.9-X-Preview-Fix.tipa applications/NextPost-1.0.9-X-Preview-Fix.tipa
+          cp NextPost-1.0.9-X-Preview-Fix.sha256 applications/NextPost-1.0.9-X-Preview-Fix.sha256
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add applications/NextPost-1.0.8-UnityAds-Mediation.tipa applications/NextPost-1.0.8-UnityAds-Mediation.sha256
+          git add applications/NextPost-1.0.9-X-Preview-Fix.tipa applications/NextPost-1.0.9-X-Preview-Fix.sha256
 
           if git diff --cached --quiet; then
-            echo "Next Post 1.0.8 Unity Ads build is already published."
+            echo "Next Post 1.0.9 X preview fix build is already published."
             exit 0
           fi
 
-          git commit -m "Publish Next Post 1.0.8 Unity Ads mediation TIPA"
+          git commit -m "Publish Next Post 1.0.9 X preview fix TIPA"
           git pull --rebase origin main
           git push origin HEAD:main

--- a/.github/workflows/publish-nextpost-transfer.yml
+++ b/.github/workflows/publish-nextpost-transfer.yml
@@ -1,12 +1,12 @@
 name: Publish Next Post to Transfer
 
-# 1.0.8 Unity Ads mediation publication trigger (forced after successful build)
+# 1.0.9 X preview fix publication trigger
 on:
   workflow_dispatch:
   push:
     branches: [main]
     paths:
-      - 'applications/NextPost-1.0.8-UnityAds-Mediation.tipa'
+      - 'applications/NextPost-1.0.9-X-Preview-Fix.tipa'
       - '.github/workflows/publish-nextpost-transfer.yml'
 
 permissions:
@@ -29,9 +29,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          SRC='applications/NextPost-1.0.8-UnityAds-Mediation.tipa'
-          DEST_DIR='transfer/files/NextPost/1.0.8'
-          DEST="$DEST_DIR/NextPost-1.0.8-UnityAds-Mediation.tipa"
+          SRC='applications/NextPost-1.0.9-X-Preview-Fix.tipa'
+          DEST_DIR='transfer/files/NextPost/1.0.9'
+          DEST="$DEST_DIR/NextPost-1.0.9-X-Preview-Fix.tipa"
           INDEX='transfer/index.json'
 
           test -s "$SRC"
@@ -50,18 +50,18 @@ jobs:
           index_path = Path('transfer/index.json')
           data = json.loads(index_path.read_text())
           files = data.get('files', [])
-          entry_id = 'nextpost-1.0.8-unityads-mediation'
+          entry_id = 'nextpost-1.0.9-x-preview-fix'
           files = [item for item in files if item.get('id') != entry_id]
           entry = {
               'id': entry_id,
-              'name': 'Next Post 1.0.8 Unity Ads Mediation',
-              'fileName': 'NextPost-1.0.8-UnityAds-Mediation.tipa',
+              'name': 'Next Post 1.0.9 X Preview Fix',
+              'fileName': 'NextPost-1.0.9-X-Preview-Fix.tipa',
               'type': 'tipa',
               'platform': 'TrollStore / iOS 16+',
-              'version': '1.0.8',
-              'url': 'https://nextsolution.cc/transfer/files/NextPost/1.0.8/NextPost-1.0.8-UnityAds-Mediation.tipa',
+              'version': '1.0.9',
+              'url': 'https://nextsolution.cc/transfer/files/NextPost/1.0.9/NextPost-1.0.9-X-Preview-Fix.tipa',
               'sha256': os.environ['SHA256'],
-              'notes': 'Adds the official Unity Ads SDK and LevelPlay Unity Ads adapter to Next Post. Includes Unity Ads SKAdNetwork support and keeps the existing ironSource LevelPlay banner/interstitial integration. Configure the Unity Ads bidder/instance for Next Post in LevelPlay using the Unity Ads Game ID and Banner/Interstitial placement IDs.'
+              'notes': 'Fixes missing X post link previews. Next Post now shares the exact published article URL (.html when that is the live route) instead of forcing a clean route that may not exist yet, and passes the article URL separately to the X web intent so it is recognized as the card target. Keeps LevelPlay + Unity Ads mediation support from 1.0.8.'
           }
           data['files'] = [entry] + files
           data['updatedAt'] = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
@@ -69,7 +69,7 @@ jobs:
           PY
 
           python3 -m json.tool "$INDEX" >/dev/null
-          grep -q 'nextpost-1.0.8-unityads-mediation' "$INDEX"
+          grep -q 'nextpost-1.0.9-x-preview-fix' "$INDEX"
           grep -q "$SHA256" "$INDEX"
           test "$(sha256sum "$DEST" | awk '{print $1}')" = "$SHA256"
 
@@ -79,7 +79,7 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add transfer/files/NextPost/1.0.8/NextPost-1.0.8-UnityAds-Mediation.tipa transfer/index.json
-          git commit -m 'Publish Next Post 1.0.8 Unity Ads mediation to Transfer' || true
+          git add transfer/files/NextPost/1.0.9/NextPost-1.0.9-X-Preview-Fix.tipa transfer/index.json
+          git commit -m 'Publish Next Post 1.0.9 X preview fix to Transfer' || true
           git pull --rebase origin main
           git push origin HEAD:main

--- a/NextPost/Sources/Models.swift
+++ b/NextPost/Sources/Models.swift
@@ -19,24 +19,34 @@ struct PublishedArticle: Decodable, Identifiable, Hashable {
 
     var id: String { cleanURL.absoluteString }
 
-    var cleanURL: URL {
+    /// The exact URL published by the website manifest/feed.
+    ///
+    /// Some newly published articles are available immediately at their
+    /// legacy `.html` route before a clean `/slug/` copy exists. Social
+    /// crawlers such as X must receive the URL that definitely serves the
+    /// article metadata, otherwise the link card can fail with a 404/no card.
+    var publishedURL: URL {
         if let absolute = URL(string: href), absolute.scheme != nil {
-            return Self.cleaned(url: absolute)
+            return absolute
         }
 
         let trimmed = href.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        let withoutHTML = trimmed.hasSuffix(".html") ? String(trimmed.dropLast(5)) : trimmed
-        return URL(string: "https://nextsolution.cc/\(withoutHTML)/")!
+        return URL(string: "https://nextsolution.cc/\(trimmed)")!
+    }
+
+    /// Clean canonical-style URL retained for deduplication/history.
+    var cleanURL: URL {
+        Self.cleaned(url: publishedURL)
     }
 
     /// Dedicated sharing URL for X/Twitter cards.
     ///
-    /// The article keeps its clean canonical route, while a small query string
-    /// gives X a fresh crawl target when a card image has previously been
-    /// cached. The website still declares the clean article URL as canonical.
+    /// Use the exact published route as the crawl target, then add a small
+    /// query string so X can refresh a previously cached card. This avoids
+    /// forcing a `/slug/` route that may not exist yet for brand-new articles.
     var socialShareURL: URL {
-        guard var components = URLComponents(url: cleanURL, resolvingAgainstBaseURL: false) else {
-            return cleanURL
+        guard var components = URLComponents(url: publishedURL, resolvingAgainstBaseURL: false) else {
+            return publishedURL
         }
 
         var items = components.queryItems ?? []
@@ -48,17 +58,25 @@ struct PublishedArticle: Decodable, Identifiable, Hashable {
             items.append(URLQueryItem(name: "v", value: version))
         }
         components.queryItems = items
-        return components.url ?? cleanURL
+        return components.url ?? publishedURL
     }
 
     private static func cleaned(url: URL) -> URL {
-        var value = url.absoluteString
-        if value.hasSuffix(".html") {
-            value = String(value.dropLast(5)) + "/"
-        } else if !value.hasSuffix("/") {
-            value += "/"
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
         }
-        return URL(string: value) ?? url
+
+        components.query = nil
+        components.fragment = nil
+
+        var path = components.path
+        if path.hasSuffix(".html") {
+            path = String(path.dropLast(5)) + "/"
+        } else if !path.hasSuffix("/") {
+            path += "/"
+        }
+        components.path = path
+        return components.url ?? url
     }
 
     static func == (lhs: PublishedArticle, rhs: PublishedArticle) -> Bool {

--- a/NextPost/Sources/NextPostStore.swift
+++ b/NextPost/Sources/NextPostStore.swift
@@ -134,29 +134,38 @@ final class NextPostStore: ObservableObject {
     func openInX() {
         guard !generatedPost.isEmpty else { return }
 
-        let encoded = generatedPost.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        if let appURL = URL(string: "twitter://post?message=\(encoded)") {
-            UIApplication.shared.open(appURL, options: [:]) { success in
-                guard !success else { return }
-                Task { @MainActor in
-                    self.openXWebIntent()
-                }
-            }
-        } else {
-            openXWebIntent()
+        // Give X the article URL as an explicit Web Intent URL parameter rather
+        // than burying it only inside pre-filled text. That lets X recognize
+        // the link as the card target and avoids deep-link query parsing from
+        // splitting article URLs that themselves contain UTM parameters.
+        guard let article = selectedArticle else {
+            openXWebIntent(text: generatedPost, url: nil)
+            return
         }
+
+        let shareURL = article.socialShareURL
+        let linkedLine = "🔗 \(shareURL.absoluteString)\n"
+        let textOnly = generatedPost
+            .replacingOccurrences(of: linkedLine, with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        openXWebIntent(text: textOnly, url: shareURL)
     }
 
     func openArticle() {
-        guard let url = selectedArticle?.cleanURL else { return }
+        guard let url = selectedArticle?.publishedURL else { return }
         UIApplication.shared.open(url)
     }
 
-    private func openXWebIntent() {
+    private func openXWebIntent(text: String, url: URL?) {
         var components = URLComponents(string: "https://twitter.com/intent/tweet")
-        components?.queryItems = [URLQueryItem(name: "text", value: generatedPost)]
-        guard let url = components?.url else { return }
-        UIApplication.shared.open(url)
+        var items = [URLQueryItem(name: "text", value: text)]
+        if let url {
+            items.append(URLQueryItem(name: "url", value: url.absoluteString))
+        }
+        components?.queryItems = items
+        guard let intentURL = components?.url else { return }
+        UIApplication.shared.open(intentURL)
     }
 
     private func reconcileUsedLinks(with articles: [PublishedArticle]) {
@@ -175,6 +184,6 @@ final class NextPostStore: ObservableObject {
         defaults.set(cycleNumber, forKey: Key.cycleNumber)
         defaults.set(generatedPost, forKey: Key.generatedPost)
         defaults.set(selectedArticle?.title, forKey: Key.selectedTitle)
-        defaults.set(selectedArticle?.cleanURL.absoluteString, forKey: Key.selectedURL)
+        defaults.set(selectedArticle?.publishedURL.absoluteString, forKey: Key.selectedURL)
     }
 }

--- a/NextPost/project.yml
+++ b/NextPost/project.yml
@@ -20,8 +20,8 @@ settings:
     TARGETED_DEVICE_FAMILY: "1"
     SUPPORTS_MACCATALYST: "NO"
     CODE_SIGN_STYLE: Automatic
-    MARKETING_VERSION: "1.0.8"
-    CURRENT_PROJECT_VERSION: "8"
+    MARKETING_VERSION: "1.0.9"
+    CURRENT_PROJECT_VERSION: "9"
     OTHER_LDFLAGS: "$(inherited) -ObjC -lz -lsqlite3 -framework JavaScriptCore -framework WebKit -framework AdSupport -framework SystemConfiguration"
 
 targets:


### PR DESCRIPTION
Fixes missing X/Twitter article previews in Next Post. The app now shares the exact published article URL from the manifest (including .html when that is the live route) instead of forcing a /slug/ route that may not exist yet for newly published articles. The Open in X action also passes the article URL separately through the X web intent so X recognizes it as the card target. Keeps the LevelPlay + Unity Ads integration from 1.0.8 and bumps to 1.0.9.