### PR TITLE
Validate Aspire Maintenance 1.1.4 dashboard build

### DIFF
--- a/.github/workflows/build-aspire-maintenance.yml
+++ b/.github/workflows/build-aspire-maintenance.yml
@@ -1,3 +1,4 @@
+# CI trigger for Aspire Maintenance 1.1.4 test build
 name: Build Aspire Maintenance 1.1.4
 
 on:


### PR DESCRIPTION
CI-only validation PR to build the Aspire Maintenance 1.1.4 dashboard redesign for test distribution through NS Transfer. Do not merge.